### PR TITLE
Improve reloading ListItems in Listable

### DIFF
--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -149,7 +149,7 @@ public extension Spotable where Self : Listable {
       cell.configure(&component.items[index])
     }
 
-    tableView.reloadSection()
+    tableView.reload([index], section: 0, animation: .None)
     completion?()
   }
 


### PR DESCRIPTION
This PR changes how `Listable` reloads individual items when `update` is called on
`SpotsController`.

```swift
tableView.reloadSection()
```

```swift
tableView.reload([index], section: 0, animation: .None)
```