### PR TITLE
Feature init with JSON

### DIFF
--- a/Pod/Tests/Controllers/TestSpotsController.swift
+++ b/Pod/Tests/Controllers/TestSpotsController.swift
@@ -152,4 +152,21 @@ class SpotsControllerTests : XCTestCase {
 
     XCTAssert(spotController.filter { $0 is Listable }.count == 2)
   }
+
+  func testJSONInitialiser() {
+    let sourceController = SpotsController(spot: ListSpot().then {
+      $0.items = [ListItem(title: "First item")]
+      })
+    let jsonController = SpotsController([
+      "components" : [
+        ["type" : "list",
+          "items" : [
+            ["title" : "First item"]
+          ]
+        ]
+      ]
+      ])
+
+    XCTAssert(sourceController.spot.component == jsonController.spot.component)
+  }
 }

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ on the view model.
 
 ### View models in the Cloud
 ```swift
-let spots = Parser.parse(json)
-let controller = SpotsController(spots: spots)
+let controller = SpotsController(json)
 navigationController?.pushViewController(controller, animated: true)
 ```
 

--- a/Source/Controllers/SpotsController.swift
+++ b/Source/Controllers/SpotsController.swift
@@ -68,6 +68,10 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     self.init(spots: [spot])
   }
 
+  public convenience init(_ json: [String : AnyObject]) {
+    self.init(spots: Parser.parse(json))
+  }
+
   public required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -98,7 +102,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   public override func viewDidAppear(animated: Bool) {
     super.viewDidAppear(animated)
-  
+
     spotsScrollView.configured = true
   }
 


### PR DESCRIPTION
This PR adds a convenience init on SpotsController.

```swift
let controller = SpotsController(json)
navigationController?.pushViewController(controller, animated: true)
```