### PR TITLE
Add fallback to cell size if view model height is 0

### DIFF
--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -134,7 +134,12 @@ extension CarouselSpot: UICollectionViewDataSource {
     let reuseIdentifier = item(indexPath).kind.isPresent ? item(indexPath).kind : component.kind
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
 
-    (cell as? SpotConfigurable)?.configure(&component.items[indexPath.item])
+    if let cell = cell as? SpotConfigurable {
+      cell.configure(&component.items[indexPath.item])
+      if component.items[indexPath.item].size.height == 0.0 {
+        component.items[indexPath.item].size = cell.size
+      }
+    }
 
     if let configure = configure, view = cell as? SpotConfigurable {
       configure(view)

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -76,12 +76,17 @@ extension GridSpot: UICollectionViewDataSource {
     let reuseIdentifier = item(indexPath).kind.isPresent ? item(indexPath).kind : component.kind
     let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
 
-    (cell as? SpotConfigurable)?.configure(&component.items[indexPath.item])
-    
+    if let cell = cell as? SpotConfigurable {
+      cell.configure(&component.items[indexPath.item])
+      if component.items[indexPath.item].size.height == 0.0 {
+        component.items[indexPath.item].size = cell.size
+      }
+    }
+
     if let configure = configure, view = cell as? SpotConfigurable {
       configure(view)
     }
-    
+
     collectionView.collectionViewLayout.invalidateLayout()
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -120,10 +120,13 @@ extension ListSpot: UITableViewDataSource {
       .dequeueReusableCellWithIdentifier(reuseIdentifier, forIndexPath: indexPath)
       .then { $0.optimize() }
 
-    if indexPath.item < component.items.count {
-      (cell as? SpotConfigurable)?.configure(&component.items[indexPath.item])
+    if let cell = cell as? SpotConfigurable where indexPath.item < component.items.count {
+      cell.configure(&component.items[indexPath.item])
+      if component.items[indexPath.item].size.height == 0.0 {
+        component.items[indexPath.item].size = cell.size
+      }
     }
-    
+
     if let configure = configure, view = cell as? SpotConfigurable {
       configure(view)
     }


### PR DESCRIPTION
With this PR, if you don't have dynamic height, you no longer need to specify the view model height, it would get that from the cell if the view model height is still zero when configure has ended.

This shouldn't break current implementations, it is more of a nice to have.

All credit and blame for this goes to @vadymmarkov :grin: 