### PR TITLE
Only trigger infinite scrolling if delegate is set

### DIFF
--- a/Sources/iOS/Controllers/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Controllers/SpotsController+UIScrollViewDelegate.swift
@@ -26,12 +26,12 @@ extension SpotsController {
     }
 
     // Infinite scrolling
-    if shouldFetch {
-      refreshPositions.append(size.height - itemOffset)
-      refreshing = true
-      self.spotsScrollDelegate?.spotDidReachEnd {
-        self.refreshing = false
-      }
+    guard let delegate = spotsScrollDelegate where shouldFetch else { return }
+
+    refreshPositions.append(size.height - itemOffset)
+    refreshing = true
+    delegate.spotDidReachEnd {
+      self.refreshing = false
     }
   }
 


### PR DESCRIPTION
This fixes refreshing being stuck at refreshing when reaching the
bottom.