### PR TITLE
Improve updating spots

### DIFF
--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -148,6 +148,8 @@ extension SpotsController {
   public func updateSpotAtIndex(index: Int, closure: (spot: Spotable) -> Spotable, completion: (() -> Void)? = nil) {
     guard let spot = spotAtIndex(index) else { return }
     spots[spot.index] = closure(spot: spot)
+    spot.prepare()
+    spot.setup(container.bounds.size)
 
     dispatch { [weak self] in
       guard let weakSelf = self else { return }

--- a/Source/Spots/List/ListSpot.swift
+++ b/Source/Spots/List/ListSpot.swift
@@ -55,16 +55,15 @@ public class ListSpot: NSObject, Spotable, Listable {
   }
 
   public func setup(size: CGSize) {
-    if component.size == nil {
-      var height = component.items.reduce(0, combine: { $0 + $1.size.height })
+    prepare()
+    var height = component.items.reduce(0, combine: { $0 + $1.size.height })
 
-      if !component.title.isEmpty { height += headerHeight }
+    if !component.title.isEmpty { height += headerHeight }
 
-      tableView.frame.size = size
-      tableView.contentSize = CGSize(
-        width: tableView.frame.width,
-        height: height - tableView.contentInset.top - tableView.contentInset.bottom)
-    }
+    tableView.frame.size = size
+    tableView.contentSize = CGSize(
+      width: tableView.frame.width,
+      height: height - tableView.contentInset.top - tableView.contentInset.bottom)
 
     ListSpot.configure?(view: tableView)
   }


### PR DESCRIPTION
We had some issues with Spots not rendering correctly when modifying the data, it appeared correctly as soon as you started to scroll. I believe this was because the `ListItem` was not configured with a size and when you scrolled they got configured which would explain this behavior.

Running `prepare` & `setup` when `updateSpotAtIndex` should configure all items in the list with the appropriate heights.

`setup` on `ListSpot` has now been refactored to not run if the component already has a size. It will do processing without any conditions.