### PR TITLE
Feature: spots scroll delegate

### DIFF
--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -2,7 +2,7 @@ import Spots
 import Sugar
 import Fakery
 
-class ForYouController: SpotsController, SpotsDelegate {
+class ForYouController: SpotsController, SpotsDelegate, SpotsScrollDelegate {
 
   static let faker = Faker()
 
@@ -13,6 +13,7 @@ class ForYouController: SpotsController, SpotsDelegate {
     
     self.title = title
     spotDelegate = self
+    spotsScrollDelegate = self
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = ForYouController.generateItems(0, to: 10)

--- a/Examples/SpotsFeed/SpotsFeed/FeedController.swift
+++ b/Examples/SpotsFeed/SpotsFeed/FeedController.swift
@@ -2,12 +2,13 @@ import Sugar
 import Fakery
 import Spots
 
-public class FeedController: SpotsController, SpotsDelegate {
+public class FeedController: SpotsController, SpotsDelegate, SpotsScrollDelegate {
 
   public static let faker = Faker()
   
   public override func viewDidLoad() {
     self.spotDelegate = self
+    self.spotsScrollDelegate = self
     super.viewDidLoad()
   }
 

--- a/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
+++ b/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
@@ -34,7 +34,7 @@ extension SpotsController {
     container.contentInset.top = -scrollView.contentOffset.y
 
     delay(0.5) {
-      self.spotScrollDelegate?.spotsDidReload(self.refreshControl) { [weak self] in
+      self.spotsScrollDelegate?.spotsDidReload(self.refreshControl) { [weak self] in
         guard let weakSelf = self else { return }
         UIView.animateWithDuration(0.3, animations: {
           weakSelf.container.contentInset = weakSelf.initialContentInset

--- a/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
+++ b/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
@@ -34,7 +34,7 @@ extension SpotsController {
     container.contentInset.top = -scrollView.contentOffset.y
 
     delay(0.5) {
-      self.spotDelegate?.spotsDidReload(self.refreshControl) { [weak self] in
+      self.spotScrollDelegate?.spotsDidReload(self.refreshControl) { [weak self] in
         guard let weakSelf = self else { return }
         UIView.animateWithDuration(0.3, animations: {
           weakSelf.container.contentInset = weakSelf.initialContentInset

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -20,7 +20,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     }
   }
 
-  weak public var spotScrollDelegate: SpotScrollDelegate?
+  weak public var spotsScrollDelegate: SpotsScrollDelegate?
 
   lazy public var container: SpotsScrollView = { [unowned self] in
     let container = SpotsScrollView(frame: self.view.frame)
@@ -186,7 +186,7 @@ extension SpotsController {
   public func refreshSpots(refreshControl: UIRefreshControl) {
     dispatch { [weak self] in
       if let weakSelf = self {
-        weakSelf.spotScrollDelegate?.spotsDidReload(refreshControl) { }
+        weakSelf.spotsScrollDelegate?.spotsDidReload(refreshControl) { }
       }
     }
   }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -20,6 +20,8 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     }
   }
 
+  weak public var spotScrollDelegate: SpotScrollDelegate?
+
   lazy public var container: SpotsScrollView = { [unowned self] in
     let container = SpotsScrollView(frame: self.view.frame)
     container.alwaysBounceVertical = true
@@ -183,8 +185,8 @@ extension SpotsController {
 
   public func refreshSpots(refreshControl: UIRefreshControl) {
     dispatch { [weak self] in
-      if let weakSelf = self, spotDelegate = weakSelf.spotDelegate {
-        spotDelegate.spotsDidReload(refreshControl) { }
+      if let weakSelf = self {
+        weakSelf.spotScrollDelegate?.spotsDidReload(refreshControl) { }
       }
     }
   }

--- a/Source/Library/SpotsDelegate.swift
+++ b/Source/Library/SpotsDelegate.swift
@@ -5,7 +5,7 @@ public protocol SpotsDelegate: class {
   func spotDidSelectItem(spot: Spotable, item: ListItem)
 }
 
-public protocol SpotScrollDelegate: class {
+public protocol SpotsScrollDelegate: class {
 
   func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
   func spotDidReachEnd(completion: (() -> Void)?)

--- a/Source/Library/SpotsDelegate.swift
+++ b/Source/Library/SpotsDelegate.swift
@@ -5,7 +5,7 @@ public protocol SpotsDelegate: class {
   func spotDidSelectItem(spot: Spotable, item: ListItem)
 }
 
-public protocol SpotsScrollDelegate: class {
+public protocol SpotScrollDelegate: class {
 
   func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
   func spotDidReachEnd(completion: (() -> Void)?)

--- a/Source/Library/SpotsDelegate.swift
+++ b/Source/Library/SpotsDelegate.swift
@@ -3,10 +3,15 @@ import UIKit
 public protocol SpotsDelegate: class {
 
   func spotDidSelectItem(spot: Spotable, item: ListItem)
+}
+
+public protocol SpotsScrollDelegate: class {
+
   func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
   func spotDidReachEnd(completion: (() -> Void)?)
 }
 
 extension SpotsDelegate {
+
   public func spotDidReachEnd(completion: (() -> Void)? = nil) {}
 }


### PR DESCRIPTION
@zenangst @RamonGilabert 
I feel like these methods don't belong to `SpotsDelegate`:
```swift
func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
func spotDidReachEnd(completion: (() -> Void)?)
```

It's more about scrolling. Also got one controller in the project that is not refreshable and only need to handle `spotDidSelectItem`. With this solution we don't need to create workarounds with empty delegate func implementations.