### PR TITLE
Improve/public api

### DIFF
--- a/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
@@ -13,10 +13,10 @@ class FavoritesController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = FavoritesController.generateItems(0, to: 11)
-      self?.update(closure: { (spot) -> Spotable in
+      self?.update { (spot) -> Spotable in
         spot.component.items = items
         return spot
-      })
+      }
     }
   }
 

--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -18,10 +18,10 @@ class ForYouController: SpotsController, SpotsDelegate {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = ForYouController.generateItems(0, to: 10)
-      self?.update(closure: { (spot) -> Spotable in
+      self?.update { (spot) -> Spotable in
         spot.component.items = items
         return spot
-      })
+      }
     }
   }
 

--- a/Examples/Apple News/AppleNews/Controllers/SavedController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SavedController.swift
@@ -15,10 +15,10 @@ class SavedController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = ForYouController.generateItems(0, to: 2)
-      self?.update(closure: { (spot) -> Spotable in
+      self?.update { (spot) -> Spotable in
         spot.component.items = items
         return spot
-      })
+      }
     }
   }
 }

--- a/Examples/Apple News/AppleNews/Controllers/SearchController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SearchController.swift
@@ -18,10 +18,10 @@ class SearchController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = FavoritesController.generateItems(0, to: 4)
-      self?.update(spotAtIndex: 2, closure: { (spot) -> Spotable in
+      self?.update(spotAtIndex: 2) { (spot) -> Spotable in
         spot.component.items = items
         return spot
-      })
+      }
     }
 
     if let spot = spot as? ListSpot,
@@ -41,16 +41,16 @@ extension SearchController: UITextFieldDelegate {
           let items = FavoritesController.generateItems(0, to: 4)
 
           if self?.spot(1)?.component.title == "Results" {
-            self?.update(spotAtIndex: 1, closure: { (spot) -> Spotable in
+            self?.update(spotAtIndex: 1) { (spot) -> Spotable in
               spot.component.title = "Suggestions"
               return spot
-            })
+            }
           }
 
-          self?.update(spotAtIndex: 2, closure: { (spot) -> Spotable in
+          self?.update(spotAtIndex: 2) { (spot) -> Spotable in
             spot.component.items = items
             return spot
-          })
+          }
         }
     } else if textField.text?.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) > 0 ||
       string.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) > 0 {
@@ -58,17 +58,17 @@ extension SearchController: UITextFieldDelegate {
         dispatch(queue: .Interactive) { [weak self] in
 
           if self?.spot(1)?.component.title == "Suggestions" {
-            self?.update(spotAtIndex: 1, closure: { (spot) -> Spotable in
+            self?.update(spotAtIndex: 1) { (spot) -> Spotable in
               spot.component.title = "Results"
               return spot
-            })
+            }
           }
 
           let items = FavoritesController.generateItems(0, to: 11)
-          self?.update(spotAtIndex: 2, closure: { (spot) -> Spotable in
+          self?.update(spotAtIndex: 2) { (spot) -> Spotable in
             spot.component.items = items
             return spot
-          })
+          }
         }
     }
 

--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -15,13 +15,12 @@ class SpotsControllerTests : XCTestCase {
     let component = Component(title: "Component")
     let listSpot = ListSpot(component: component)
     let spotController = SpotsController(spot: listSpot)
-
     let items = [ListItem(title: "item1")]
 
-    spotController.update(closure: { spot -> Spotable in
+    spotController.update { (spot) -> Spotable in
       spot.component.items = items
       return spot
-    })
+    }
 
     XCTAssert(spotController.spot.component.items == items)
   }

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -36,13 +36,13 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   weak public var spotsScrollDelegate: SpotsScrollDelegate?
 
   lazy public var spotsScrollView: SpotsScrollView = { [unowned self] in
-    let container = SpotsScrollView(frame: self.view.frame)
-    container.alwaysBounceVertical = true
-    container.backgroundColor = UIColor.whiteColor()
-    container.clipsToBounds = true
-    container.delegate = self
+    let scrollView = SpotsScrollView(frame: self.view.frame)
+    scrollView.alwaysBounceVertical = true
+    scrollView.backgroundColor = UIColor.whiteColor()
+    scrollView.clipsToBounds = true
+    scrollView.delegate = self
 
-    return container
+    return scrollView
     }()
 
   public lazy var tableView: UITableView = { [unowned self] in

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -153,7 +153,7 @@ extension SpotsController {
     }
   }
 
-  public func update(spotAtIndex index: Int = 0, closure: (spot: Spotable) -> Spotable) {
+  public func update(spotAtIndex index: Int = 0, _ closure: (spot: Spotable) -> Spotable) {
     guard let spot = spot(index) else { return }
     spots[spot.index] = closure(spot: spot)
     spot.prepare()

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -17,9 +17,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   }
 
   public var spot: Spotable {
-    get {
-      return spot(0)!
-    }
+    get { return spot(0)! }
   }
 
   weak public var spotsRefreshDelegate: SpotsRefreshDelegate? {

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -155,7 +155,7 @@ extension SpotsController {
     }
   }
 
-  public func update(spotAtIndex index: Int = 0, closure: (spot: Spotable) -> Spotable, completion: (() -> Void)? = nil) {
+  public func update(spotAtIndex index: Int = 0, closure: (spot: Spotable) -> Spotable) {
     guard let spot = spot(index) else { return }
     spots[spot.index] = closure(spot: spot)
     spot.prepare()


### PR DESCRIPTION
With this PR the `update` methods is improved. You can now drop the `closure` label when calling `update` on a Spot.

### Before
```diff
- update(closure: { (spot) -> Spotable in return spot })
```

### After
```diff
+update { (spot) -> Spotable in return spot }
```

Updating a spot at a specific index looks like this

```swift
update(spotAtIndex: 1) { (spot) -> Spotable in
  // here be dragons
  return spot
}
```