### PR TITLE
Feature header height

### DIFF
--- a/Example/Apple News/AppleNews/Headers/ListHeaderView.swift
+++ b/Example/Apple News/AppleNews/Headers/ListHeaderView.swift
@@ -2,6 +2,8 @@ import UIKit
 
 public class ListHeaderView: UIView, Componentable {
 
+  public var height: CGFloat = 44
+
   lazy var label: UILabel = { [unowned self] in
     let label = UILabel(frame: self.frame)
     label.font = UIFont.boldSystemFontOfSize(11)

--- a/Source/Library/Componentable.swift
+++ b/Source/Library/Componentable.swift
@@ -1,3 +1,6 @@
+import UIKit
+
 public protocol Componentable {
+  var height: CGFloat { get }
   func configure(component: Component)
 }

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -139,12 +139,13 @@ extension ListSpot: UITableViewDataSource {
   }
 
   public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    if let header = ListSpot.headers[component.kind] {
-      let header = header.init(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: headerHeight))
-      if let configurable = header as? Componentable {
-        configurable.configure(component)
+    if let cachedHeader = cachedHeaders[component.kind] {
+      return cachedHeader as? UIView
+    } else {
+      if let header = ListSpot.headers[component.kind] {
+        let header = header.init(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: headerHeight))
+        return header
       }
-      return header
     }
 
     return nil

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -17,6 +17,7 @@ public class ListSpot: NSObject, Spotable {
   public weak var spotDelegate: SpotsDelegate?
 
   private var cachedCells = [String : Itemble]()
+  private var cachedHeaders = [String : Componentable]()
 
   public lazy var tableView: UITableView = { [unowned self] in
     let tableView = UITableView()
@@ -49,6 +50,16 @@ public class ListSpot: NSObject, Spotable {
         }
       }
     }
+
+    if let headerType = ListSpot.headers[component.kind] {
+      let header = headerType.init(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: headerHeight))
+      if let configurable = header as? Componentable {
+        configurable.configure(component)
+        cachedHeaders[component.kind] = configurable
+        headerHeight = configurable.height
+      }
+    }
+
     cachedCells.removeAll()
   }
 

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -11,7 +11,7 @@ public class ListSpot: NSObject, Spotable {
 
   public var index = 0
   public let itemHeight: CGFloat = 44
-  public let headerHeight: CGFloat = 44
+  public var headerHeight: CGFloat = 44
   public var component: Component
   public weak var sizeDelegate: SpotSizeDelegate?
   public weak var spotDelegate: SpotsDelegate?

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -141,11 +141,9 @@ extension ListSpot: UITableViewDataSource {
   public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
     if let cachedHeader = cachedHeaders[component.kind] {
       return cachedHeader as? UIView
-    } else {
-      if let header = ListSpot.headers[component.kind] {
-        let header = header.init(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: headerHeight))
-        return header
-      }
+    } else if let header = ListSpot.headers[component.kind] {
+      let header = header.init(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: headerHeight))
+      return header
     }
 
     return nil


### PR DESCRIPTION
Adds support for custom header heights if they conform to the `Componentable` protocol.
Aslo, headers are cached in the initializer so it should be faster than before.