### PR TITLE
Improve sizing of the container in viewWillAppear

### DIFF
--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -5,6 +5,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   public private(set) var spots: [Spotable]
   private var refreshing = false
+  private var initialContentInset: UIEdgeInsets = UIEdgeInsetsZero
 
   lazy public var container: SpotScrollView = { [unowned self] in
     let container = SpotScrollView(frame: self.view.frame)
@@ -72,6 +73,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     container.frame = UIScreen.mainScreen().bounds
     container.frame.size.height -= ceil(tabBarController?.tabBar.frame.height ?? 0)
     container.frame.size.height -= ceil(CGRectGetMaxY(navigationController?.navigationBar.frame ?? CGRectZero))
+    initialContentInset = container.contentInset
 
     for spot in self.spots {
       spot.render().layoutSubviews()

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -114,18 +114,16 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   public func scrollViewDidEndDragging(scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     guard refreshControl.refreshing else { return }
-    let defaultContainerOffset = container.contentOffset
-    let defaultContainerInset = container.contentInset.top
     container.contentInset.top = -scrollView.contentOffset.y
 
     delay(1.0) {
       self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
+        guard let weakSelf = self else { return }
         UIView.animateWithDuration(0.3, animations: {
-          self?.container.contentOffset = defaultContainerOffset
-          self?.container.contentInset.top = defaultContainerInset
+          weakSelf.container.contentInset = weakSelf.initialContentInset
           }, completion: { _ in
-            self?.refreshing = false
-            self?.refreshControl.endRefreshing()
+            weakSelf.refreshing = false
+            weakSelf.refreshControl.endRefreshing()
         })
       }
     }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -4,7 +4,13 @@ import Sugar
 public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   public private(set) var spots: [Spotable]
-  private var refreshing = false
+  private var refreshing = false {
+    didSet {
+      if !refreshing {
+        refreshControl.endRefreshing()
+      }
+    }
+  }
   private var initialContentInset: UIEdgeInsets = UIEdgeInsetsZero
 
   lazy public var container: SpotScrollView = { [unowned self] in
@@ -125,7 +131,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
         weakSelf.container.contentInset = weakSelf.initialContentInset
         }, completion: { _ in
           weakSelf.refreshing = false
-          weakSelf.refreshControl.endRefreshing()
       })
     }
   }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -119,16 +119,14 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     guard refreshControl.refreshing else { return }
     container.contentInset.top = -scrollView.contentOffset.y
 
-    delay(1.0) {
-      self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
-        guard let weakSelf = self else { return }
-        UIView.animateWithDuration(0.3, animations: {
-          weakSelf.container.contentInset = weakSelf.initialContentInset
-          }, completion: { _ in
-            weakSelf.refreshing = false
-            weakSelf.refreshControl.endRefreshing()
-        })
-      }
+    self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
+      guard let weakSelf = self else { return }
+      UIView.animateWithDuration(0.3, animations: {
+        weakSelf.container.contentInset = weakSelf.initialContentInset
+        }, completion: { _ in
+          weakSelf.refreshing = false
+          weakSelf.refreshControl.endRefreshing()
+      })
     }
   }
 

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -82,7 +82,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
     initialContentInset = container.contentInset
 
-    for spot in self.spots {
+    spots.forEach { spot in
       spot.render().layoutSubviews()
       spot.render().setNeedsDisplay()
     }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -71,8 +71,9 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     super.viewWillAppear(animated)
 
     container.frame = UIScreen.mainScreen().bounds
-    container.frame.size.height -= ceil(tabBarController?.tabBar.frame.height ?? 0)
-    container.frame.size.height -= ceil(CGRectGetMaxY(navigationController?.navigationBar.frame ?? CGRectZero))
+    container.frame.size.height -= ceil(container.contentInset.top + container.contentOffset.y)
+    container.contentInset.bottom = tabBarController?.tabBar.frame.height ?? container.contentInset.bottom
+
     initialContentInset = container.contentInset
 
     for spot in self.spots {

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -66,6 +66,25 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     }
   }
 
+  public override func viewWillAppear(animated: Bool) {
+    super.viewWillAppear(animated)
+
+    container.frame = UIScreen.mainScreen().bounds
+    container.frame.size.height -= ceil(tabBarController?.tabBar.frame.height ?? 0)
+    container.frame.size.height -= ceil(CGRectGetMaxY(navigationController?.navigationBar.frame ?? CGRectZero))
+
+    for spot in self.spots {
+      spot.render().layoutSubviews()
+      spot.render().setNeedsDisplay()
+    }
+  }
+
+  public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+
+    spots.forEach { $0.layout(size) }
+  }
+
   public func scrollViewDidScroll(scrollView: UIScrollView) {
     let bounds = scrollView.bounds
     let inset = scrollView.contentInset
@@ -110,20 +129,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
         })
       }
     }
-  }
-
-  public override func viewWillAppear(animated: Bool) {
-    super.viewWillAppear(animated)
-    for spot in self.spots {
-      spot.render().layoutSubviews()
-      spot.render().setNeedsDisplay()
-    }
-  }
-
-  public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-    spots.forEach { $0.layout(size) }
   }
 
   public func spotAtIndex(index: Int) -> Spotable? {

--- a/Source/Views/SpotScrollView.swift
+++ b/Source/Views/SpotScrollView.swift
@@ -114,12 +114,6 @@ public class SpotScrollView: UIScrollView {
       }
     }
 
-    if let navigationController = UIApplication.sharedApplication().keyWindow?.rootViewController as? UINavigationController,
-      tabBarController = navigationController.viewControllers.first as? UITabBarController
-      where tabBarController.tabBar.translucent {
-        contentInset.bottom = tabBarController.tabBar.frame.height
-    }
-
     let minimumContentHeight = bounds.height - (contentInset.top + contentInset.bottom)
     let initialContentOffset = contentOffset
     contentSize = CGSize(width: bounds.size.width, height: fmax(yOffsetOfCurrentSubview, minimumContentHeight))


### PR DESCRIPTION
With this PR, the container view will resize depending if a navigation bar or tab bar is present.

```swift
+    container.frame = UIScreen.mainScreen().bounds
+    container.frame.size.height -= ceil(container.contentInset.top + container.contentOffset.y)
+    container.contentInset.bottom = tabBarController?.tabBar.frame.height ?? container.contentInset.bottom
+
+    initialContentInset = container.contentInset
```

This should also improve the refresh method;

```swift
    self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
      guard let weakSelf = self else { return }
      UIView.animateWithDuration(0.3, animations: {
        weakSelf.container.contentInset = weakSelf.initialContentInset
        }, completion: { _ in
          weakSelf.refreshing = false
          weakSelf.refreshControl.endRefreshing()
      })
    }
```
