### PR TITLE
Allow more configuration on the cell

### DIFF
--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -9,6 +9,7 @@ public protocol Spotable: class {
 
   var index: Int { get set }
   var component: Component { get set }
+  var configureBlock: (ViewConfigurable -> Void)? { get set }
 
   init(component: Component)
 

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -9,7 +9,7 @@ public protocol Spotable: class {
 
   var index: Int { get set }
   var component: Component { get set }
-  var configureBlock: (ViewConfigurable -> Void)? { get set }
+  var configure: (ViewConfigurable -> Void)? { get set }
 
   init(component: Component)
 

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -135,8 +135,8 @@ extension CarouselSpot: UICollectionViewDataSource {
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     
-    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
-      configure(viewConfigurable)
+    if let configure = configure, view = cell as? ViewConfigurable {
+      configure(view)
     }
     
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -12,7 +12,7 @@ public class CarouselSpot: NSObject, Spotable, Gridable {
   public var index = 0
   public var paginate = false
   
-  public var configureBlock: (ViewConfigurable -> Void)?
+  public var configure: (ViewConfigurable -> Void)?
 
   public weak var carouselScrollDelegate: SpotsCarouselScrollDelegate?
   public weak var spotsDelegate: SpotsDelegate?
@@ -135,8 +135,8 @@ extension CarouselSpot: UICollectionViewDataSource {
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     
-    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
-      configureBlock(viewConfigurable)
+    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
+      configure(viewConfigurable)
     }
     
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -11,6 +11,8 @@ public class CarouselSpot: NSObject, Spotable, Gridable {
   public var component: Component
   public var index = 0
   public var paginate = false
+  
+  public var configureBlock: (ViewConfigurable -> Void)?
 
   public weak var carouselScrollDelegate: SpotsCarouselScrollDelegate?
   public weak var spotsDelegate: SpotsDelegate?
@@ -132,6 +134,11 @@ extension CarouselSpot: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
+    
+    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
+      configureBlock(viewConfigurable)
+    }
+    
     collectionView.collectionViewLayout.invalidateLayout()
 
     return cell

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -10,6 +10,8 @@ public class GridSpot: NSObject, Spotable, Gridable {
   public var cachedViews = [String : ViewConfigurable]()
   public var component: Component
   public var index = 0
+  
+  public var configureBlock: (ViewConfigurable -> Void)?
 
   public weak var spotsDelegate: SpotsDelegate?
 
@@ -76,6 +78,11 @@ extension GridSpot: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
+    
+    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
+      configureBlock(viewConfigurable)
+    }
+    
     collectionView.collectionViewLayout.invalidateLayout()
 
     return cell

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -10,8 +10,7 @@ public class GridSpot: NSObject, Spotable, Gridable {
   public var cachedViews = [String : ViewConfigurable]()
   public var component: Component
   public var index = 0
-  
-  public var configureBlock: (ViewConfigurable -> Void)?
+  public var configure: (ViewConfigurable -> Void)?
 
   public weak var spotsDelegate: SpotsDelegate?
 
@@ -79,8 +78,8 @@ extension GridSpot: UICollectionViewDataSource {
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     
-    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
-      configureBlock(viewConfigurable)
+    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
+      configure(viewConfigurable)
     }
     
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -78,8 +78,8 @@ extension GridSpot: UICollectionViewDataSource {
 
     (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     
-    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
-      configure(viewConfigurable)
+    if let configure = configure, view = cell as? ViewConfigurable {
+      configure(view)
     }
     
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -13,6 +13,8 @@ public class ListSpot: NSObject, Spotable, Listable {
   public var component: Component
   public var cachedHeaders = [String : Componentable]()
   public var cachedCells = [String : ViewConfigurable]()
+  
+  public var configureBlock: (UITableViewCell -> Void)?
 
   public let itemHeight: CGFloat = 44
 
@@ -121,6 +123,10 @@ extension ListSpot: UITableViewDataSource {
 
     if indexPath.item < component.items.count {
       (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
+    }
+    
+    if let configureBlock = configureBlock {
+      configureBlock(cell)
     }
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -124,8 +124,8 @@ extension ListSpot: UITableViewDataSource {
       (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     }
     
-    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
-      configure(viewConfigurable)
+    if let configure = configure, view = cell as? ViewConfigurable {
+      configure(view)
     }
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -13,8 +13,7 @@ public class ListSpot: NSObject, Spotable, Listable {
   public var component: Component
   public var cachedHeaders = [String : Componentable]()
   public var cachedCells = [String : ViewConfigurable]()
-  
-  public var configureBlock: (ViewConfigurable -> Void)?
+  public var configure: (ViewConfigurable -> Void)?
 
   public let itemHeight: CGFloat = 44
 
@@ -125,8 +124,8 @@ extension ListSpot: UITableViewDataSource {
       (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     }
     
-    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
-      configureBlock(viewConfigurable)
+    if let configure = configure, viewConfigurable = cell as? ViewConfigurable {
+      configure(viewConfigurable)
     }
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -14,7 +14,7 @@ public class ListSpot: NSObject, Spotable, Listable {
   public var cachedHeaders = [String : Componentable]()
   public var cachedCells = [String : ViewConfigurable]()
   
-  public var configureBlock: (UITableViewCell -> Void)?
+  public var configureBlock: (ViewConfigurable -> Void)?
 
   public let itemHeight: CGFloat = 44
 
@@ -125,8 +125,8 @@ extension ListSpot: UITableViewDataSource {
       (cell as? ViewConfigurable)?.configure(&component.items[indexPath.item])
     }
     
-    if let configureBlock = configureBlock {
-      configureBlock(cell)
+    if let configureBlock = configureBlock, viewConfigurable = cell as? ViewConfigurable {
+      configureBlock(viewConfigurable)
     }
 
     return cell

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -10,6 +10,8 @@ public class ViewSpot: NSObject, Spotable, Viewable {
   public weak var spotsDelegate: SpotsDelegate?
   public var component: Component
   public var index = 0
+  
+  public var configureBlock: (ViewConfigurable -> Void)?
 
   public lazy var scrollView = UIScrollView()
 

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -11,7 +11,7 @@ public class ViewSpot: NSObject, Spotable, Viewable {
   public var component: Component
   public var index = 0
   
-  public var configureBlock: (ViewConfigurable -> Void)?
+  public var configure: (ViewConfigurable -> Void)?
 
   public lazy var scrollView = UIScrollView()
 


### PR DESCRIPTION
I don't know if better ways exist. Sometimes we want to have more configuration over the cell, something that `viewModel` can't help, like setting delegate, ...

However, this may defeat the purpose of Spots ViewModel

```swift
public override func viewDidLoad() {
    super.viewDidLoad()
    
    if let spot = spots.first as? ListSpot {
      spot.configureBlock = { [weak self] cell in
        if let toggleCell = cell as? Toggle, weakSelf = self {
          toggleCell.delegate = weakSelf
        }
      }
    }
  }
```