### PR TITLE
Feature/convenience properties

### DIFF
--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -133,4 +133,19 @@ class SpotsControllerTests : XCTestCase {
       XCTAssertEqual(self.spotController?.spotAtIndex(0)?.component.items.count, 1)
     }
   }
+
+  func testComputedPropertiesOnSpotable() {
+    let component = Component(title: "Component", kind: "list", items: [
+      ListItem(title: "title1", kind: "list"),
+      ListItem(title: "title2", kind: "list")
+      ])
+    let spot = ListSpot(component: component)
+
+    XCTAssert(spot.items == component.items)
+
+    let newItems = [ListItem(title: "title3", kind: "list")]
+    spot.items = newItems
+    XCTAssertFalse(spot.items == component.items)
+    XCTAssert(spot.items == newItems)
+  }
 }

--- a/Source/Library/Spotable.swift
+++ b/Source/Library/Spotable.swift
@@ -28,6 +28,15 @@ public protocol Spotable: class {
 
 public extension Spotable {
 
+  var items: [ListItem] {
+    set(items) {
+      component.items = items
+    }
+    get {
+      return component.items
+    }
+  }
+
   public func append(item: ListItem, completion: (() -> Void)? = nil) {}
   public func append(items: [ListItem], completion: (() -> Void)? = nil) {}
   public func prepend(items: [ListItem], completion: (() -> Void)? = nil) {}


### PR DESCRIPTION
You can now easily access the spots item by just calling `Spot.items`.
You can also set them if you like.

`Spotable.swift`
```swift
public extension Spotable {

  var items: [ListItem] {
    set(items) {
      component.items = items
    }
    get {
      return component.items
    }
  }
}
```