### PR TITLE
Force update after mutating data source

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -157,42 +157,66 @@ extension SpotsController {
   }
 
   public func append(item: ViewModel, spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.append(item) { completion?() }
+    spot(spotIndex, Spotable.self)?.append(item) {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func append(items: [ViewModel], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.append(items) { completion?() }
+    spot(spotIndex, Spotable.self)?.append(items) {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func prepend(items: [ViewModel], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.prepend(items)  { completion?() }
+    spot(spotIndex, Spotable.self)?.prepend(items)  {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func insert(item: ViewModel, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.insert(item, index: index)  { completion?() }
+    spot(spotIndex, Spotable.self)?.insert(item, index: index)  {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func update(item: ViewModel, index: Int = 0, spotIndex: Int, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.update(item, index: index)  { completion?() }
+    spot(spotIndex, Spotable.self)?.update(item, index: index)  {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func update(indexes indexes: [Int], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.reload(indexes) { completion?() }
+    spot(spotIndex, Spotable.self)?.reload(indexes) {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func delete(index: Int, spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.delete(index) { completion?() }
+    spot(spotIndex, Spotable.self)?.delete(index) {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 
   public func delete(indexes indexes: [Int], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.delete(indexes) { completion?() }
+    spot(spotIndex, Spotable.self)?.delete(indexes) {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+    }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
 


### PR DESCRIPTION
This PR should fix the issue when calling update in a SpotsController that has many spots and the contentOffset gets lost after the update. Calling force update after every mutating functions realigns the views like they appeared before the update.