### PR TITLE
Call forceUpdate in viewDidAppear

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -84,6 +84,8 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
 
+    spotsScrollView.forceUpdate = true
+
     if let tabBarController = self.tabBarController
       where tabBarController.tabBar.translucent {
         spotsScrollView.contentInset.bottom = tabBarController.tabBar.frame.height


### PR DESCRIPTION
If you have multiple spots inside of a `SpotsController` and you have that thing be a part of a tab bar, you could end up with a misaligned view. This PR fixes that issue by force updating the view alignment when the controller will appear on screen.

```swift
spotsScrollView.forceUpdate = true
```