### PR TITLE
Feature spot search

### DIFF
--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -149,17 +149,21 @@ class SpotsControllerTests : XCTestCase {
     XCTAssert(spot.items == newItems)
   }
 
-  func testFindSpotWithClosure() {
+  func testFindAndFilterSpotWithClosure() {
     let listSpot = ListSpot(component: Component(title: "ListSpot"))
-    let gridSpot = ListSpot(component: Component(title: "GridSpot", items: [ListItem(title: "ListItem")]))
-    spotController = SpotsController(spots: [listSpot, gridSpot], refreshable: true)
+    let listSpot2 = ListSpot(component: Component(title: "ListSpot2"))
+    let gridSpot = GridSpot(component: Component(title: "GridSpot", items: [ListItem(title: "ListItem")]))
+    let spotController = SpotsController(spots: [listSpot, listSpot2, gridSpot], refreshable: true)
 
-    XCTAssertNotNil(spotController?.find { $1.component.title == "ListSpot" })
-    XCTAssertNotNil(spotController?.find { $1.component.title == "GridSpot" })
-    XCTAssertNotNil(spotController?.find { $1 is Listable })
-    XCTAssertNotNil(spotController?.find { $1.items.filter{ $0.title == "ListItem" }.first != nil })
-    XCTAssertEqual(spotController?.find { $0.index == 0 }?.component.title, "ListSpot")
-    XCTAssertEqual(spotController?.find { $0.index == 1 }?.component.title, "GridSpot")
+    XCTAssertNotNil(spotController.spot{ $1.component.title == "ListSpot" })
+    XCTAssertNotNil(spotController.spot{ $1.component.title == "GridSpot" })
+    XCTAssertNotNil(spotController.spot{ $1 is Listable })
+    XCTAssertNotNil(spotController.spot{ $1 is Gridable })
+    XCTAssertNotNil(spotController.spot{ $1.items.filter{ $0.title == "ListItem" }.first != nil })
+    XCTAssertEqual(spotController.spot{ $0.index == 0 }?.component.title, "ListSpot")
+    XCTAssertEqual(spotController.spot{ $0.index == 1 }?.component.title, "ListSpot2")
+    XCTAssertEqual(spotController.spot{ $0.index == 2 }?.component.title, "GridSpot")
 
+    XCTAssert(spotController.filter { $0 is Listable }.count == 2)
   }
 }

--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -149,12 +149,17 @@ class SpotsControllerTests : XCTestCase {
     XCTAssert(spot.items == newItems)
   }
 
-  func testSpotAtIndexWithInferredType() {
-    let component = Component(title: "Component")
-    let listSpot = ListSpot(component: component)
-    spotController = SpotsController(spots: [listSpot], refreshable: true)
+  func testFindSpotWithClosure() {
+    let listSpot = ListSpot(component: Component(title: "ListSpot"))
+    let gridSpot = ListSpot(component: Component(title: "GridSpot", items: [ListItem(title: "ListItem")]))
+    spotController = SpotsController(spots: [listSpot, gridSpot], refreshable: true)
 
-    let foundComponent = spotController?.spot(NSPredicate(format: "SELF.component.title = '%@'", component.title))
-    print(foundComponent)
+    XCTAssertNotNil(spotController?.spot { $1.component.title == "ListSpot" })
+    XCTAssertNotNil(spotController?.spot { $1.component.title == "GridSpot" })
+    XCTAssertNotNil(spotController?.spot { $1 is Listable })
+    XCTAssertNotNil(spotController?.spot { $1.items.filter{ $0.title == "ListItem" }.first != nil })
+    XCTAssertEqual(spotController?.spot { $0.index == 0 }?.component.title, "ListSpot")
+    XCTAssertEqual(spotController?.spot { $0.index == 1 }?.component.title, "GridSpot")
+
   }
 }

