### PR TITLE
Restrict Gridable from modifying view model width if span is zero

### DIFF
--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -185,7 +185,9 @@ public extension Spotable where Self : Gridable {
       if cached?.isKindOfClass(componentClass) == false { cached = nil }
       if cached == nil { cached = componentClass.init() }
 
-      component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
+      if component.span > 0 {
+        component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
+      }
       (cached as? ViewConfigurable)?.configure(&component.items[index])
     }
     cached = nil


### PR DESCRIPTION
We had a bug where the `width` was set to `inf` on `ViewModel` that were added to a `Gridable` spot. This was caused by the caching method modifying the width of the `ViewModel` even if the `span` was set to zero on the `Component`.

This PR should fix that issue.