### PR TITLE
Add refresh control if spotsRefreshDelegate is set

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -70,7 +70,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     super.viewDidLoad()
 
     view.addSubview(spotsScrollView)
-    spotsScrollView.insertSubview(refreshControl, atIndex: 0)
 
     spots.enumerate().forEach { index, spot in
       spots[index].index = index
@@ -93,6 +92,11 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
       where tabBarController.tabBar.translucent {
         spotsScrollView.contentInset.bottom = tabBarController.tabBar.frame.height
     }
+
+    guard let _ = spotsRefreshDelegate where refreshControl.superview == nil
+      else { return }
+
+    spotsScrollView.insertSubview(refreshControl, atIndex: 0)
   }
 
   public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
Before, we always added the refresh control. This PR fixes that issue by moving the insert code to `viewWillAppear`. So it will only add the refresh control if the delegate is set, it will only add it once because it checks if it has a superview or not.