### PR TITLE
Set minimumLineSpacing for GridSpot

### DIFF
--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -34,11 +34,12 @@ public class GridSpot: NSObject, Spotable, Gridable {
     self.init(component: Component(title: title, kind: kind))
   }
 
-  public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0) {
+  public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
     self.init(component: component)
 
     layout.sectionInset = UIEdgeInsetsMake(top, left, bottom, right)
     layout.minimumInteritemSpacing = itemSpacing
+    layout.minimumLineSpacing = lineSpacing
   }
 }
 


### PR DESCRIPTION
Before, we always had a small offset at the bottom when using collection views, this PR fixes that by setting `minimumLineSpacing` on `UICollectionViewFlowLayout`.