--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -154,12 +154,12 @@ class SpotsControllerTests : XCTestCase {
     let gridSpot = ListSpot(component: Component(title: "GridSpot", items: [ListItem(title: "ListItem")]))
     spotController = SpotsController(spots: [listSpot, gridSpot], refreshable: true)
 
-    XCTAssertNotNil(spotController?.spot { $1.component.title == "ListSpot" })
-    XCTAssertNotNil(spotController?.spot { $1.component.title == "GridSpot" })
-    XCTAssertNotNil(spotController?.spot { $1 is Listable })
-    XCTAssertNotNil(spotController?.spot { $1.items.filter{ $0.title == "ListItem" }.first != nil })
-    XCTAssertEqual(spotController?.spot { $0.index == 0 }?.component.title, "ListSpot")
-    XCTAssertEqual(spotController?.spot { $0.index == 1 }?.component.title, "GridSpot")
+    XCTAssertNotNil(spotController?.find { $1.component.title == "ListSpot" })
+    XCTAssertNotNil(spotController?.find { $1.component.title == "GridSpot" })
+    XCTAssertNotNil(spotController?.find { $1 is Listable })
+    XCTAssertNotNil(spotController?.find { $1.items.filter{ $0.title == "ListItem" }.first != nil })
+    XCTAssertEqual(spotController?.find { $0.index == 0 }?.component.title, "ListSpot")
+    XCTAssertEqual(spotController?.find { $0.index == 1 }?.component.title, "GridSpot")
 
   }
 }

--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -148,4 +148,13 @@ class SpotsControllerTests : XCTestCase {
     XCTAssertFalse(spot.items == component.items)
     XCTAssert(spot.items == newItems)
   }
+
+  func testSpotAtIndexWithInferredType() {
+    let component = Component(title: "Component")
+    let listSpot = ListSpot(component: component)
+    spotController = SpotsController(spots: [listSpot], refreshable: true)
+
+    let foundComponent = spotController?.spot(NSPredicate(format: "SELF.component.title = '%@'", component.title))
+    print(foundComponent)
+  }
 }

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -83,7 +83,7 @@ public class SpotsController: UIViewController {
   }
 
   public func spotAtIndex(index: Int) -> Spotable? {
-    return spots.filter { $0.index == index }.first
+    return spots.filter{ $0.index == index }.first
   }
 
   public func reloadSpots() {

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -86,6 +86,7 @@ public class SpotsController: UIViewController {
     return spots.filter{ $0.index == index }.first
   }
 
+  public func spot(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
     for (index, spot) in spots.enumerate() where closure(index: index, spot: spot)
     { return spot }
     return nil

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -86,6 +86,12 @@ public class SpotsController: UIViewController {
     return spots.filter{ $0.index == index }.first
   }
 
+  public func spot(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
+    for (index, spot) in spots.enumerate() where closure(index: index, spot: spot)
+    { return spot }
+    return nil
+  }
+
   public func reloadSpots() {
     dispatch { [weak self] in
       self?.spots.forEach { $0.reload([]) {} }

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -87,8 +87,10 @@ public class SpotsController: UIViewController {
   }
 
   public func spot(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
-    for (index, spot) in spots.enumerate() where closure(index: index, spot: spot)
-    { return spot }
+    for (index, spot) in spots.enumerate()
+      where closure(index: index, spot: spot) {
+        return spot
+    }
     return nil
   }
 

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -86,7 +86,6 @@ public class SpotsController: UIViewController {
     return spots.filter{ $0.index == index }.first
   }
 
-  public func find(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
     for (index, spot) in spots.enumerate() where closure(index: index, spot: spot)
     { return spot }
     return nil

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -86,7 +86,7 @@ public class SpotsController: UIViewController {
     return spots.filter{ $0.index == index }.first
   }
 
-  public func spot(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
+  public func find(closure: (index: Int, spot: Spotable) -> Bool) -> Spotable? {
     for (index, spot) in spots.enumerate() where closure(index: index, spot: spot)
     { return spot }
     return nil

--- a/Source/SpotsController.swift
+++ b/Source/SpotsController.swift
@@ -92,6 +92,10 @@ public class SpotsController: UIViewController {
     return nil
   }
 
+  public func filter(@noescape includeElement: (Spotable) -> Bool) -> [Spotable] {
+    return spots.filter(includeElement)
+  }
+
   public func reloadSpots() {
     dispatch { [weak self] in
       self?.spots.forEach { $0.reload([]) {} }


### PR DESCRIPTION
This PR adds an easier way of searching for spots, instead of just referencing the ID, you are free to construct your own query with a closure;

```swift
    .find { $1.component.title == "ListSpot" }
    .find { $1 is Listable }
    .find { $1.items.filter{ $0.title == "ListItem" }.first != nil }
    .find { $0.index == 0 }?.component.title, "ListSpot"
```