### PR TITLE
Refactor Spots Controller

### DIFF
--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -64,9 +64,7 @@ public class SpotsController: UIViewController {
       .FlexibleWidth
     ]
 
-    for (index, _) in spots.enumerate() {
-      self.spots[index].index = index
-    }
+    spots.enumerate().forEach { spot($0.index).index = $0.index }
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -44,7 +44,7 @@ public class SpotsController: UIViewController {
     return refreshControl
     }()
 
-  public required init(spots: [Spotable], refreshable: Bool = true) {
+  public required init(spots: [Spotable] = [], refreshable: Bool = true) {
     self.spots = spots
     super.init(nibName: nil, bundle: nil)
 

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -89,20 +89,19 @@ public class SpotsController: UIViewController {
   }
 
   public func updateSpotAtIndex(index: Int, closure: (spot: Spotable) -> Spotable, completion: (() -> Void)? = nil) {
-    if let spot = spotAtIndex(index) {
+    guard let spot = spotAtIndex(index) else { return }
       spots[spot.index] = closure(spot: spot)
 
-      dispatch { [weak self] in
-        guard let weakSelf = self else { return }
+    dispatch { [weak self] in
+      guard let weakSelf = self else { return }
 
-        weakSelf.spots[spot.index].reload([index]) {
-          weakSelf.collectionView.performBatchUpdates({
-            weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
-            }, completion: { _ in
-              weakSelf.collectionView.collectionViewLayout.invalidateLayout()
-              completion?()
-          })
-        }
+      weakSelf.spot(spot.index).reload([index]) {
+        weakSelf.collectionView.performBatchUpdates({
+          weakSelf.collectionView.reloadItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+          }, completion: { _ in
+            weakSelf.collectionView.collectionViewLayout.invalidateLayout()
+            completion?()
+        })
       }
     }
   }

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -173,13 +173,11 @@ extension SpotsController: UICollectionViewDataSource {
   public func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(SpotsController.reuseIdentifier, forIndexPath: indexPath)
 
-    if let spotCell = cell as? SpotCell {
-      spotCell.spotView = spots[indexPath.item].render()
-    }
-
+    (cell as? SpotCell)?.spotView = spot(indexPath.item).render()
     cell.optimize()
-    spots[indexPath.item].sizeDelegate = self
-    spots[indexPath.item].spotDelegate = spotDelegate
+
+    spot(indexPath).sizeDelegate = self
+    spot(indexPath).spotDelegate = spotDelegate
 
     return cell
   }
@@ -188,15 +186,14 @@ extension SpotsController: UICollectionViewDataSource {
 extension SpotsController: UICollectionViewDelegateFlowLayout {
 
   public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-    var component = spots[indexPath.item].component
-    if component.size == nil {
-      spots[indexPath.item].setup()
-      component.size = CGSize(
-        width: UIScreen.mainScreen().bounds.width,
-        height: spots[indexPath.item].render().frame.height)
+    if component(indexPath).size == nil {
+      spot(indexPath).setup()
+      spot(indexPath).component.size = CGSize(
+        width: collectionView.frame.width,
+        height: spot(indexPath).render().frame.height)
     }
 
-    return component.size!
+    return component(indexPath).size!
   }
 }
 

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -190,7 +190,7 @@ extension SpotsController: UICollectionViewDelegateFlowLayout {
       spot(indexPath).setup()
       spot(indexPath).component.size = CGSize(
         width: collectionView.frame.width,
-        height: spot(indexPath).render().frame.height)
+        height: ceil(spot(indexPath).render().frame.height))
     }
 
     return component(indexPath).size!

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -84,8 +84,7 @@ public class SpotsController: UIViewController {
 
   public func reloadSpots() {
     dispatch { [weak self] in
-      guard let weakSelf = self else { return }
-      weakSelf.spots.forEach { $0.reload([]) {} }
+      self?.spots.forEach { $0.reload([]) {} }
     }
   }
 

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -149,6 +149,21 @@ public class SpotsController: UIViewController {
   }
 }
 
+extension SpotsController {
+
+  private func component(indexPath: NSIndexPath) -> Component {
+    return spot(indexPath).component
+  }
+
+  private func spot(indexPath: NSIndexPath) -> Spotable {
+    return spots[indexPath.item]
+  }
+
+  private func spot(index: Int) -> Spotable {
+    return spots[index]
+  }
+}
+
 extension SpotsController: UICollectionViewDataSource {
 
   public func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -79,8 +79,7 @@ public class SpotsController: UIViewController {
   }
 
   public func spotAtIndex(index: Int) -> Spotable? {
-    let spot = spots.filter { $0.index == index }.first
-    return spot
+    return spots.filter { $0.index == index }.first
   }
 
   public func reloadSpots() {

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -22,11 +22,11 @@ public class SpotsController: UIViewController {
     collectionView.alwaysBounceVertical = true
     collectionView.autoresizesSubviews = true
     collectionView.autoresizingMask = [
-      .FlexibleRightMargin,
-      .FlexibleLeftMargin,
       .FlexibleBottomMargin,
-      .FlexibleTopMargin,
       .FlexibleHeight,
+      .FlexibleLeftMargin,
+      .FlexibleRightMargin,
+      .FlexibleTopMargin,
       .FlexibleWidth
     ]
     collectionView.backgroundColor = UIColor.whiteColor()

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -21,7 +21,14 @@ public class SpotsController: UIViewController {
 
     collectionView.alwaysBounceVertical = true
     collectionView.autoresizesSubviews = true
-    collectionView.autoresizingMask = [.FlexibleRightMargin, .FlexibleLeftMargin, .FlexibleBottomMargin, .FlexibleTopMargin, .FlexibleHeight, .FlexibleWidth]
+    collectionView.autoresizingMask = [
+      .FlexibleRightMargin,
+      .FlexibleLeftMargin,
+      .FlexibleBottomMargin,
+      .FlexibleTopMargin,
+      .FlexibleHeight,
+      .FlexibleWidth
+    ]
     collectionView.backgroundColor = UIColor.whiteColor()
     collectionView.dataSource = self
     collectionView.delegate = self
@@ -47,7 +54,14 @@ public class SpotsController: UIViewController {
     }
 
     view.autoresizesSubviews = true
-    view.autoresizingMask = [.FlexibleRightMargin, .FlexibleLeftMargin, .FlexibleBottomMargin, .FlexibleTopMargin, .FlexibleHeight, .FlexibleWidth]
+    view.autoresizingMask = [
+      .FlexibleBottomMargin,
+      .FlexibleHeight,
+      .FlexibleLeftMargin,
+      .FlexibleRightMargin,
+      .FlexibleTopMargin,
+      .FlexibleWidth
+    ]
 
     for (index, _) in spots.enumerate() {
       self.spots[index].index = index

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -49,6 +49,7 @@ public class SpotsController: UIViewController {
     super.init(nibName: nil, bundle: nil)
 
     view.addSubview(collectionView)
+
     if refreshable {
       collectionView.addSubview(refreshControl)
     }

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -107,33 +107,27 @@ public class SpotsController: UIViewController {
   }
 
   public func append(item: ListItem, spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.append(item) { completion?() }
+    spotAtIndex(spotIndex)?.append(item) { completion?() }
   }
   
   public func append(items: [ListItem], spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.append(items) { completion?() }
+    spotAtIndex(spotIndex)?.append(items) { completion?() }
   }
 
   public func insert(item: ListItem, index: Int, spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.insert(item, index: index)  { completion?() }
+    spotAtIndex(spotIndex)?.insert(item, index: index)  { completion?() }
   }
 
   public func update(item: ListItem, index: Int, spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.update(item, index: index)  { completion?() }
+    spotAtIndex(spotIndex)?.update(item, index: index)  { completion?() }
   }
 
   public func delete(index: Int, spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.delete(index) { completion?() }
+    spotAtIndex(spotIndex)?.delete(index) { completion?() }
   }
 
   public func delete(indexes indexes: [Int], spotIndex: Int, completion: (() -> Void)? = nil) {
-    guard let spot = spotAtIndex(spotIndex) else { return }
-    spot.delete(indexes) { completion?() }
+    spotAtIndex(spotIndex)?.delete(indexes) { completion?() }
   }
 
   public func refreshSpots(refreshControl: UIRefreshControl) {


### PR DESCRIPTION
We were relying a lot of subscripting which makes the code hard to read.

This PR adds three convenience methods that should take care of that;

`component(indexPath: NSIndexPath) -> Component`
`spot(indexPath: NSIndexPath) -> Spotable`
`spot(index: Int) -> Spotable`