### PR TITLE
Feature/infix operator on component

### DIFF
--- a/Pod/Tests/Models/TestComponent.swift
+++ b/Pod/Tests/Models/TestComponent.swift
@@ -51,4 +51,24 @@ class ComponentTests : XCTestCase {
     codeComponent.items.append(ListItem(title: "item2"))
     XCTAssertFalse(jsonComponent == codeComponent)
   }
+
+  func testInfixOperator() {
+    var component = Component()
+    let listItem = ListItem(title: "item1")
+
+    component + listItem
+    
+    XCTAssert(component.items.count == 1)
+
+    let listItems = [
+      ListItem(title: "item2"),
+      ListItem(title: "item3")
+    ]
+
+    component + listItems
+
+    XCTAssert(component.items.count == 3)
+    XCTAssert(component.items[1] == listItems[0])
+    XCTAssert(component.items[2] == listItems[1])
+  }
 }

--- a/Source/Models/Component.swift
+++ b/Source/Models/Component.swift
@@ -1,6 +1,7 @@
 import Tailor
 import Sugar
 
+infix operator + {}
 public struct Component: Mappable {
   public var index = 0
   public var title = ""

--- a/Source/Models/Component.swift
+++ b/Source/Models/Component.swift
@@ -2,6 +2,15 @@ import Tailor
 import Sugar
 
 infix operator + {}
+
+public func + (inout left: Component, right: ListItem) {
+  left.items.append(right)
+}
+
+public func + (inout left: Component, right: [ListItem]) {
+  left.items.appendContentsOf(right)
+}
+
 public struct Component: Mappable {
   public var index = 0
   public var title = ""


### PR DESCRIPTION
With this PR, you can do the following using the `+` infix operator on `Component`

```swift
component + ListItem()
```

Or

```swift
component + [
  ListItem()
  ListItem()
]
```

This is what the infix operator looks like;

```swift
public func + (inout left: Component, right: ListItem) {
  left.items.append(right)
}

public func + (inout left: Component, right: [ListItem]) {
  left.items.appendContentsOf(right)
}
```