### PR TITLE
Feature/meta functions

### DIFF
--- a/Sources/Shared/Models/ViewModel.swift
+++ b/Sources/Shared/Models/ViewModel.swift
@@ -46,6 +46,18 @@ public struct ViewModel: Mappable {
     self.meta = meta
     self.relations = relations
   }
+
+  public func meta<T>(key: String, _ defaultValue: T) -> T {
+    return meta[key] as? T ?? defaultValue
+  }
+
+  public func meta<T>(key: String, type: T.Type) -> T? {
+    return meta[key] as? T
+  }
+
+  public func relation(key: String, _ index: Int) -> ViewModel? {
+    return relations[key]?[index] ?? nil
+  }
 }
 
 public func ==(lhs: [ViewModel], rhs: [ViewModel]) -> Bool {

--- a/SpotsTests/Shared/TestViewModel.swift
+++ b/SpotsTests/Shared/TestViewModel.swift
@@ -62,16 +62,14 @@ class ViewModelTests : XCTestCase {
   }
 
   func testMetaWithType() {
-    let modelFoo = ViewModel(title: "foo",
-      meta: ["id" : 1])
+    let modelFoo = ViewModel(title: "foo", meta: ["id" : 1])
 
     XCTAssert(modelFoo.meta("id", type: Int.self) == 1)
     XCTAssertNil(modelFoo.meta("foo", type: String.self))
   }
 
   func testMetaWithDefaultValue() {
-    let modelFoo = ViewModel(title: "foo",
-      meta: ["id" : 1])
+    let modelFoo = ViewModel(title: "foo", meta: ["id" : 1])
 
     XCTAssert(modelFoo.meta("id", 0) == 1)
     XCTAssert(modelFoo.meta("foo", "bar") == "bar")

--- a/SpotsTests/Shared/TestViewModel.swift
+++ b/SpotsTests/Shared/TestViewModel.swift
@@ -59,4 +59,20 @@ class ViewModelTests : XCTestCase {
         ]])
     XCTAssert(modelFoo.relations["bar"]!.first!.title == "bar")
   }
+
+  func testMetaWithType() {
+    let modelFoo = ViewModel(title: "foo",
+      meta: ["id" : 1])
+
+    XCTAssert(modelFoo.meta("id", type: Int.self) == 1)
+    XCTAssertNil(modelFoo.meta("foo", type: String.self))
+  }
+
+  func testMetaWithDefaultValue() {
+    let modelFoo = ViewModel(title: "foo",
+      meta: ["id" : 1])
+
+    XCTAssert(modelFoo.meta("id", 0) == 1)
+    XCTAssert(modelFoo.meta("foo", "bar") == "bar")
+  }
 }

--- a/SpotsTests/Shared/TestViewModel.swift
+++ b/SpotsTests/Shared/TestViewModel.swift
@@ -58,6 +58,7 @@ class ViewModelTests : XCTestCase {
         ViewModel(title: "bar")
         ]])
     XCTAssert(modelFoo.relations["bar"]!.first!.title == "bar")
+    XCTAssert(modelFoo.relation("bar", 0)?.title == "bar")
   }
 
   func testMetaWithType() {


### PR DESCRIPTION
@zenangst 
This PR adds generic functions to get `meta` by key and type to avoid type casting.

```swift
// Type
let modelFoo = ViewModel(title: "foo", meta: ["id" : 1])
modelFoo.meta("id", type: Int.self) // 1
modelFoo.meta("foo", type: String.self) // nil

// Default value
modelFoo.meta("id", 0) // 1
modelFoo.meta("foo", "bar") // bar
```

Also there is a function to get a relation in a more simple way:

```swift
modelFoo.relation("bar", 0)
```