### PR TITLE
Dispatch all updates in main queue

### DIFF
--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -71,20 +71,25 @@ public class SpotsController: UIViewController {
   }
 
   public func reloadSpots() {
-    dispatch { self.spots.forEach { $0.reload() } }
+    dispatch { [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.spots.forEach { $0.reload() }
+    }
   }
 
   public func updateSpotAtIndex(index: Int, closure: (spot: Spotable) -> Spotable) {
     if let spot = spotAtIndex(index) {
       spots[spot.index] = closure(spot: spot)
 
-      dispatch {
-        self.spots[spot.index].reload()
+      dispatch { [weak self] in
+        guard let weakSelf = self else { return }
 
-        self.collectionView.performBatchUpdates({
-          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+        weakSelf.spots[spot.index].reload()
+
+        weakSelf.collectionView.performBatchUpdates({
+          weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
           }, completion: { _ in
-            self.collectionView.collectionViewLayout.invalidateLayout()
+            weakSelf.collectionView.collectionViewLayout.invalidateLayout()
         })
       }
     }
@@ -94,13 +99,15 @@ public class SpotsController: UIViewController {
     if let spot = spotAtIndex(spotIndex) {
       spot.component.items.append(item)
 
-      dispatch {
-        self.spots[spot.index].reload()
+      dispatch { [weak self] in
+        guard let weakSelf = self else { return }
+      
+        weakSelf.spots[spot.index].reload()
 
-        self.collectionView.performBatchUpdates({
-          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: spotIndex, inSection: 0)])
+        weakSelf.collectionView.performBatchUpdates({
+          weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: spotIndex, inSection: 0)])
           }, completion: { _ in
-            self.collectionView.collectionViewLayout.invalidateLayout()
+            weakSelf.collectionView.collectionViewLayout.invalidateLayout()
         })
       }
     }
@@ -114,20 +121,22 @@ public class SpotsController: UIViewController {
         spot.component.items.insert(item, atIndex: index)
       }
 
-      dispatch {
-        self.spots[spot.index].reload()
-        self.collectionView.performBatchUpdates({
-          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+      dispatch { [weak self] in
+        guard let weakSelf = self else { return }
+      
+        weakSelf.spots[spot.index].reload()
+        weakSelf.collectionView.performBatchUpdates({
+          weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
           }, completion: { _ in
-            self.collectionView.collectionViewLayout.invalidateLayout()
+            weakSelf.collectionView.collectionViewLayout.invalidateLayout()
         })
       }
     }
   }
 
   public func refreshSpots(refreshControl: UIRefreshControl) {
-    dispatch {
-      if let spotDelegate = self.spotDelegate {
+    dispatch { [weak self] in
+      if let weakSelf = self, spotDelegate = weakSelf.spotDelegate {
         spotDelegate.spotsDidReload(refreshControl)
       } else {
         delay(0.5) { [weak self] in

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -71,32 +71,38 @@ public class SpotsController: UIViewController {
   }
 
   public func reloadSpots() {
-    spots.forEach { $0.reload() }
+    dispatch { self.spots.forEach { $0.reload() } }
   }
 
   public func updateSpotAtIndex(index: Int, closure: (spot: Spotable) -> Spotable) {
     if let spot = spotAtIndex(index) {
       spots[spot.index] = closure(spot: spot)
-      spots[spot.index].reload()
 
-      collectionView.performBatchUpdates({
-        self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
-        }, completion: { _ in
-          self.collectionView.collectionViewLayout.invalidateLayout()
-      })
+      dispatch {
+        self.spots[spot.index].reload()
+
+        self.collectionView.performBatchUpdates({
+          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+          }, completion: { _ in
+            self.collectionView.collectionViewLayout.invalidateLayout()
+        })
+      }
     }
   }
 
   public func append(item: ListItem, spotIndex: Int) {
     if let spot = spotAtIndex(spotIndex) {
       spot.component.items.append(item)
-      spots[spot.index].reload()
 
-      collectionView.performBatchUpdates({
-        self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: spotIndex, inSection: 0)])
-        }, completion: { _ in
-          self.collectionView.collectionViewLayout.invalidateLayout()
-      })
+      dispatch {
+        self.spots[spot.index].reload()
+
+        self.collectionView.performBatchUpdates({
+          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: spotIndex, inSection: 0)])
+          }, completion: { _ in
+            self.collectionView.collectionViewLayout.invalidateLayout()
+        })
+      }
     }
   }
 
@@ -108,21 +114,25 @@ public class SpotsController: UIViewController {
         spot.component.items.insert(item, atIndex: index)
       }
 
-      spots[spot.index].reload()
-      collectionView.performBatchUpdates({
-        self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
-        }, completion: { _ in
-          self.collectionView.collectionViewLayout.invalidateLayout()
-      })
+      dispatch {
+        self.spots[spot.index].reload()
+        self.collectionView.performBatchUpdates({
+          self.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+          }, completion: { _ in
+            self.collectionView.collectionViewLayout.invalidateLayout()
+        })
+      }
     }
   }
 
   public func refreshSpots(refreshControl: UIRefreshControl) {
-    if let spotDelegate = spotDelegate {
-      spotDelegate.spotsDidReload(refreshControl)
-    } else {
-      delay(0.5) { [weak self] in
-        self?.refreshControl.endRefreshing()
+    dispatch {
+      if let spotDelegate = self.spotDelegate {
+        spotDelegate.spotsDidReload(refreshControl)
+      } else {
+        delay(0.5) { [weak self] in
+          self?.refreshControl.endRefreshing()
+        }
       }
     }
   }

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -125,6 +125,7 @@ public class SpotsController: UIViewController {
         guard let weakSelf = self else { return }
       
         weakSelf.spots[spot.index].reload()
+
         weakSelf.collectionView.performBatchUpdates({
           weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
           }, completion: { _ in


### PR DESCRIPTION
Now you shouldn't have to care about dispatching when using `reloadSpots`, `updateSpotAtIndex`, `append`, `insert` or `refreshSpots`.