### PR TITLE
Remove refreshable label in init

### DIFF
--- a/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
@@ -39,7 +39,7 @@ class ExploreController: SpotsController {
       ListSpot(component: browse)
     ]
 
-    self.init(spots: spots, refreshable: false)
+    self.init(spots: spots)
     self.title = title
   }
 

--- a/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
@@ -12,7 +12,7 @@ class FavoritesController: SpotsController {
       GridSpot(favorites, top: 10, left: 10, bottom: 20, right: 10, itemSpacing: -5)
     ]
 
-    self.init(spots: spots, refreshable: false)
+    self.init(spots: spots)
     self.title = title
 
     dispatch(queue: .Interactive) { [weak self] in

--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -9,8 +9,8 @@ class ForYouController: SpotsController, SpotsDelegate {
   convenience init(title: String) {
     let component = Component()
     let feedSpot = ListSpot(component: component)
-    self.init(spots: [feedSpot], refreshable: true)
-    
+    self.init(spots: [feedSpot])
+
     self.title = title
     spotsDelegate = self
     spotsScrollDelegate = self

--- a/Examples/Apple News/AppleNews/Controllers/SavedController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SavedController.swift
@@ -9,7 +9,7 @@ class SavedController: SpotsController {
   convenience init(title: String) {
     let component = Component()
     let feedSpot = ListSpot(component: component)
-    self.init(spots: [feedSpot], refreshable: false)
+    self.init(spots: [feedSpot])
 
     self.title = title
 

--- a/Examples/Apple News/AppleNews/Controllers/SearchController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SearchController.swift
@@ -12,7 +12,7 @@ class SearchController: SpotsController {
       TitleSpot(title: "Suggestions")
     ]
 
-    self.init(spots: spots, refreshable: false)
+    self.init(spots: spots)
     self.title = title
 
     dispatch(queue: .Interactive) { [weak self] in

--- a/Examples/SpotsDemo/Demo/JSONController.swift
+++ b/Examples/SpotsDemo/Demo/JSONController.swift
@@ -109,5 +109,4 @@ class JSONController: UIViewController {
       submitButton.frame = CGRect(x: 50, y: textView.frame.maxY + 50, width: totalSize.width - 100, height: 50)
     }
   }
-
 }

--- a/Examples/SpotsDemo/Demo/JSONController.swift
+++ b/Examples/SpotsDemo/Demo/JSONController.swift
@@ -31,10 +31,16 @@ class JSONController: UIViewController {
     return button
     }()
 
+  lazy var tapGesture: UITapGestureRecognizer = { [weak self] in
+    let tapGesture = UITapGestureRecognizer(target: self, action: "backgroundTapped:")
+    return tapGesture
+  }()
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
     view.backgroundColor = UIColor.whiteColor()
+    view.addGestureRecognizer(tapGesture)
 
     navigationItem.backBarButtonItem = UIBarButtonItem(title: nil, style: .Plain, target: nil, action: nil)
 
@@ -58,12 +64,6 @@ class JSONController: UIViewController {
     textView.text = json
 
     setupFrames()
-  }
-
-  override func viewDidAppear(animated: Bool) {
-    super.viewDidAppear(animated)
-
-    submitButtonDidPress()
   }
 
   override func viewDidLayoutSubviews() {
@@ -91,6 +91,10 @@ class JSONController: UIViewController {
         presentViewController(alertController, animated: true, completion: nil)
       }
     }
+  }
+
+  func backgroundTapped(gesture: UITapGestureRecognizer) {
+    textView.resignFirstResponder()
   }
 
   // MARK - Configuration

--- a/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
+++ b/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let feedSpot = ListSpot(component: feedComponent)
     let components: [Spotable] = [feedSpot]
 
-    let controller = FeedController(spots: components, refreshable: true)
+    let controller = FeedController(spots: components)
     controller.title = "Feed"
 
     applyStyles()

--- a/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
+++ b/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     controller.title = "Feed"
 
     applyStyles()
-    
+
     navigationController = UINavigationController(rootViewController: controller)
     window?.rootViewController = navigationController
     window?.makeKeyAndVisible()
@@ -81,7 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         var content = [post]
         content.appendContentsOf(comments)
-        
+
         let feedComponent = Component(span: 1, items: content)
         let feedSpot = ListSpot(component: feedComponent)
         let controller = SpotsController(spots: [feedSpot])

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -20,8 +20,19 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     }
   }
 
+  weak public var spotsRefreshDelegate: SpotsRefreshDelegate? {
+    didSet {
+      if spotsRefreshDelegate != nil {
+        tableView.addSubview(refreshControl)
+        container.addSubview(tableView)
+      } else {
+        refreshControl.removeFromSuperview()
+        tableView.removeFromSuperview()
+      }
+    }
+  }
+
   weak public var spotsScrollDelegate: SpotsScrollDelegate?
-  weak public var spotsRefreshDelegate: SpotsRefreshDelegate?
 
   lazy public var container: SpotsScrollView = { [unowned self] in
     let container = SpotsScrollView(frame: self.view.frame)

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -51,15 +51,10 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   // MARK: Initializer
 
-  public required init(spots: [Spotable] = [], refreshable: Bool = false) {
+  public required init(spots: [Spotable] = []) {
     self.spots = spots
     super.init(nibName: nil, bundle: nil)
     view.addSubview(container)
-
-    if refreshable {
-      tableView.addSubview(refreshControl)
-      container.addSubview(tableView)
-    }
 
     spots.enumerate().forEach { spot($0.index).index = $0.index }
   }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -76,7 +76,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
       spot.component.size = CGSize(
         width: view.frame.width,
         height: ceil(spot.render().frame.height))
-      spot.spotsDelegate = spotsDelegate
     }
   }
 


### PR DESCRIPTION
With this PR, you no longer need to set the SpotsController as refreshable during init. This is handled when the SpotsController gets a delegate assigned.

```swift
didSet {
      if spotsRefreshDelegate != nil {
        tableView.addSubview(refreshControl)
        container.addSubview(tableView)
      } else {
        refreshControl.removeFromSuperview()
        tableView.removeFromSuperview()
      }
    }
```