### PR TITLE
Add caching when preparing Spots

### DIFF
--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -175,17 +175,20 @@ public extension Spotable where Self : Gridable {
       collectionView.registerClass(T.defaultView, forCellWithReuseIdentifier: component.kind)
     }
 
+    var cached: UIView?
     for (index, item) in component.items.enumerate() {
       let reuseIdentifer = item.kind.isEmpty ? component.kind : item.kind
       let componentCellClass = T.views[reuseIdentifer] ?? T.defaultView
 
       component.items[index].index = index
 
-      if let cell = componentCellClass.init() as? Itemble {
-        component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
-        cell.configure(&component.items[index])
+      if cached == nil && cached.dynamicType != componentCellClass { cached = componentCellClass.init() }
+      component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
+      cached!.then {
+        ($0 as? Itemble)?.configure(&component.items[index])
       }
     }
+    cached = nil
   }
 
   public func reload(indexes: [Int] = [], completion: (() -> Void)?) {

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -22,16 +22,19 @@ public extension Spotable where Self : Listable {
       tableView.registerClass(T.defaultView, forCellReuseIdentifier: component.kind)
     }
 
+    var cached: UIView?
     for (index, item) in component.items.enumerate() {
       let reuseIdentifer = item.kind.isEmpty ? component.kind : item.kind
       let componentCellClass = T.views[reuseIdentifer] ?? T.defaultView
 
       component.items[index].index = index
 
-      componentCellClass.init().then {
+      if cached == nil && cached.dynamicType != componentCellClass { cached = componentCellClass.init() }
+      cached!.then {
         ($0 as? Itemble)?.configure(&component.items[index])
       }
     }
+    cached = nil
   }
 
   public func append(item: ListItem, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
This PR should optimise the setup of `Listable` and `Gridable` spots. It should save a whole lot of initialisations as it reuses the last view that was initialised instead of creating a new one each time.