### PR TITLE
Improve refreshing SpotController

### DIFF
--- a/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
+++ b/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
@@ -33,13 +33,15 @@ extension SpotsController {
     guard refreshControl.refreshing else { return }
     container.contentInset.top = -scrollView.contentOffset.y
 
-    self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
-      guard let weakSelf = self else { return }
-      UIView.animateWithDuration(0.3, animations: {
-        weakSelf.container.contentInset = weakSelf.initialContentInset
-        }, completion: { _ in
-          weakSelf.refreshing = false
-      })
+    delay(0.5) {
+      self.spotDelegate?.spotsDidReload(refreshControl) { [weak self] in
+        guard let weakSelf = self else { return }
+        UIView.animateWithDuration(0.3, animations: {
+          weakSelf.container.contentInset = weakSelf.initialContentInset
+          }, completion: { _ in
+            weakSelf.refreshing = false
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a small delay so that the refreshing looks a lot smoother.
Before it was quiet jumpy, that is not what we want, this is what we want.
The delay is set to `0.5` which should be good enough.