### PR TITLE
Remove infix operators

### DIFF
--- a/Pod/Tests/Models/TestComponent.swift
+++ b/Pod/Tests/Models/TestComponent.swift
@@ -51,24 +51,4 @@ class ComponentTests : XCTestCase {
     codeComponent.items.append(ListItem(title: "item2"))
     XCTAssertFalse(jsonComponent == codeComponent)
   }
-
-  func testInfixOperator() {
-    var component = Component()
-    let listItem = ListItem(title: "item1")
-
-    component + listItem
-    
-    XCTAssert(component.items.count == 1)
-
-    let listItems = [
-      ListItem(title: "item2"),
-      ListItem(title: "item3")
-    ]
-
-    component + listItems
-
-    XCTAssert(component.items.count == 3)
-    XCTAssert(component.items[1] == listItems[0])
-    XCTAssert(component.items[2] == listItems[1])
-  }
 }

--- a/Source/Models/Component.swift
+++ b/Source/Models/Component.swift
@@ -1,16 +1,6 @@
 import Tailor
 import Sugar
 
-infix operator + {}
-
-public func + (inout left: Component, right: ListItem) {
-  left.items.append(right)
-}
-
-public func + (inout left: Component, right: [ListItem]) {
-  left.items.appendContentsOf(right)
-}
-
 public struct Component: Mappable {
   public var index = 0
   public var title = ""


### PR DESCRIPTION
This caused a lot of conflicts with other Pods that use the same infix operators. Couldn’t figure out how to scope it to just apply to Component and ListItem so I’m just gonna remove it for now.