### PR TITLE
Implement completion for spots reload

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -123,9 +123,19 @@ extension SpotsController {
     return spots.filter(includeElement)
   }
 
-  public func reload() {
+  public func reload(completion: (() -> Void)? = nil) {
+    var spotsLeft = spots.count
+
     dispatch { [weak self] in
-      self?.spots.forEach { $0.reload([]) {} }
+      self?.spots.forEach { spot in
+        spot.reload([]) {
+          spotsLeft--
+
+          if spotsLeft == 0 {
+            completion?()
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
@zenangst Sometimes it's useful. Kinda need to do `spotsScrollView.forceUpdate = true` when everything is reloaded.

```swift
reload {
  // Do your stuff
}
```