### PR TITLE
Feature default cell setup

### DIFF
--- a/Source/Spots/Carousel/CarouselSpot.swift
+++ b/Source/Spots/Carousel/CarouselSpot.swift
@@ -7,6 +7,7 @@ public class CarouselSpot: NSObject, Spotable {
   public var component: Component
   public weak var sizeDelegate: SpotSizeDelegate?
   public weak var spotDelegate: SpotsDelegate?
+  public static var defaultCell: UICollectionViewCell.Type = CarouselSpotCell.self
 
   public lazy var layout: UICollectionViewFlowLayout = { [unowned self] in
     let layout = UICollectionViewFlowLayout()
@@ -33,7 +34,7 @@ public class CarouselSpot: NSObject, Spotable {
     let items = component.items
     for (index, item) in items.enumerate() {
       self.component.index = index
-      let componentCellClass = CarouselSpot.cells[item.kind] ?? CarouselSpotCell.self
+      let componentCellClass = CarouselSpot.cells[item.kind] ?? CarouselSpot.defaultCell
       self.collectionView.registerClass(componentCellClass, forCellWithReuseIdentifier: "CarouselCell\(item.kind.capitalizedString)")
 
       guard let gridCell = componentCellClass.init() as? Itemble else { return }

--- a/Source/Spots/Feed/FeedSpot.swift
+++ b/Source/Spots/Feed/FeedSpot.swift
@@ -11,6 +11,7 @@ public class FeedSpot: NSObject, Spotable {
 
   public static var cells = [String : UITableViewCell.Type]()
   public static var headers = [String : UIView.Type]()
+  public static var defaultCell: UITableViewCell.Type = FeedSpotCell.self
   
   public let itemHeight: CGFloat = 44
   public let headerHeight: CGFloat = 44
@@ -38,7 +39,7 @@ public class FeedSpot: NSObject, Spotable {
     let items = component.items
     for (index, item) in items.enumerate() {
       self.component.index = index
-      let componentCellClass = FeedSpot.cells[item.kind] ?? FeedSpotCell.self
+      let componentCellClass = FeedSpot.cells[item.kind] ?? FeedSpot.defaultCell
       if let cachedCell = cachedCells[item.kind] {
         cachedCell.configure(&self.component.items[index])
       } else if let listCell = componentCellClass.init() as? Itemble {

--- a/Source/Spots/Grid/GridSpot.swift
+++ b/Source/Spots/Grid/GridSpot.swift
@@ -9,6 +9,7 @@ public class GridSpot: NSObject, Spotable {
   public var component: Component
   public weak var sizeDelegate: SpotSizeDelegate?
   public weak var spotDelegate: SpotsDelegate?
+  public static var defaultCell: UICollectionViewCell.Type = GridSpotCell.self
 
   public lazy var layout: UICollectionViewFlowLayout = { [unowned self] in
     let size = UIScreen.mainScreen().bounds.width / CGFloat(self.component.span)
@@ -39,7 +40,7 @@ public class GridSpot: NSObject, Spotable {
     let items = component.items
     for (index, item) in items.enumerate() {
       self.component.index = index
-      let componentCellClass = GridSpot.cells[item.kind] ?? GridSpotCell.self
+      let componentCellClass = GridSpot.cells[item.kind] ?? GridSpot.defaultCell
       collectionView.registerClass(componentCellClass, forCellWithReuseIdentifier: "\(cellPrefix)\(item.kind.capitalizedString)")
 
       if let gridCell = componentCellClass.init() as? Itemble {

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -11,6 +11,7 @@ public class ListSpot: NSObject, Spotable {
 
   public let itemHeight: CGFloat = 44
   public let headerHeight: CGFloat = 44
+  public static var defaultCell: UITableViewCell.Type = ListSpotCell.self
 
   public var component: Component
   public weak var sizeDelegate: SpotSizeDelegate?
@@ -35,7 +36,7 @@ public class ListSpot: NSObject, Spotable {
 
     let items = component.items
     for (index, item) in items.enumerate() {
-      let componentCellClass = ListSpot.cells[item.kind] ?? ListSpotCell.self
+      let componentCellClass = ListSpot.cells[item.kind] ?? ListSpot.defaultCell
       if let cachedCell = cachedCells[item.kind] {
         cachedCell.configure(&self.component.items[index])
       } else {


### PR DESCRIPTION
You can now set your own default cell to all spots. So if a `ListItem` does not have a `kind` property, it will use the corresponding Spot default cell.