### PR TITLE
Remove return from update closure

### DIFF
--- a/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
@@ -13,9 +13,8 @@ class FavoritesController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = FavoritesController.generateItems(0, to: 11)
-      self?.update { (spot) -> Spotable in
+      self?.update { spot in
         spot.component.items = items
-        return spot
       }
     }
   }

--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -18,9 +18,8 @@ class ForYouController: SpotsController, SpotsDelegate {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = ForYouController.generateItems(0, to: 10)
-      self?.update { (spot) -> Spotable in
+      self?.update { spot in
         spot.component.items = items
-        return spot
       }
     }
   }

--- a/Examples/Apple News/AppleNews/Controllers/SavedController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SavedController.swift
@@ -15,9 +15,8 @@ class SavedController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = ForYouController.generateItems(0, to: 2)
-      self?.update { (spot) -> Spotable in
+      self?.update { spot in
         spot.component.items = items
-        return spot
       }
     }
   }

--- a/Examples/Apple News/AppleNews/Controllers/SearchController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SearchController.swift
@@ -18,9 +18,8 @@ class SearchController: SpotsController {
 
     dispatch(queue: .Interactive) { [weak self] in
       let items = FavoritesController.generateItems(0, to: 4)
-      self?.update(spotAtIndex: 2) { (spot) -> Spotable in
+      self?.update(spotAtIndex: 2) { spot in
         spot.component.items = items
-        return spot
       }
     }
 
@@ -41,15 +40,13 @@ extension SearchController: UITextFieldDelegate {
           let items = FavoritesController.generateItems(0, to: 4)
 
           if self?.spot(1)?.component.title == "Results" {
-            self?.update(spotAtIndex: 1) { (spot) -> Spotable in
+            self?.update(spotAtIndex: 1) { spot in
               spot.component.title = "Suggestions"
-              return spot
             }
           }
 
-          self?.update(spotAtIndex: 2) { (spot) -> Spotable in
+          self?.update(spotAtIndex: 2) { spot in
             spot.component.items = items
-            return spot
           }
         }
     } else if textField.text?.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) > 0 ||
@@ -58,16 +55,14 @@ extension SearchController: UITextFieldDelegate {
         dispatch(queue: .Interactive) { [weak self] in
 
           if self?.spot(1)?.component.title == "Suggestions" {
-            self?.update(spotAtIndex: 1) { (spot) -> Spotable in
+            self?.update(spotAtIndex: 1) { spot in
               spot.component.title = "Results"
-              return spot
             }
           }
 
           let items = FavoritesController.generateItems(0, to: 11)
-          self?.update(spotAtIndex: 2) { (spot) -> Spotable in
+          self?.update(spotAtIndex: 2) { spot in
             spot.component.items = items
-            return spot
           }
         }
     }

--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -17,9 +17,8 @@ class SpotsControllerTests : XCTestCase {
     let spotController = SpotsController(spot: listSpot)
     let items = [ListItem(title: "item1")]
 
-    spotController.update { (spot) -> Spotable in
+    spotController.update { spot in
       spot.component.items = items
-      return spot
     }
 
     XCTAssert(spotController.spot.component.items == items)

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -153,9 +153,9 @@ extension SpotsController {
     }
   }
 
-  public func update(spotAtIndex index: Int = 0, _ closure: (spot: Spotable) -> Spotable) {
+  public func update(spotAtIndex index: Int = 0, _ closure: (spot: Spotable) -> Void) {
     guard let spot = spot(index) else { return }
-    spots[spot.index] = closure(spot: spot)
+    closure(spot: spot)
     spot.prepare()
     spot.setup(spotsScrollView.bounds.size)
 


### PR DESCRIPTION
In this PR, we remove the return value for the update closure.

Thanks @vadymmarkov 💖

## Before
```swift
self?.update { (spot) -> Spotable in
  spot.component.items = items
  return spot
}
```

## After
```swift
self?.update { spot in
  spot.component.items = items
}
```