### PR TITLE
Remove all references and dependencies on Imaginary

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "hyperoslo/Sugar"
-github "hyperoslo/Imaginary" "master"
 github "zenangst/Tailor"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,8 +1,6 @@
-github "hyperoslo/Cache" "5af9d7f80b5c39ec578c54874d5acda248d10831"
 github "Quick/Nimble" "v3.2.0"
 github "Quick/Quick" "v0.9.1"
 github "hyperoslo/Sugar" "1.0.10"
 github "SwiftyJSON/SwiftyJSON" "2.3.3"
 github "vadymmarkov/Fakery" "1.1.2"
-github "hyperoslo/Imaginary" "243448a070decf6d8fcdc503b14505a2951af680"
 github "zenangst/Tailor" "0.4.5"

--- a/Sources/iOS/Spots/Carousel/CarouselSpotCell.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpotCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Imaginary
 import Sugar
 
 class CarouselSpotCell: UICollectionViewCell, ViewConfigurable {
@@ -28,10 +27,7 @@ class CarouselSpotCell: UICollectionViewCell, ViewConfigurable {
   }
 
   func configure(inout item: ViewModel) {
-    if !item.image.isEmpty {
-      imageView.setImage(NSURL(string: item.image))
-    }
-
+    imageView.image = UIImage(named: item.image)
     imageView.frame = contentView.frame
     label.text = item.title
   }

--- a/Sources/iOS/Spots/Grid/GridSpotCell.swift
+++ b/Sources/iOS/Spots/Grid/GridSpotCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Imaginary
 import Sugar
 
 class GridSpotCell: UICollectionViewCell, ViewConfigurable {
@@ -29,11 +28,7 @@ class GridSpotCell: UICollectionViewCell, ViewConfigurable {
   }
 
   func configure(inout item: ViewModel) {
-    if item.image != "" {
-      let URL = NSURL(string: item.image)
-      imageView.setImage(URL)
-    }
-
+    imageView.image = UIImage(named: item.image)
     imageView.frame = contentView.frame
     label.text = item.title
   }

--- a/Sources/iOS/Spots/List/ListSpotCell.swift
+++ b/Sources/iOS/Spots/List/ListSpotCell.swift
@@ -1,5 +1,5 @@
 import UIKit
-import Imaginary
+import Sugar
 
 public class ListSpotCell: UITableViewCell, ViewConfigurable {
 
@@ -23,14 +23,7 @@ public class ListSpotCell: UITableViewCell, ViewConfigurable {
 
     detailTextLabel?.text = item.subtitle
     textLabel?.text = item.title
-
-    if !item.image.isEmpty {
-      if let url = NSURL(string: item.image) {
-        imageView?.setImage(url, placeholder: UIImage(named: "ImagePlaceholder"))
-      } else {
-        imageView?.image = UIImage(named: item.image)
-      }
-    }
+    imageView?.image = UIImage(named: item.image)
 
     item.size.height = item.size.height > 0.0 ? item.size.height : size.height
   }

--- a/Spots.podspec
+++ b/Spots.podspec
@@ -18,5 +18,4 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.dependency 'Sugar'
   s.dependency 'Tailor'
-  s.dependency 'Imaginary'
 end

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -46,9 +46,7 @@
 		D58478E71C440645006EBA49 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponent.swift */; };
 		D58478E81C440645006EBA49 /* TestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782C1C43FF34006EBA49 /* TestViewModel.swift */; };
 		D58478ED1C440726006EBA49 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
-		D58478EE1C440726006EBA49 /* Imaginary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478EA1C440726006EBA49 /* Imaginary.framework */; };
 		D58478EF1C440726006EBA49 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478EB1C440726006EBA49 /* Sugar.framework */; };
-		D58478F01C440726006EBA49 /* Cache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478EC1C440726006EBA49 /* Cache.framework */; };
 		D58478F21C44074C006EBA49 /* Sugar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478EB1C440726006EBA49 /* Sugar.framework */; };
 		D58478F51C44074C006EBA49 /* Fakery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F31C44074C006EBA49 /* Fakery.framework */; };
 		D58478F61C44074C006EBA49 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F41C44074C006EBA49 /* SwiftyJSON.framework */; };
@@ -134,9 +132,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D58478ED1C440726006EBA49 /* Tailor.framework in Frameworks */,
-				D58478EE1C440726006EBA49 /* Imaginary.framework in Frameworks */,
 				D58478EF1C440726006EBA49 /* Sugar.framework in Frameworks */,
-				D58478F01C440726006EBA49 /* Cache.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -576,9 +572,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Tailor.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Imaginary.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Sugar.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Cache.framework",
 			);
 			outputPaths = (
 			);


### PR DESCRIPTION
People should be free to use what ever image loading/caching they want. Supplying a default in a cell that is hardly even used feels a bit redundant, also, Imaginary is not released and is holding this release.

We might consider re-adding it again in the future but for the time being this feels like a good decision.