### PR TITLE
Rename Itemble and ListItem

### DIFF
--- a/Examples/Apple News/AppleNews/Cells/FeedItemCell.swift
+++ b/Examples/Apple News/AppleNews/Cells/FeedItemCell.swift
@@ -2,7 +2,7 @@ import Spots
 import Sugar
 import Imaginary
 
-class FeedItemCell: UITableViewCell, Itemble {
+class FeedItemCell: UITableViewCell, ViewConfigurable {
 
   var size = CGSize(width: 0, height: 0)
 
@@ -37,7 +37,7 @@ class FeedItemCell: UITableViewCell, Itemble {
       fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     if !item.image.isEmpty {
       let URL = NSURL(string: item.image)
       customImageView.setImage(URL)

--- a/Examples/Apple News/AppleNews/Cells/GridTopicCell.swift
+++ b/Examples/Apple News/AppleNews/Cells/GridTopicCell.swift
@@ -5,7 +5,7 @@ import Spots
 import Imaginary
 import Hue
 
-class GridTopicCell: UICollectionViewCell, Itemble {
+class GridTopicCell: UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 125, height: 160)
 
@@ -67,7 +67,7 @@ class GridTopicCell: UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     if !item.image.isEmpty {
       imageView.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
       imageView.image = nil

--- a/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
@@ -5,28 +5,28 @@ class ExploreController: SpotsController {
 
   convenience init(title: String) {
     let suggestedChannels = Component(span: 3, items: [
-      ListItem(title: "Apple",   kind: "topic", image: ExploreController.suggestedImage(1)),
-      ListItem(title: "Spotify", kind: "topic", image: ExploreController.suggestedImage(2)),
-      ListItem(title: "Google",  kind: "topic", image: ExploreController.suggestedImage(3))
+      ViewModel(title: "Apple",   kind: "topic", image: ExploreController.suggestedImage(1)),
+      ViewModel(title: "Spotify", kind: "topic", image: ExploreController.suggestedImage(2)),
+      ViewModel(title: "Google",  kind: "topic", image: ExploreController.suggestedImage(3))
       ])
 
     let suggestedTopics = Component(span: 3, items: [
-      ListItem(title: "Business", kind: "topic", meta: ["color" : "5A0E20"]),
-      ListItem(title: "Software", kind: "topic", meta: ["color" : "760D26"]),
-      ListItem(title: "News",     kind: "topic", meta: ["color" : "2266B5"]),
-      ListItem(title: "iOS",      kind: "topic", meta: ["color" : "4CBCFB"])
+      ViewModel(title: "Business", kind: "topic", meta: ["color" : "5A0E20"]),
+      ViewModel(title: "Software", kind: "topic", meta: ["color" : "760D26"]),
+      ViewModel(title: "News",     kind: "topic", meta: ["color" : "2266B5"]),
+      ViewModel(title: "iOS",      kind: "topic", meta: ["color" : "4CBCFB"])
       ])
 
     let browse = Component(title: "Browse", items: [
-      ListItem(title: "News"),
-      ListItem(title: "Business"),
-      ListItem(title: "Politics"),
-      ListItem(title: "Travel"),
-      ListItem(title: "Technology"),
-      ListItem(title: "Sports"),
-      ListItem(title: "Science"),
-      ListItem(title: "Entertainment"),
-      ListItem(title: "Food")
+      ViewModel(title: "News"),
+      ViewModel(title: "Business"),
+      ViewModel(title: "Politics"),
+      ViewModel(title: "Travel"),
+      ViewModel(title: "Technology"),
+      ViewModel(title: "Sports"),
+      ViewModel(title: "Science"),
+      ViewModel(title: "Entertainment"),
+      ViewModel(title: "Food")
       ])
 
     let spots: [Spotable] = [

--- a/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
@@ -12,16 +12,16 @@ class FavoritesController: SpotsController {
     self.title = title
   }
 
-  static func generateItem(index: Int, kind: String = "topic") -> ListItem {
-    let item = ListItem(title: faker.commerce.department(),
+  static func generateItem(index: Int, kind: String = "topic") -> ViewModel {
+    let item = ViewModel(title: faker.commerce.department(),
       kind: kind,
       image: faker.internet.image(width: 125, height: 160) + "?type=avatar&id=\(index)")
 
     return item
   }
 
-  static func generateItems(from: Int, to: Int, kind: String = "topic") -> [ListItem] {
-    var items = [ListItem]()
+  static func generateItems(from: Int, to: Int, kind: String = "topic") -> [ViewModel] {
+    var items = [ViewModel]()
     for i in from...from+to {
       autoreleasepool({
         items.append(generateItem(i))

--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -17,12 +17,12 @@ class ForYouController: SpotsController, SpotsDelegate {
     spotsRefreshDelegate = self
   }
 
-  func spotDidSelectItem(spot: Spotable, item: ListItem) { }
+  func spotDidSelectItem(spot: Spotable, item: ViewModel) { }
 
-  static func generateItem(index: Int, kind: String = "feed") -> ListItem {
+  static func generateItem(index: Int, kind: String = "feed") -> ViewModel {
     let sencenceCount = Int(arc4random_uniform(4) + 2)
 
-    let item = ListItem(title: faker.lorem.sentences(amount: sencenceCount),
+    let item = ViewModel(title: faker.lorem.sentences(amount: sencenceCount),
       subtitle: faker.lorem.sentences(amount: 1),
       kind: kind,
       image: faker.internet.image(width: 180, height: 180) + "?type=avatar&id=\(index)")
@@ -30,8 +30,8 @@ class ForYouController: SpotsController, SpotsDelegate {
     return item
   }
 
-  static func generateItems(from: Int, to: Int, kind: String = "feed") -> [ListItem] {
-    var items = [ListItem]()
+  static func generateItems(from: Int, to: Int, kind: String = "feed") -> [ViewModel] {
+    var items = [ViewModel]()
     for i in from...from+to {
       autoreleasepool({
         items.append(generateItem(i))

--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
   Imaginary:
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
@@ -47,7 +47,7 @@ CHECKOUT OPTIONS:
     :commit: d31e0257a47f05c1c800ce150d1fec104dfc9085
     :git: https://github.com/hyperoslo/Hue
   Imaginary:
-    :commit: ab000e8bd10e1ada8d50307bcaaefc8bea209e8d
+    :commit: 243448a070decf6d8fcdc503b14505a2951af680
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:

--- a/Examples/Spotify/Application/Cells/DefaultListSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/DefaultListSpotCell.swift
@@ -1,7 +1,7 @@
 import Spots
 import Imaginary
 
-public class DefaultListSpotCell: UITableViewCell, Itemble {
+public class DefaultListSpotCell: UITableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 60)
   public var item: ListItem?

--- a/Examples/Spotify/Application/Cells/FeaturedGridSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/FeaturedGridSpotCell.swift
@@ -2,7 +2,7 @@ import Spots
 import Imaginary
 import Sugar
 
-public class FeaturedGridSpotCell: UICollectionViewCell, Itemble {
+public class FeaturedGridSpotCell: UICollectionViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 100, height: 120)
 

--- a/Examples/Spotify/Application/Cells/PlayerGridSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/PlayerGridSpotCell.swift
@@ -2,7 +2,7 @@ import Spots
 import Imaginary
 import Sugar
 
-public class PlayerGridSpotCell: UICollectionViewCell, Itemble {
+public class PlayerGridSpotCell: UICollectionViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 125, height: 100)
 

--- a/Examples/Spotify/Application/Cells/PlayerListSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/PlayerListSpotCell.swift
@@ -1,7 +1,7 @@
 import Spots
 import Imaginary
 
-public class PlayerListSpotCell: UITableViewCell, Itemble {
+public class PlayerListSpotCell: UITableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 60)
   public var item: ListItem?

--- a/Examples/Spotify/Application/Cells/PlaylistGridSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/PlaylistGridSpotCell.swift
@@ -2,7 +2,7 @@ import Spots
 import Imaginary
 import Sugar
 
-public class PlaylistGridSpotCell: UICollectionViewCell, Itemble {
+public class PlaylistGridSpotCell: UICollectionViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 125, height: 160)
 

--- a/Examples/Spotify/Application/Cells/PlaylistListSpotCell.swift
+++ b/Examples/Spotify/Application/Cells/PlaylistListSpotCell.swift
@@ -1,7 +1,7 @@
 import Spots
 import Imaginary
 
-public class PlaylistListSpotCell: UITableViewCell, Itemble {
+public class PlaylistListSpotCell: UITableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 60)
   public var item: ListItem?

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
   Keychain:
     :git: https://github.com/hyperoslo/Keychain
   Spots:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
@@ -44,7 +44,7 @@ CHECKOUT OPTIONS:
     :commit: d31e0257a47f05c1c800ce150d1fec104dfc9085
     :git: https://github.com/hyperoslo/Hue
   Imaginary:
-    :commit: ab000e8bd10e1ada8d50307bcaaefc8bea209e8d
+    :commit: 243448a070decf6d8fcdc503b14505a2951af680
     :git: https://github.com/hyperoslo/Imaginary
   Keychain:
     :commit: 21e6f607394e112229a7f30bebe2f832a4d43c48

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -30,7 +30,7 @@ EXTERNAL SOURCES:
   Imaginary:
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
     :commit: d31e0257a47f05c1c800ce150d1fec104dfc9085
     :git: https://github.com/hyperoslo/Hue
   Imaginary:
-    :commit: ab000e8bd10e1ada8d50307bcaaefc8bea209e8d
+    :commit: 243448a070decf6d8fcdc503b14505a2951af680
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:

--- a/Examples/SpotsCards/SpotsCards/Cells/CardSpotCell.swift
+++ b/Examples/SpotsCards/SpotsCards/Cells/CardSpotCell.swift
@@ -4,7 +4,7 @@ import Sugar
 import Hue
 import Spots
 
-class CardSpotCell : UICollectionViewCell, Itemble {
+class CardSpotCell : UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(
     width: 325,

--- a/Examples/SpotsDemo/Demo/Cells/GridSpotCellCircle.swift
+++ b/Examples/SpotsDemo/Demo/Cells/GridSpotCellCircle.swift
@@ -3,7 +3,7 @@ import Imaginary
 import Sugar
 import Spots
 
-class GridSpotCellCircle : UICollectionViewCell, Itemble {
+class GridSpotCellCircle : UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 88, height: 120)
 
@@ -44,7 +44,7 @@ class GridSpotCellCircle : UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     optimize()
 
     imageView.frame.size.height = 88

--- a/Examples/SpotsDemo/Demo/Cells/GridSpotHeader.swift
+++ b/Examples/SpotsDemo/Demo/Cells/GridSpotHeader.swift
@@ -3,7 +3,7 @@ import Imaginary
 import Sugar
 import Spots
 
-class GridSpotHeader : UICollectionViewCell, Itemble {
+class GridSpotHeader : UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 0, height: 320)
   lazy var imageView: UIImageView = {
@@ -22,7 +22,7 @@ class GridSpotHeader : UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     optimize()
     
     if !item.image.isEmpty {

--- a/Examples/SpotsDemo/Demo/Cells/GridSpotTitles.swift
+++ b/Examples/SpotsDemo/Demo/Cells/GridSpotTitles.swift
@@ -4,7 +4,7 @@ import Sugar
 import Spots
 import Hue
 
-class GridSpotCellTitles : UICollectionViewCell, Itemble {
+class GridSpotCellTitles : UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 88, height: 88)
 
@@ -55,7 +55,7 @@ class GridSpotCellTitles : UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     optimize()
     if let textColor = item.meta["text-color"] as? String {
       titleLabel.textColor = UIColor.hex(textColor)

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -30,7 +30,7 @@ EXTERNAL SOURCES:
   Imaginary:
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
     :commit: d31e0257a47f05c1c800ce150d1fec104dfc9085
     :git: https://github.com/hyperoslo/Hue
   Imaginary:
-    :commit: ab000e8bd10e1ada8d50307bcaaefc8bea209e8d
+    :commit: 243448a070decf6d8fcdc503b14505a2951af680
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -28,14 +28,14 @@ EXTERNAL SOURCES:
   Imaginary:
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
-    :path: ../../
+    :path: "../../"
 
 CHECKOUT OPTIONS:
   Cache:
     :commit: 5af9d7f80b5c39ec578c54874d5acda248d10831
     :git: https://github.com/hyperoslo/Cache
   Imaginary:
-    :commit: ab000e8bd10e1ada8d50307bcaaefc8bea209e8d
+    :commit: 243448a070decf6d8fcdc503b14505a2951af680
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:

--- a/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
+++ b/Examples/SpotsFeed/SpotsFeed/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       case "feed:post:{id}":
         let sencenceCount = Int(arc4random_uniform(8) + 1)
         let subtitle = Faker().lorem.sentences(amount: sencenceCount) + " " + Faker().internet.url()
-        let post = ListItem(title: Faker().name.name(),
+        let post = ViewModel(title: Faker().name.name(),
             subtitle: subtitle,
             kind: "feed",
             image: "http://lorempixel.com/75/75?type=avatar&id=1",

--- a/Examples/SpotsFeed/SpotsFeed/Cells/CommentTableViewCell.swift
+++ b/Examples/SpotsFeed/SpotsFeed/Cells/CommentTableViewCell.swift
@@ -6,11 +6,11 @@ public protocol CommentTableViewCellDelegate: class {
   func commentAuthorDidTap(commentID: Int)
 }
 
-public class CommentTableViewCell: WallTableViewCell, Itemble {
+public class CommentTableViewCell: WallTableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 44)
 
-  public class func height(item: ListItem) -> CGFloat {
+  public class func height(item: ViewModel) -> CGFloat {
     let post = item.post
     let postText = post.text as NSString
     let textFrame = postText.boundingRectWithSize(CGSize(
@@ -134,7 +134,7 @@ public class CommentTableViewCell: WallTableViewCell, Itemble {
 
   // MARK: - Setup
 
-  public func setupViews(item: ListItem) -> CGFloat {
+  public func setupViews(item: ViewModel) -> CGFloat {
     let post = item.post
     let totalWidth = UIScreen.mainScreen().bounds.width
 
@@ -163,7 +163,7 @@ public class CommentTableViewCell: WallTableViewCell, Itemble {
     return bottomSeparator.frame.origin.y
   }
 
-  public func configure(inout item: ListItem) {
+  public func configure(inout item: ViewModel) {
     if bottomSeparator.frame.origin.y == 0.0 {
       item.size.width = contentView.frame.width
       item.size.height = setupViews(item)

--- a/Examples/SpotsFeed/SpotsFeed/Cells/GridSpotFeedItem.swift
+++ b/Examples/SpotsFeed/SpotsFeed/Cells/GridSpotFeedItem.swift
@@ -3,10 +3,10 @@ import Imaginary
 import Sugar
 import Spots
 
-class GridSpotFeedItem : UICollectionViewCell, Itemble {
+class GridSpotFeedItem : UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 0, height: 320)
-  var item: ListItem?
+  var item: ViewModel?
 
   lazy var canvasView: UIView = {
     let view = UIView()
@@ -69,7 +69,7 @@ class GridSpotFeedItem : UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     if !item.image.isEmpty {
       imageView.image = nil
       let URL = NSURL(string: item.image)

--- a/Examples/SpotsFeed/SpotsFeed/Cells/PostTableViewCell.swift
+++ b/Examples/SpotsFeed/SpotsFeed/Cells/PostTableViewCell.swift
@@ -16,13 +16,13 @@ public protocol PostInformationDelegate: class {
   func mediaDidTap(postID: Int, kind: Media.Kind, index: Int)
 }
 
-public class PostTableViewCell: WallTableViewCell, Itemble {
+public class PostTableViewCell: WallTableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 44)
 
   public static let reusableIdentifier = "PostTableViewCell"
 
-  public class func height(item: ListItem) -> CGFloat {
+  public class func height(item: ViewModel) -> CGFloat {
     let post = item.post
     let postText = post.text as NSString
     let textFrame = postText.boundingRectWithSize(CGSize(width: UIScreen.mainScreen().bounds.width - 40,
@@ -119,7 +119,7 @@ public class PostTableViewCell: WallTableViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func setupViews(item: ListItem) -> CGFloat {
+  public func setupViews(item: ViewModel) -> CGFloat {
     let post = item.post
     var imageHeight: CGFloat = 0
     var imageTop: CGFloat = 50
@@ -160,7 +160,7 @@ public class PostTableViewCell: WallTableViewCell, Itemble {
     return bottomSeparator.frame.origin.y
   }
 
-  public func configure(inout item: ListItem) {
+  public func configure(inout item: ViewModel) {
     item.size.width = contentView.frame.width
     item.size.height = setupViews(item)
     item.size.height = ceil(PostTableViewCell.height(item))

--- a/Examples/SpotsFeed/SpotsFeed/FeedController.swift
+++ b/Examples/SpotsFeed/SpotsFeed/FeedController.swift
@@ -13,9 +13,9 @@ public class FeedController: SpotsController, SpotsDelegate {
     super.viewDidLoad()
   }
 
-  public func spotDidSelectItem(spot: Spotable, item: ListItem) { }
+  public func spotDidSelectItem(spot: Spotable, item: ViewModel) { }
 
-  public static func generateItem(index: Int, kind: String = "feed") -> ListItem {
+  public static func generateItem(index: Int, kind: String = "feed") -> ViewModel {
     let sencenceCount = Int(arc4random_uniform(8) + 1)
     let subtitle = faker.lorem.sentences(amount: sencenceCount) + " " + faker.internet.url()
 
@@ -25,7 +25,7 @@ public class FeedController: SpotsController, SpotsDelegate {
       mediaStrings.append("http://lorempixel.com/250/250/?type=attachment&id=\(index)\(x)")
     }
 
-    let item = ListItem(title: faker.name.name(),
+    let item = ViewModel(title: faker.name.name(),
       subtitle: subtitle,
       kind: kind,
       image: "http://lorempixel.com/75/75?type=avatar&id=\(index)",
@@ -34,8 +34,8 @@ public class FeedController: SpotsController, SpotsDelegate {
     return item
   }
 
-  public static func generateItems(from: Int, to: Int, kind: String = "feed") -> [ListItem] {
-    var items = [ListItem]()
+  public static func generateItems(from: Int, to: Int, kind: String = "feed") -> [ViewModel] {
+    var items = [ViewModel]()
     for i in from...from+to {
       autoreleasepool({
         items.append(generateItem(i))

--- a/Examples/SpotsFeed/SpotsFeed/ListItem+Post.swift
+++ b/Examples/SpotsFeed/SpotsFeed/ListItem+Post.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Spots
 
-extension ListItem {
+extension ViewModel {
 
   var post: Post {
     get {

--- a/Playgrounds/Playground-iOS.playground/Contents.swift
+++ b/Playgrounds/Playground-iOS.playground/Contents.swift
@@ -4,12 +4,12 @@ import UIKit
 import Spots
 
 let myContacts = Component(title: "My contacts", items: [
-  ListItem(title: "John Hyperseed", subtitle: "Build server"),
-  ListItem(title: "Vadym Markov", subtitle: "iOS Developer"),
-  ListItem(title: "Ramon Gilabert Llop", subtitle: "iOS Developer"),
-  ListItem(title: "Khoa Pham", subtitle: "iOS Developer"),
-  ListItem(title: "Christoffer Winterkvist", subtitle: "iOS Developer")
+  ViewModel(title: "John Hyperseed", subtitle: "Build server"),
+  ViewModel(title: "Vadym Markov", subtitle: "iOS Developer"),
+  ViewModel(title: "Ramon Gilabert Llop", subtitle: "iOS Developer"),
+  ViewModel(title: "Khoa Pham", subtitle: "iOS Developer"),
+  ViewModel(title: "Christoffer Winterkvist", subtitle: "iOS Developer")
   ])
 let listSpot = ListSpot(component: myContacts)
 let controller = SpotsController(spots: [listSpot])
-controller.view
+controller.

--- a/Playgrounds/Playground-iOS.playground/timeline.xctimeline
+++ b/Playgrounds/Playground-iOS.playground/timeline.xctimeline
@@ -3,13 +3,13 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=583&amp;EndingColumnNumber=16&amp;EndingLineNumber=14&amp;StartingColumnNumber=1&amp;StartingLineNumber=13&amp;Timestamp=474238579.00413"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=588&amp;EndingColumnNumber=16&amp;EndingLineNumber=14&amp;StartingColumnNumber=1&amp;StartingLineNumber=13&amp;Timestamp=475578935.471828"
          lockedSize = "{357, 436}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=569&amp;EndingColumnNumber=16&amp;EndingLineNumber=14&amp;StartingColumnNumber=1&amp;StartingLineNumber=14&amp;Timestamp=474238579.004297"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=574&amp;EndingColumnNumber=16&amp;EndingLineNumber=14&amp;StartingColumnNumber=1&amp;StartingLineNumber=14&amp;Timestamp=475578935.472296"
          lockedSize = "{312, 352}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the public API.
 * [JSON structure](#json-structure)
 * [Models](#models)
 * [Component](#component)
-* [ListItem](#listitem)
+* [ViewModel](#viewmodel)
 * [Installation](#installation)
 * [Dependencies](#dependencies)
 * [Author](#author)
@@ -45,7 +45,7 @@ the public API.
 - Features both infinity scrolling and pull to refresh, all you have to do is to
 setup delegates that conform to the public protocols on `SpotsController`.
 - No need to implement your own data source, every `Spotable` object has their
-own set of `ListItem`’s.
+own set of `ViewModel`’s.
 which is maintained internally and is there at your disposable if you decide to
 make changes to them.
 - Easy configuration of `UICollectionView`’s, `UITableView`'s and any custom spot
@@ -76,11 +76,11 @@ The JSON data will be parsed into view model data and your view controller is re
 ### Programmatic approach
 ```swift
 let myContacts = Component(title: "My contacts", items: [
-  ListItem(title: "John Hyperseed"),
-  ListItem(title: "Vadym Markov"),
-  ListItem(title: "Ramon Gilabert Llop"),
-  ListItem(title: "Khoa Pham"),
-  ListItem(title: "Christoffer Winterkvist")
+  ViewModel(title: "John Hyperseed"),
+  ViewModel(title: "Vadym Markov"),
+  ViewModel(title: "Ramon Gilabert Llop"),
+  ViewModel(title: "Khoa Pham"),
+  ViewModel(title: "Christoffer Winterkvist")
 ])
 let listSpot = ListSpot(component: myContacts)
 let controller = SpotsController(spots: [listSpot])
@@ -97,7 +97,7 @@ The `SpotsController` inherits from `UIViewController` but it sports some core f
 
 ```swift
 public protocol SpotsDelegate: class {
-func spotDidSelectItem(spot: Spotable, item: ListItem)
+  func spotDidSelectItem(spot: Spotable, item: ViewModel)
 }
 ```
 
@@ -107,7 +107,7 @@ func spotDidSelectItem(spot: Spotable, item: ListItem)
 
 ```swift
 public protocol SpotsRefreshDelegate: class {
-func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
+  func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
 }
 ```
 
@@ -117,7 +117,7 @@ func spotsDidReload(refreshControl: UIRefreshControl, completion: (() -> Void)?)
 
 ```swift
 public protocol SpotsScrollDelegate: class {
-func spotDidReachEnd(completion: (() -> Void)?)
+  func spotDidReachEnd(completion: (() -> Void)?)
 }
 ```
 
@@ -127,7 +127,7 @@ func spotDidReachEnd(completion: (() -> Void)?)
 
 ```swift
 public protocol SpotsCarouselScrollDelegate: class {
-func spotDidEndScrolling(spot: Spotable, item: ListItem)
+  func spotDidEndScrolling(spot: Spotable, item: ViewModel)
 }
 ```
 
@@ -137,56 +137,65 @@ func spotDidEndScrolling(spot: Spotable, item: ListItem)
 
 ```json
 {
-"components" : [
-{
-"title"    : "Hyper iOS",
-"type"     : "list",
-"span"     : "1",
-"items" : [
-{
-"title"    : "John Hyperseed",
-"subtitle" : "Build server",
-"image"    : "{image url}",
-"type"     : "profile",
-"action"   : "profile:1",
-"meta"     : {"nationality" : "Apple"}
-},
-{
-"title"    : "Vadym Markov",
-"subtitle" : "iOS Developer",
-"image"    : "{image url}",
-"type"     : "profile",
-"action"   : "profile:2",
-"meta"     : {"nationality" : "Ukrainian"}
-},
-{
-"title"    : "Ramon Gilabert Llop",
-"subtitle" : "iOS Developer",
-"image"    : "{image url}",
-"type"     : "profile",
-"action"   : "profile:3",
-"meta"     : {"nationality" : "Catalan"}
-},
-{
-"title"    : "Khoa Pham",
-"subtitle" : "iOS Developer",
-"image"    : "{image url}",
-"type"     : "profile",
-"action"   : "profile:4",
-"meta"     : {"nationality" : "Vietnamese"}
-},
-{
-"title"    : "Christoffer Winterkvist",
-"subtitle" : "iOS Developer",
-"image"    : "{image url}",
-"type"     : "profile",
-"action"   : "profile:5",
-"meta"     : {"nationality" : "Swedish"}
-}
-],
-"meta" : []
-}
-]
+   "components":[
+      {
+         "title":"Hyper iOS",
+         "type":"list",
+         "span":"1",
+         "items":[
+            {
+               "title":"John Hyperseed",
+               "subtitle":"Build server",
+               "image":"{image url}",
+               "type":"profile",
+               "action":"profile:1",
+               "meta":{
+                  "nationality":"Apple"
+               }
+            },
+            {
+               "title":"Vadym Markov",
+               "subtitle":"iOS Developer",
+               "image":"{image url}",
+               "type":"profile",
+               "action":"profile:2",
+               "meta":{
+                  "nationality":"Ukrainian"
+               }
+            },
+            {
+               "title":"Ramon Gilabert Llop",
+               "subtitle":"iOS Developer",
+               "image":"{image url}",
+               "type":"profile",
+               "action":"profile:3",
+               "meta":{
+                  "nationality":"Catalan"
+               }
+            },
+            {
+               "title":"Khoa Pham",
+               "subtitle":"iOS Developer",
+               "image":"{image url}",
+               "type":"profile",
+               "action":"profile:4",
+               "meta":{
+                  "nationality":"Vietnamese"
+               }
+            },
+            {
+               "title":"Christoffer Winterkvist",
+               "subtitle":"iOS Developer",
+               "image":"{image url}",
+               "type":"profile",
+               "action":"profile:5",
+               "meta":{
+                  "nationality":"Swedish"
+               }
+            }
+         ]
+      }
+   ]
 }
 ```
 
@@ -195,14 +204,14 @@ func spotDidEndScrolling(spot: Spotable, item: ListItem)
 ### Component
 
 ```swift
-public struct Component: Mappable {
-public var index = 0
-public var title = ""
-public var kind = ""
-public var span: CGFloat = 0
-public var items = [ListItem]()
-public var size: CGSize?
-public var meta = [String : String]()
+  public struct Component: Mappable {
+  public var index = 0
+  public var title = ""
+  public var kind = ""
+  public var span: CGFloat = 0
+  public var items = [ViewModel]()
+  public var size: CGSize?
+  public var meta = [String : String]()
 }
 ```
 
@@ -219,18 +228,18 @@ Calculated value based on the amount of items and their combined heights.
 - **.meta**
 Custom data that you are free to use as you like in your implementation.
 
-### ListItem
+### ViewModel
 
 ```swift
-public struct ListItem: Mappable {
-public var index = 0
-public var title = ""
-public var subtitle = ""
-public var image = ""
-public var kind = ""
-public var action: String?
-public var size = CGSize(width: 0, height: 0)
-public var meta = [String : AnyObject]()
+  public struct ViewModel: Mappable {
+  public var index = 0
+  public var title = ""
+  public var subtitle = ""
+  public var image = ""
+  public var kind = ""
+  public var action: String?
+  public var size = CGSize(width: 0, height: 0)
+  public var meta = [String : AnyObject]()
 }
 ```
 
@@ -266,7 +275,7 @@ pod 'Spots'
 - **[Sugar](https://github.com/hyperoslo/Sugar)**
 To sweeten the implementation.
 - **[Tailor](https://github.com/zenangst/Tailor)**
-To seamlessly map JSON to both `Component` and `ListItem`.
+To seamlessly map JSON to both `Component` and `ViewModel`.
 - **[Imaginary](https://github.com/hyperoslo/Imaginary)**
 To offer a solid and easy-to-use solution for loading remote images in both core and custom views.
 

--- a/Sources/Shared/Library/Itemble.swift
+++ b/Sources/Shared/Library/Itemble.swift
@@ -4,8 +4,8 @@
   import Foundation
 #endif
 
-public protocol Itemble: class {
+public protocol ViewConfigurable: class {
   var size: CGSize { get set }
 
-  func configure(inout item: ListItem)
+  func configure(inout item: ViewModel)
 }

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -12,7 +12,7 @@ public struct Component: Mappable {
   public var title = ""
   public var kind = ""
   public var span: CGFloat = 0
-  public var items = [ListItem]()
+  public var items = [ViewModel]()
   public var size: CGSize?
   public var meta = [String : String]()
 
@@ -24,7 +24,7 @@ public struct Component: Mappable {
     meta  <- map.property("meta")
   }
 
-  public init(title: String = "", kind: String = "", span: CGFloat = 0, items: [ListItem] = [], meta: [String : String] = [:]) {
+  public init(title: String = "", kind: String = "", span: CGFloat = 0, items: [ViewModel] = [], meta: [String : String] = [:]) {
     self.title = title
     self.kind = kind
     self.span = span

--- a/Sources/Shared/Models/ListItem.swift
+++ b/Sources/Shared/Models/ListItem.swift
@@ -7,7 +7,7 @@
 import Tailor
 import Sugar
 
-public struct ListItem: Mappable {
+public struct ViewModel: Mappable {
   public var index = 0
   public var title = ""
   public var subtitle = ""
@@ -42,7 +42,7 @@ public struct ListItem: Mappable {
   }
 }
 
-public func ==(lhs: [ListItem], rhs: [ListItem]) -> Bool {
+public func ==(lhs: [ViewModel], rhs: [ViewModel]) -> Bool {
   var equal = lhs.count == rhs.count
 
   if !equal { return false }
@@ -54,7 +54,7 @@ public func ==(lhs: [ListItem], rhs: [ListItem]) -> Bool {
   return equal
 }
 
-public func ==(lhs: ListItem, rhs: ListItem) -> Bool {
+public func ==(lhs: ViewModel, rhs: ViewModel) -> Bool {
   let equal = lhs.title == rhs.title &&
     lhs.subtitle == rhs.subtitle &&
     lhs.image == rhs.image &&
@@ -64,7 +64,7 @@ public func ==(lhs: ListItem, rhs: ListItem) -> Bool {
   return equal
 }
 
-public func ===(lhs: ListItem, rhs: ListItem) -> Bool {
+public func ===(lhs: ViewModel, rhs: ViewModel) -> Bool {
   let equal = lhs.title == rhs.title &&
     lhs.subtitle == rhs.subtitle &&
     lhs.image == rhs.image &&
@@ -75,6 +75,6 @@ public func ===(lhs: ListItem, rhs: ListItem) -> Bool {
   return equal
 }
 
-public func !=(lhs: ListItem, rhs: ListItem) -> Bool {
+public func !=(lhs: ViewModel, rhs: ViewModel) -> Bool {
   return !(lhs == rhs)
 }

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -149,27 +149,27 @@ extension SpotsController {
     }
   }
 
-  public func append(item: ListItem, spotIndex: Int = 0, completion: (() -> Void)? = nil) {
+  public func append(item: ViewModel, spotIndex: Int = 0, completion: (() -> Void)? = nil) {
     spot(spotIndex)?.append(item) { completion?() }
     spot(spotIndex)?.refreshIndexes()
   }
 
-  public func append(items: [ListItem], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
+  public func append(items: [ViewModel], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
     spot(spotIndex)?.append(items) { completion?() }
     spot(spotIndex)?.refreshIndexes()
   }
 
-  public func prepend(items: [ListItem], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
+  public func prepend(items: [ViewModel], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
     spot(spotIndex)?.prepend(items)  { completion?() }
     spot(spotIndex)?.refreshIndexes()
   }
 
-  public func insert(item: ListItem, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
+  public func insert(item: ViewModel, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
     spot(spotIndex)?.insert(item, index: index)  { completion?() }
     spot(spotIndex)?.refreshIndexes()
   }
 
-  public func update(item: ListItem, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
+  public func update(item: ViewModel, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
     spot(spotIndex)?.update(item, index: index)  { completion?() }
     spot(spotIndex)?.refreshIndexes()
   }
@@ -194,7 +194,7 @@ extension SpotsController {
     }
   }
 
-  public func scrollTo(spotIndex index: Int = 0, @noescape includeElement: (ListItem) -> Bool) {
+  public func scrollTo(spotIndex index: Int = 0, @noescape includeElement: (ViewModel) -> Bool) {
     guard let itemY = spot(index)?.scrollTo(includeElement) else { return }
 
     if spot(index)?.spotHeight() > spotsScrollView.frame.height - spotsScrollView.contentInset.bottom {

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -19,7 +19,7 @@ public extension Spotable where Self : Gridable {
     prepareSpot(self)
   }
 
-  public func append(item: ListItem, completion: (() -> Void)? = nil) {
+  public func append(item: ViewModel, completion: (() -> Void)? = nil) {
     var indexes = [Int]()
     let count = component.items.count
 
@@ -40,7 +40,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func append(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func append(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexes = [Int]()
     let count = component.items.count
 
@@ -61,7 +61,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func insert(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
+  public func insert(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
     component.items.insert(item, atIndex: index)
     var indexes = [Int]()
     let count = component.items.count
@@ -80,7 +80,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func prepend(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func prepend(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexes = [Int]()
     let count = component.items.count
 
@@ -101,7 +101,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func delete(item: ListItem, completion: (() -> Void)? = nil) {
+  public func delete(item: ViewModel, completion: (() -> Void)? = nil) {
     guard let index = component.items.indexOf({ $0 == item})
       else { completion?(); return }
 
@@ -115,7 +115,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func delete(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func delete(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexes = [Int]()
     let count = component.items.count
 
@@ -144,7 +144,7 @@ public extension Spotable where Self : Gridable {
     }
   }
 
-  public func update(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
+  public func update(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
     items[index] = item
 
     let cellClass = self.dynamicType.views[item.kind] ?? self.dynamicType.defaultView
@@ -153,7 +153,7 @@ public extension Spotable where Self : Gridable {
       : component.kind
 
     collectionView.registerClass(cellClass, forCellWithReuseIdentifier: reuseIdentifier)
-    if let cell = cellClass.init() as? Itemble {
+    if let cell = cellClass.init() as? ViewConfigurable {
       component.items[index].index = index
       cell.configure(&component.items[index])
     }
@@ -186,7 +186,7 @@ public extension Spotable where Self : Gridable {
       if cached == nil { cached = componentClass.init() }
 
       component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
-      (cached as? Itemble)?.configure(&component.items[index])
+      (cached as? ViewConfigurable)?.configure(&component.items[index])
     }
     cached = nil
   }
@@ -195,7 +195,7 @@ public extension Spotable where Self : Gridable {
     let items = component.items
     for (index, item) in items.enumerate() {
       let cellClass = self.dynamicType.views[item.kind] ?? self.dynamicType.defaultView
-      if let cell = cellClass.init() as? Itemble {
+      if let cell = cellClass.init() as? ViewConfigurable {
         component.items[index].index = index
         cell.configure(&component.items[index])
       }

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -29,7 +29,7 @@ public extension Spotable where Self : Listable {
     cached = nil
   }
 
-  func prepareItem<T: Spotable>(item: ListItem, index: Int, spot: T, inout cached: UIView?) {
+  func prepareItem<T: Spotable>(item: ViewModel, index: Int, spot: T, inout cached: UIView?) {
     let reuseIdentifer = item.kind.isEmpty ? component.kind : item.kind
     let componentClass = T.views[reuseIdentifer] ?? T.defaultView
 
@@ -38,10 +38,10 @@ public extension Spotable where Self : Listable {
     if cached?.isKindOfClass(componentClass) == false { cached = nil }
     if cached == nil { cached = componentClass.init() }
 
-    (cached as? Itemble)?.configure(&component.items[index])
+    (cached as? ViewConfigurable)?.configure(&component.items[index])
   }
 
-  public func append(item: ListItem, completion: (() -> Void)? = nil) {
+  public func append(item: ViewModel, completion: (() -> Void)? = nil) {
     let count = component.items.count
     component.items.append(item)
 
@@ -56,7 +56,7 @@ public extension Spotable where Self : Listable {
     cached = nil
   }
 
-  public func append(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func append(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexes = [Int]()
     let count = component.items.count
 
@@ -76,7 +76,7 @@ public extension Spotable where Self : Listable {
     }
   }
 
-  public func insert(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
+  public func insert(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
     component.items.insert(item, atIndex: index)
 
     dispatch { [weak self] in
@@ -86,7 +86,7 @@ public extension Spotable where Self : Listable {
     }
   }
 
-  public func prepend(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func prepend(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexes = [Int]()
 
     component.items.insertContentsOf(items, at: 0)
@@ -102,7 +102,7 @@ public extension Spotable where Self : Listable {
     }
   }
 
-  public func delete(item: ListItem, completion: (() -> Void)? = nil) {
+  public func delete(item: ViewModel, completion: (() -> Void)? = nil) {
     guard let index = component.items.indexOf({ $0 == item})
       else { completion?(); return }
 
@@ -115,7 +115,7 @@ public extension Spotable where Self : Listable {
     }
   }
 
-  public func delete(items: [ListItem], completion: (() -> Void)? = nil) {
+  public func delete(items: [ViewModel], completion: (() -> Void)? = nil) {
     var indexPaths = [Int]()
     let count = component.items.count
 
@@ -149,7 +149,7 @@ public extension Spotable where Self : Listable {
     }
   }
 
-  public func update(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
+  public func update(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
     items[index] = item
 
     let cellClass = self.dynamicType.views[item.kind] ?? self.dynamicType.defaultView
@@ -158,7 +158,7 @@ public extension Spotable where Self : Listable {
       : component.kind
 
     tableView.registerClass(cellClass, forCellReuseIdentifier: reuseIdentifier)
-    if let cell = cellClass.init() as? Itemble {
+    if let cell = cellClass.init() as? ViewConfigurable {
       component.items[index].index = index
       cell.configure(&component.items[index])
     }
@@ -177,7 +177,7 @@ public extension Spotable where Self : Listable {
         : component.kind
 
       tableView.registerClass(cellClass, forCellReuseIdentifier: reuseIdentifier)
-      if let cell = cellClass.init() as? Itemble {
+      if let cell = cellClass.init() as? ViewConfigurable {
         component.items[index].index = index
         cell.configure(&component.items[index])
       }
@@ -198,7 +198,7 @@ public extension Spotable where Self : Listable {
     tableView.layoutIfNeeded()
   }
 
-  public func scrollTo(@noescape includeElement: (ListItem) -> Bool) -> CGFloat {
+  public func scrollTo(@noescape includeElement: (ViewModel) -> Bool) -> CGFloat {
     guard let item = items.filter(includeElement).first else { return 0.0 }
 
     let height = component.items[0...item.index].reduce(0, combine: { $0 + $1.size.height })

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -13,23 +13,23 @@ public protocol Spotable: class {
   init(component: Component)
 
   func setup(size: CGSize)
-  func append(item: ListItem, completion: (() -> Void)?)
-  func append(items: [ListItem], completion: (() -> Void)?)
-  func prepend(items: [ListItem], completion: (() -> Void)?)
-  func insert(item: ListItem, index: Int, completion: (() -> Void)?)
-  func update(item: ListItem, index: Int, completion: (() -> Void)?)
+  func append(item: ViewModel, completion: (() -> Void)?)
+  func append(items: [ViewModel], completion: (() -> Void)?)
+  func prepend(items: [ViewModel], completion: (() -> Void)?)
+  func insert(item: ViewModel, index: Int, completion: (() -> Void)?)
+  func update(item: ViewModel, index: Int, completion: (() -> Void)?)
   func delete(index: Int, completion: (() -> Void)?)
   func delete(indexes: [Int], completion: (() -> Void)?)
   func reload(indexes: [Int], completion: (() -> Void)?)
   func render() -> UIScrollView
   func layout(size: CGSize)
   func prepare()
-  func scrollTo(@noescape includeElement: (ListItem) -> Bool) -> CGFloat
+  func scrollTo(@noescape includeElement: (ViewModel) -> Bool) -> CGFloat
 }
 
 public extension Spotable {
 
-  var items: [ListItem] {
+  var items: [ViewModel] {
     set(items) {
       component.items = items
     }
@@ -38,11 +38,11 @@ public extension Spotable {
     }
   }
 
-  public func item(index: Int) -> ListItem {
+  public func item(index: Int) -> ViewModel {
     return component.items[index]
   }
 
-  public func item(indexPath: NSIndexPath) -> ListItem {
+  public func item(indexPath: NSIndexPath) -> ViewModel {
     return component.items[indexPath.item]
   }
 
@@ -56,7 +56,7 @@ public extension Spotable {
     }
   }
 
-  public func scrollTo(@noescape includeElement: (ListItem) -> Bool) -> CGFloat {
+  public func scrollTo(@noescape includeElement: (ViewModel) -> Bool) -> CGFloat {
     return 0.0
   }
 }

--- a/Sources/iOS/Library/SpotsDelegates.swift
+++ b/Sources/iOS/Library/SpotsDelegates.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public protocol SpotsDelegate: class {
 
-  func spotDidSelectItem(spot: Spotable, item: ListItem)
+  func spotDidSelectItem(spot: Spotable, item: ViewModel)
 }
 
 public protocol SpotsRefreshDelegate: class {
@@ -17,5 +17,5 @@ public protocol SpotsScrollDelegate: class {
 
 public protocol SpotsCarouselScrollDelegate: class {
 
-  func spotDidEndScrolling(spot: Spotable, item: ListItem)
+  func spotDidEndScrolling(spot: Spotable, item: ViewModel)
 }

--- a/Sources/iOS/Library/Viewable.swift
+++ b/Sources/iOS/Library/Viewable.swift
@@ -27,8 +27,8 @@ public extension Spotable where Self : Viewable {
       if T.views.keys.contains($0.kind) {
         let viewClass = T.views[$0.kind] ?? T.defaultView
         let view = viewClass.init().then {
-          ($0 as? Itemble)?.configure(&component.items[index])
-          guard let size = ($0 as? Itemble)?.size else { return }
+          ($0 as? ViewConfigurable)?.configure(&component.items[index])
+          guard let size = ($0 as? ViewConfigurable)?.size else { return }
           $0.frame.size = size
         }
         scrollView.addSubview(view)
@@ -48,22 +48,22 @@ public extension Spotable where Self : Viewable {
     }
   }
 
-  func append(item: ListItem, completion: (() -> Void)? = nil) {
+  func append(item: ViewModel, completion: (() -> Void)? = nil) {
     let dynamic = self.dynamicType
 
     guard dynamic.views.keys.contains(item.kind) else { return }
 
     let viewClass = dynamic.views[item.kind] ?? dynamic.defaultView
     let view = viewClass.init().then {
-      ($0 as? Itemble)?.configure(&component.items[index])
-      guard let size = ($0 as? Itemble)?.size else { return }
+      ($0 as? ViewConfigurable)?.configure(&component.items[index])
+      guard let size = ($0 as? ViewConfigurable)?.size else { return }
       $0.frame.size = size
     }
     scrollView.addSubview(view)
     component.items.append(item)
   }
 
-  func append(items: [ListItem], completion: (() -> Void)? = nil) {
+  func append(items: [ViewModel], completion: (() -> Void)? = nil) {
     for item in items {
       let dynamic = self.dynamicType
 
@@ -71,8 +71,8 @@ public extension Spotable where Self : Viewable {
 
       let viewClass = dynamic.views[item.kind] ?? dynamic.defaultView
       let view = viewClass.init().then {
-        ($0 as? Itemble)?.configure(&component.items[index])
-        guard let size = ($0 as? Itemble)?.size else { return }
+        ($0 as? ViewConfigurable)?.configure(&component.items[index])
+        guard let size = ($0 as? ViewConfigurable)?.size else { return }
         $0.frame.size = size
       }
       scrollView.addSubview(view)
@@ -80,7 +80,7 @@ public extension Spotable where Self : Viewable {
     }
   }
 
-  func prepend(items: [ListItem], completion: (() -> Void)? = nil) {
+  func prepend(items: [ViewModel], completion: (() -> Void)? = nil) {
     component.items.insertContentsOf(items, at: 0)
 
     for item in items.reverse() {
@@ -90,8 +90,8 @@ public extension Spotable where Self : Viewable {
 
       let viewClass = dynamic.views[item.kind] ?? dynamic.defaultView
       let view = viewClass.init().then {
-        ($0 as? Itemble)?.configure(&component.items[index])
-        guard let size = ($0 as? Itemble)?.size else { return }
+        ($0 as? ViewConfigurable)?.configure(&component.items[index])
+        guard let size = ($0 as? ViewConfigurable)?.size else { return }
         $0.frame.size = size
       }
       scrollView.insertSubview(view, atIndex: 0)
@@ -99,23 +99,23 @@ public extension Spotable where Self : Viewable {
     }
   }
 
-  func insert(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
+  func insert(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
     let dynamic = self.dynamicType
 
     guard dynamic.views.keys.contains(item.kind) else { return }
 
     let viewClass = dynamic.views[item.kind] ?? dynamic.defaultView
     let view = viewClass.init().then {
-      ($0 as? Itemble)?.configure(&component.items[index])
-      guard let size = ($0 as? Itemble)?.size else { return }
+      ($0 as? ViewConfigurable)?.configure(&component.items[index])
+      guard let size = ($0 as? ViewConfigurable)?.size else { return }
       $0.frame.size = size
     }
     scrollView.insertSubview(view, atIndex: index)
     component.items.insert(item, atIndex: index)
   }
 
-  func update(item: ListItem, index: Int, completion: (() -> Void)? = nil) {
-    guard let view = scrollView.subviews[index] as? Itemble else { return }
+  func update(item: ViewModel, index: Int, completion: (() -> Void)? = nil) {
+    guard let view = scrollView.subviews[index] as? ViewConfigurable else { return }
 
     component.items[index] = item
     view.configure(&component.items[index])

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -7,7 +7,7 @@ public class CarouselSpot: NSObject, Spotable, Gridable {
   public static var configure: ((view: UICollectionView) -> Void)?
   public static var defaultView: UIView.Type = CarouselSpotCell.self
 
-  public var cachedViews = [String : Itemble]()
+  public var cachedViews = [String : ViewConfigurable]()
   public var component: Component
   public var index = 0
   public var paginate = false
@@ -88,7 +88,7 @@ extension CarouselSpot: UIScrollViewDelegate {
     }
   }
 
-  public func scrollTo(predicate: (ListItem) -> Bool) {
+  public func scrollTo(predicate: (ViewModel) -> Bool) {
     if let index = items.indexOf(predicate) {
       let pageWidth: CGFloat = collectionView.frame.width - layout.sectionInset.right
         + layout.sectionInset.left + layout.minimumLineSpacing
@@ -131,7 +131,7 @@ extension CarouselSpot: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath)
     cell.optimize()
 
-    if let grid = cell as? Itemble {
+    if let grid = cell as? ViewConfigurable {
       grid.configure(&component.items[indexPath.item])
       collectionView.collectionViewLayout.invalidateLayout()
     }

--- a/Sources/iOS/Spots/Carousel/CarouselSpotCell.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpotCell.swift
@@ -2,10 +2,10 @@ import UIKit
 import Imaginary
 import Sugar
 
-class CarouselSpotCell: UICollectionViewCell, Itemble {
+class CarouselSpotCell: UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 88, height: 88)
-  var item: ListItem?
+  var item: ViewModel?
 
   var label: UILabel = {
     let label = UILabel(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
@@ -30,7 +30,7 @@ class CarouselSpotCell: UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     if !item.image.isEmpty {
       imageView.setImage(NSURL(string: item.image))
     }

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -7,7 +7,7 @@ public class GridSpot: NSObject, Spotable, Gridable {
   public static var defaultView: UIView.Type = GridSpotCell.self
   public static var configure: ((view: UICollectionView) -> Void)?
 
-  public var cachedViews = [String : Itemble]()
+  public var cachedViews = [String : ViewConfigurable]()
   public var component: Component
   public var index = 0
 
@@ -75,7 +75,7 @@ extension GridSpot: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath)
     cell.optimize()
 
-    if let grid = cell as? Itemble {
+    if let grid = cell as? ViewConfigurable {
       grid.configure(&component.items[indexPath.item])
       collectionView.collectionViewLayout.invalidateLayout()
     }

--- a/Sources/iOS/Spots/Grid/GridSpotCell.swift
+++ b/Sources/iOS/Spots/Grid/GridSpotCell.swift
@@ -2,10 +2,10 @@ import UIKit
 import Imaginary
 import Sugar
 
-class GridSpotCell: UICollectionViewCell, Itemble {
+class GridSpotCell: UICollectionViewCell, ViewConfigurable {
 
   var size = CGSize(width: 88, height: 88)
-  var item: ListItem?
+  var item: ViewModel?
 
   var label: UILabel = {
     let label = UILabel(frame: CGRect(x: 0, y: 0,
@@ -33,7 +33,7 @@ class GridSpotCell: UICollectionViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func configure(inout item: ListItem) {
+  func configure(inout item: ViewModel) {
     if item.image != "" {
       let URL = NSURL(string: item.image)
       imageView.setImage(URL)

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -12,7 +12,7 @@ public class ListSpot: NSObject, Spotable, Listable {
   public var headerHeight: CGFloat = 44
   public var component: Component
   public var cachedHeaders = [String : Componentable]()
-  public var cachedCells = [String : Itemble]()
+  public var cachedCells = [String : ViewConfigurable]()
 
   public let itemHeight: CGFloat = 44
 
@@ -117,7 +117,7 @@ extension ListSpot: UITableViewDataSource {
     cell.optimize()
 
     if indexPath.item < component.items.count {
-      (cell as? Itemble)?.configure(&component.items[indexPath.item])
+      (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     }
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpotCell.swift
+++ b/Sources/iOS/Spots/List/ListSpotCell.swift
@@ -1,10 +1,10 @@
 import UIKit
 import Imaginary
 
-public class ListSpotCell: UITableViewCell, Itemble {
+public class ListSpotCell: UITableViewCell, ViewConfigurable {
 
   public var size = CGSize(width: 0, height: 44)
-  public var item: ListItem?
+  public var item: ViewModel?
 
   public override init(style: UITableViewCellStyle, reuseIdentifier: String!) {
     super.init(style: .Subtitle, reuseIdentifier: reuseIdentifier)
@@ -14,7 +14,7 @@ public class ListSpotCell: UITableViewCell, Itemble {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func configure(inout item: ListItem) {
+  public func configure(inout item: ViewModel) {
     if let action = item.action where !action.isEmpty {
       accessoryType = .DisclosureIndicator
     } else {

--- a/SpotsTests/Shared/TestComponent.swift
+++ b/SpotsTests/Shared/TestComponent.swift
@@ -28,7 +28,7 @@ class ComponentTests : XCTestCase {
       kind: json["type"] as! String,
       span: json["span"] as! CGFloat,
       meta: json["meta"] as! [String : String],
-      items: [ListItem(title: "item1")])
+      items: [ViewModel(title: "item1")])
       
     XCTAssertEqual(codeComponent.title, json["title"] as? String)
     XCTAssertEqual(codeComponent.kind,  json["type"] as? String)
@@ -49,7 +49,7 @@ class ComponentTests : XCTestCase {
       meta: json["meta"] as! [String : String])
     XCTAssertFalse(jsonComponent == codeComponent)
 
-    codeComponent.items.append(ListItem(title: "item2"))
+    codeComponent.items.append(ViewModel(title: "item2"))
     XCTAssertFalse(jsonComponent == codeComponent)
   }
 }

--- a/SpotsTests/Shared/TestListItem.swift
+++ b/SpotsTests/Shared/TestListItem.swift
@@ -3,12 +3,12 @@ import Foundation
 import XCTest
 import Fakery
 
-class ListItemTests : XCTestCase {
+class ViewModelTests : XCTestCase {
 
   static let faker = Faker()
   let json: [String : AnyObject] = [
-    "title" : ListItemTests.faker.name.firstName(),
-    "subtitle" : ListItemTests.faker.name.lastName(),
+    "title" : ViewModelTests.faker.name.firstName(),
+    "subtitle" : ViewModelTests.faker.name.lastName(),
     "image" : "smile",
     "type" : "person",
     "action" : "profile",
@@ -18,16 +18,16 @@ class ListItemTests : XCTestCase {
 
   func testInit() {
     // Test component created with JSON
-    let jsonListItem = ListItem(json)
-    XCTAssertEqual(jsonListItem.title,    json["title"] as? String)
-    XCTAssertEqual(jsonListItem.subtitle, json["subtitle"] as? String)
-    XCTAssertEqual(jsonListItem.image,    json["image"] as? String)
-    XCTAssertEqual(jsonListItem.kind,     json["type"] as? String)
-    XCTAssertEqual(jsonListItem.action,   json["action"] as? String)
-    XCTAssert(jsonListItem.meta.count == 1)
+    let jsonViewModel = ViewModel(json)
+    XCTAssertEqual(jsonViewModel.title,    json["title"] as? String)
+    XCTAssertEqual(jsonViewModel.subtitle, json["subtitle"] as? String)
+    XCTAssertEqual(jsonViewModel.image,    json["image"] as? String)
+    XCTAssertEqual(jsonViewModel.kind,     json["type"] as? String)
+    XCTAssertEqual(jsonViewModel.action,   json["action"] as? String)
+    XCTAssert(jsonViewModel.meta.count == 1)
 
     // Test component created programmatically
-    let codeListItem = ListItem(
+    let codeViewModel = ViewModel(
       title:    json["title"] as! String,
       subtitle: json["subtitle"] as! String,
       image:    json["image"] as! String,
@@ -40,16 +40,16 @@ class ListItemTests : XCTestCase {
       meta:     json["meta"] as! [String : AnyObject]
     )
 
-    XCTAssertEqual(codeListItem.title,    json["title"] as? String)
-    XCTAssertEqual(codeListItem.subtitle, json["subtitle"] as? String)
-    XCTAssertEqual(codeListItem.image,    json["image"] as? String)
-    XCTAssertEqual(codeListItem.kind,     json["type"] as? String)
-    XCTAssertEqual(codeListItem.action,   json["action"] as? String)
-    XCTAssert(codeListItem.meta.count == 1)
+    XCTAssertEqual(codeViewModel.title,    json["title"] as? String)
+    XCTAssertEqual(codeViewModel.subtitle, json["subtitle"] as? String)
+    XCTAssertEqual(codeViewModel.image,    json["image"] as? String)
+    XCTAssertEqual(codeViewModel.kind,     json["type"] as? String)
+    XCTAssertEqual(codeViewModel.action,   json["action"] as? String)
+    XCTAssert(codeViewModel.meta.count == 1)
 
     // Compare JSON and programmatically created component
-    XCTAssert(jsonListItem == codeListItem)
-    XCTAssertEqual(jsonListItem.meta["contactInfo"] as? String, codeListItem.meta["contactInfo"] as? String)
+    XCTAssert(jsonViewModel == codeViewModel)
+    XCTAssertEqual(jsonViewModel.meta["contactInfo"] as? String, codeViewModel.meta["contactInfo"] as? String)
   }
 
 }

--- a/SpotsTests/iOS/TestSpotsController.swift
+++ b/SpotsTests/iOS/TestSpotsController.swift
@@ -16,7 +16,7 @@ class SpotsControllerTests : XCTestCase {
     let component = Component(title: "Component")
     let listSpot = ListSpot(component: component)
     let spotController = SpotsController(spot: listSpot)
-    let items = [ListItem(title: "item1")]
+    let items = [ViewModel(title: "item1")]
 
     spotController.update { spot in
       spot.component.items = items
@@ -32,7 +32,7 @@ class SpotsControllerTests : XCTestCase {
 
     XCTAssert(spotController.spot.component.items.count == 0)
 
-    let item = ListItem(title: "title1", kind: "list")
+    let item = ViewModel(title: "title1", kind: "list")
     spotController.append(item, spotIndex: 0)
 
     XCTAssert(spotController.spot.component.items.count == 1)
@@ -42,7 +42,7 @@ class SpotsControllerTests : XCTestCase {
     }
 
     // Test appending item without kind
-    spotController.append(ListItem(title: "title2"), spotIndex: 0)
+    spotController.append(ViewModel(title: "title2"), spotIndex: 0)
 
     XCTAssert(spotController.spot.component.items.count == 2)
     XCTAssertEqual(spotController.spot.component.items[1].title, "title2")
@@ -54,8 +54,8 @@ class SpotsControllerTests : XCTestCase {
     let spotController = SpotsController(spot: listSpot)
 
     let items = [
-      ListItem(title: "title1", kind: "list"),
-      ListItem(title: "title2", kind: "list")
+      ViewModel(title: "title1", kind: "list"),
+      ViewModel(title: "title2", kind: "list")
     ]
     spotController.append(items, spotIndex: 0)
 
@@ -64,8 +64,8 @@ class SpotsControllerTests : XCTestCase {
 
     // Test appending items without kind
     spotController.append([
-      ListItem(title: "title3"),
-      ListItem(title: "title4")
+      ViewModel(title: "title3"),
+      ViewModel(title: "title4")
       ], spotIndex: 0)
 
     XCTAssertEqual(spotController.spot.component.items.count, 4)
@@ -79,8 +79,8 @@ class SpotsControllerTests : XCTestCase {
     let spotController = SpotsController(spot: listSpot)
 
     let items = [
-      ListItem(title: "title1", kind: "list"),
-      ListItem(title: "title2", kind: "list")
+      ViewModel(title: "title1", kind: "list"),
+      ViewModel(title: "title2", kind: "list")
     ]
     spotController.prepend(items, spotIndex: 0)
 
@@ -88,8 +88,8 @@ class SpotsControllerTests : XCTestCase {
     XCTAssert(spotController.spot.component.items == items)
 
     spotController.prepend([
-      ListItem(title: "title3"),
-      ListItem(title: "title4")
+      ViewModel(title: "title3"),
+      ViewModel(title: "title4")
       ], spotIndex: 0)
 
     XCTAssertEqual(spotController.spot.component.items[0].title, "title3")
@@ -98,8 +98,8 @@ class SpotsControllerTests : XCTestCase {
 
   func testDeleteItem() {
     let component = Component(title: "Component", kind: "list", items: [
-      ListItem(title: "title1", kind: "list"),
-      ListItem(title: "title2", kind: "list")
+      ViewModel(title: "title1", kind: "list"),
+      ViewModel(title: "title2", kind: "list")
       ])
     let initialListSpot = ListSpot(component: component)
 
@@ -123,14 +123,14 @@ class SpotsControllerTests : XCTestCase {
 
   func testComputedPropertiesOnSpotable() {
     let component = Component(title: "Component", kind: "list", items: [
-      ListItem(title: "title1", kind: "list"),
-      ListItem(title: "title2", kind: "list")
+      ViewModel(title: "title1", kind: "list"),
+      ViewModel(title: "title2", kind: "list")
       ])
     let spot = ListSpot(component: component)
 
     XCTAssert(spot.items == component.items)
 
-    let newItems = [ListItem(title: "title3", kind: "list")]
+    let newItems = [ViewModel(title: "title3", kind: "list")]
     spot.items = newItems
     XCTAssertFalse(spot.items == component.items)
     XCTAssert(spot.items == newItems)
@@ -139,14 +139,14 @@ class SpotsControllerTests : XCTestCase {
   func testFindAndFilterSpotWithClosure() {
     let listSpot = ListSpot(component: Component(title: "ListSpot"))
     let listSpot2 = ListSpot(component: Component(title: "ListSpot2"))
-    let gridSpot = GridSpot(component: Component(title: "GridSpot", items: [ListItem(title: "ListItem")]))
+    let gridSpot = GridSpot(component: Component(title: "GridSpot", items: [ViewModel(title: "ViewModel")]))
     let spotController = SpotsController(spots: [listSpot, listSpot2, gridSpot])
 
     XCTAssertNotNil(spotController.spot{ $1.component.title == "ListSpot" })
     XCTAssertNotNil(spotController.spot{ $1.component.title == "GridSpot" })
     XCTAssertNotNil(spotController.spot{ $1 is Listable })
     XCTAssertNotNil(spotController.spot{ $1 is Gridable })
-    XCTAssertNotNil(spotController.spot{ $1.items.filter{ $0.title == "ListItem" }.first != nil })
+    XCTAssertNotNil(spotController.spot{ $1.items.filter{ $0.title == "ViewModel" }.first != nil })
     XCTAssertEqual(spotController.spot{ $0.index == 0 }?.component.title, "ListSpot")
     XCTAssertEqual(spotController.spot{ $0.index == 1 }?.component.title, "ListSpot2")
     XCTAssertEqual(spotController.spot{ $0.index == 2 }?.component.title, "GridSpot")
@@ -156,7 +156,7 @@ class SpotsControllerTests : XCTestCase {
 
   func testJSONInitialiser() {
     let sourceController = SpotsController(spot: ListSpot().then {
-      $0.items = [ListItem(title: "First item")]
+      $0.items = [ViewModel(title: "First item")]
       })
     let jsonController = SpotsController([
       "components" : [


### PR DESCRIPTION
This PR changes the naming of two components.

`Itemble` is now renamed to `ViewConfigurable`, this is done because the protocol is actually on the view (in most cases a cell).

`ListItem` is renamed to `ViewModel` to better describe intent. `ListItem` was a bit confusing as it could appear inside of a `Gridable` spot, which could make people go 🤔

- [x] Update core foundation
- [x] Update README
- [x] Update playground
- [x] Update tests