### PR TITLE
Fix faulty boolean value in infinite scrolling

### DIFF
--- a/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
+++ b/Source/Controllers/SpotsController+UIScrollViewDelegate.swift
@@ -20,7 +20,7 @@ extension SpotsController {
 
     // Infinite scrolling
     if shouldFetch && !refreshing {
-      refreshing = false
+      refreshing = true
       delay(0.2) {
         self.spotsScrollDelegate?.spotDidReachEnd {
           self.refreshing = false


### PR DESCRIPTION
So, this thing wans't working because it was setting the wrong value when
it started refreshing.