### PR TITLE
Fix jumpyness in infinte scrolling

### DIFF
--- a/Source/Views/SpotsScrollView.swift
+++ b/Source/Views/SpotsScrollView.swift
@@ -98,6 +98,14 @@ public class SpotsScrollView: UIScrollView {
           frame.origin.y = self.contentOffset.y
         }
 
+        // TODO: Fix this properly...
+        // This should also apply for UICollectionView but I haven't figured out a way to resize them properly without it going ape-shit over that the layout is incorrect.
+        if subview is UITableView {
+          let remainingBoundsHeight = fmax(CGRectGetMaxY(bounds) - CGRectGetMinY(frame), 0.0)
+          let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
+          frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
+        }
+
         frame.size.width = ceil(contentView.frame.size.width)
 
         scrollView.frame = frame
@@ -118,7 +126,11 @@ public class SpotsScrollView: UIScrollView {
     let initialContentOffset = contentOffset
     contentSize = CGSize(width: bounds.size.width, height: fmax(yOffsetOfCurrentSubview, minimumContentHeight))
 
+    print("contentSize: \(contentSize)")
+    print("contentInset: \(contentInset)")
+
     if initialContentOffset != contentOffset {
+      print("setNeedsLayout")
       setNeedsLayout()
       layoutIfNeeded()
     }

--- a/Source/Views/SpotsScrollView.swift
+++ b/Source/Views/SpotsScrollView.swift
@@ -126,11 +126,7 @@ public class SpotsScrollView: UIScrollView {
     let initialContentOffset = contentOffset
     contentSize = CGSize(width: bounds.size.width, height: fmax(yOffsetOfCurrentSubview, minimumContentHeight))
 
-    print("contentSize: \(contentSize)")
-    print("contentInset: \(contentInset)")
-
     if initialContentOffset != contentOffset {
-      print("setNeedsLayout")
       setNeedsLayout()
       layoutIfNeeded()
     }


### PR DESCRIPTION
Add some more logic to handle the sizing of the subviews, this should fix the jumpy
experience that we have been having when you scroll to the bottom. It should also fix
the transition jumping when the list is being dismissed by presenting a new view.

```swift
        if subview is UITableView {
          let remainingBoundsHeight = fmax(CGRectGetMaxY(bounds) - CGRectGetMinY(frame), 0.0)
          let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
          frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
        }
```

This needs to be refactored in the future to also support `UICollectionView`'s. I added a `TODO:` and
a comment in the source code so that we don't forget about it.