### PR TITLE
Improve For You controller in Apple News demo

### DIFF
--- a/Examples/Apple News/AppleNews/AppDelegate.swift
+++ b/Examples/Apple News/AppleNews/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarDelegate {
       searchController,
       savedController
     ]
-    tabBarController.selectedIndex = 2
+    tabBarController.selectedIndex = 0
 
     tabBarController.tabBar.translucent = true
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -5,7 +5,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   public static var configure: ((container: SpotsScrollView) -> Void)?
 
-  public private(set) var initialContentInset: UIEdgeInsets = UIEdgeInsetsZero
   public private(set) var spots: [Spotable]
 
   public var refreshPositions = [CGFloat]()


### PR DESCRIPTION
This PR improves the example of Apple News by adding a small animation when the title bar changes in the For You controller.

![animate-titlebar](https://cloud.githubusercontent.com/assets/57446/13160066/a7dc675c-d695-11e5-9e9c-e7a263afcd5c.gif)
