### PR TITLE
Refactor internal protocols

### DIFF
--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.1.0):
+  - Spots (1.1.1):
     - Brick
     - Sugar
     - Tailor
@@ -67,7 +67,7 @@ SPEC CHECKSUMS:
   Fakery: a4121424cf731cacc04a5ff1735fcc6e3efc656d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
-  Spots: 7c45d341050453355e1bf75b9f9635c5e97f2820
+  Spots: f2d6167ff461682a15b5f4d4a509357dc80d17fb
   Sugar: ca8778ac9d076fba1366b889e6bc205f376465e4
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 7388a9bb2ae83db9e07d5940de08eb444efa15a8

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - Imaginary (0.1.0):
     - Cache
   - Keychain (1.0.0)
-  - Spots (1.1.0):
+  - Spots (1.1.1):
     - Brick
     - Sugar
     - Tailor
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
-  Spots: 7c45d341050453355e1bf75b9f9635c5e97f2820
+  Spots: f2d6167ff461682a15b5f4d4a509357dc80d17fb
   Sugar: ca8778ac9d076fba1366b889e6bc205f376465e4
   Tailor: 7388a9bb2ae83db9e07d5940de08eb444efa15a8
   Whisper: 18b574de21a089c0d664b115f26e0d9ccbbadbab

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.1.0):
+  - Spots (1.1.1):
     - Brick
     - Sugar
     - Tailor
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
-  Spots: 7c45d341050453355e1bf75b9f9635c5e97f2820
+  Spots: f2d6167ff461682a15b5f4d4a509357dc80d17fb
   Sugar: ca8778ac9d076fba1366b889e6bc205f376465e4
   Tailor: 7388a9bb2ae83db9e07d5940de08eb444efa15a8
 

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.1.0):
+  - Spots (1.1.1):
     - Brick
     - Sugar
     - Tailor
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
-  Spots: 7c45d341050453355e1bf75b9f9635c5e97f2820
+  Spots: f2d6167ff461682a15b5f4d4a509357dc80d17fb
   Sugar: ca8778ac9d076fba1366b889e6bc205f376465e4
   Tailor: 7388a9bb2ae83db9e07d5940de08eb444efa15a8
 

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - SwiftyJSON
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.1.0):
+  - Spots (1.1.1):
     - Brick
     - Sugar
     - Tailor
@@ -47,7 +47,7 @@ SPEC CHECKSUMS:
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Fakery: a4121424cf731cacc04a5ff1735fcc6e3efc656d
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
-  Spots: 7c45d341050453355e1bf75b9f9635c5e97f2820
+  Spots: f2d6167ff461682a15b5f4d4a509357dc80d17fb
   Sugar: ca8778ac9d076fba1366b889e6bc205f376465e4
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 7388a9bb2ae83db9e07d5940de08eb444efa15a8

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -10,7 +10,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   public private(set) var spots: [Spotable]
 
   public var refreshPositions = [CGFloat]()
-
   public var refreshing = false
 
   weak public var spotsDelegate: SpotsDelegate? {

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -17,7 +17,7 @@ public extension Spotable where Self : Gridable {
   }
 
   public func prepare() {
-    registerAndPrepare(self) { (classType, withIdentifier) in
+    registerAndPrepare { (classType, withIdentifier) in
       collectionView.registerClass(classType, forCellWithReuseIdentifier: withIdentifier)
     }
 

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -17,39 +17,19 @@ public extension Spotable where Self : Gridable {
   }
 
   public func prepare() {
-    prepareSpot(self)
-  }
-
-  /**
-   - Parameter spot: Spotable
-   */
-  private func prepareSpot<T: Spotable>(spot: T) {
-    if component.kind.isEmpty { component.kind = "grid" }
-
-    for (reuseIdentifier, classType) in T.views.storage {
-      collectionView.registerClass(classType, forCellWithReuseIdentifier: reuseIdentifier)
-    }
-
-    if !T.views.storage.keys.contains(component.kind) {
-      collectionView.registerClass(T.defaultView, forCellWithReuseIdentifier: component.kind)
+    registerAndPrepare(self) { (classType, withIdentifier) in
+      collectionView.registerClass(classType, forCellWithReuseIdentifier: withIdentifier)
     }
 
     var cached: UIView?
     for (index, item) in component.items.enumerate() {
-      let reuseIdentifer = item.kind.isPresent ? item.kind : component.kind
-      let componentClass = T.views.storage[reuseIdentifer] ?? T.defaultView
-
-      component.items[index].index = index
-
-      if cached?.isKindOfClass(componentClass) == false { cached = nil }
-      if cached == nil { cached = componentClass.init() }
+      cachedViewFor(item, cache: &cached)
 
       if component.span > 0 {
         component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
       }
       (cached as? SpotConfigurable)?.configure(&component.items[index])
     }
-    cached = nil
   }
 
   /**

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -29,7 +29,7 @@ public extension Spotable where Self : Listable {
       completion?()
     }
     var cached: UIView?
-    prepareItem(item, index: count, spot: self, cached: &cached)
+    prepareItem(item, index: count, cached: &cached)
   }
 
   /**
@@ -45,7 +45,7 @@ public extension Spotable where Self : Listable {
     var cached: UIView?
     items.enumerate().forEach {
       indexes.append(count + $0.index)
-      prepareItem($0.element, index: count + $0.index, spot: self, cached: &cached)
+      prepareItem($0.element, index: count + $0.index, cached: &cached)
     }
 
     dispatch { [weak self] in

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -11,7 +11,7 @@ public extension Spotable where Self : Listable {
   typealias Completion = (() -> Void)?
 
   public func prepare() {
-    registerAndPrepare(self) { (classType, withIdentifier) in
+    registerAndPrepare { (classType, withIdentifier) in
       tableView.registerClass(classType, forCellReuseIdentifier: withIdentifier)
     }
   }

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -9,29 +9,10 @@ public protocol Listable: Spotable {
 public extension Spotable where Self : Listable {
 
   typealias Completion = (() -> Void)?
+
   public func prepare() {
-    prepareSpot(self)
-  }
-
-  /**
-   - Parameter spot: Spotable
-   */
-  private func prepareSpot<T: Spotable>(spot: T) {
-    if component.kind.isEmpty { component.kind = "list" }
-
-    for (reuseIdentifier, classType) in T.views.storage {
-      tableView.registerClass(classType, forCellReuseIdentifier: reuseIdentifier)
-    }
-
-    if !T.views.storage.keys.contains(component.kind) {
-      tableView.registerClass(T.defaultView, forCellReuseIdentifier: component.kind)
-    }
-
-    var cached: UIView?
-    defer { cached = nil }
-
-    for (index, item) in component.items.enumerate() {
-      prepareItem(item, index: index, spot: self, cached: &cached)
+    registerAndPrepare(self) { (classType, withIdentifier) in
+      tableView.registerClass(classType, forCellReuseIdentifier: withIdentifier)
     }
   }
 
@@ -48,8 +29,6 @@ public extension Spotable where Self : Listable {
       completion?()
     }
     var cached: UIView?
-    defer { cached = nil }
-
     prepareItem(item, index: count, spot: self, cached: &cached)
   }
 
@@ -68,7 +47,6 @@ public extension Spotable where Self : Listable {
       indexes.append(count + $0.index)
       prepareItem($0.element, index: count + $0.index, spot: self, cached: &cached)
     }
-    cached = nil
 
     dispatch { [weak self] in
       self?.tableView.insert(indexes, animation: .None)

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -5,6 +5,7 @@ public protocol Spotable: class {
 
   static var views: ViewRegistry { get }
   static var defaultView: UIView.Type { get set }
+  static var defaultKind: String { get }
 
   weak var spotsDelegate: SpotsDelegate? { get set }
 

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -39,6 +39,7 @@ public extension Spotable {
 
   /**
    - Parameter spot: Spotable
+   - Parameter register: A closure containing class type and reuse identifer
    */
   func registerAndPrepare<T: Spotable>(spot: T, @noescape register: (classType: UIView.Type, withIdentifier: String) -> Void) {
     if component.kind.isEmpty { component.kind = spot.dynamicType.defaultKind }

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -54,7 +54,7 @@ public extension Spotable {
 
     var cached: UIView?
     component.items.enumerate().forEach {
-      prepareItem($1, index: $0, spot: self, cached: &cached)
+      prepareItem($1, index: $0, cached: &cached)
     }
   }
 
@@ -108,7 +108,7 @@ public extension Spotable {
    - Parameter spot: The spot that should be prepared
    - Parameter cached: An optional UIView, used to reduce the amount of different reusable views that should be prepared.
    */
-  public func prepareItem<T: Spotable>(item: ViewModel, index: Int, spot: T, inout cached: UIView?) {
+  public func prepareItem(item: ViewModel, index: Int, inout cached: UIView?) {
     cachedViewFor(item, cache: &cached)
 
     component.items[index].index = index

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -124,4 +124,12 @@ public extension Spotable {
       component.items[index].size.height = view.size.height
     }
   }
+
+  func cachedViewFor(item: ViewModel, inout cache: UIView?) {
+    let reuseIdentifer = item.kind.isPresent ? item.kind : component.kind
+    let componentClass = self.dynamicType.views.storage[reuseIdentifer] ?? self.dynamicType.defaultView
+
+    if cache?.isKindOfClass(componentClass) == false { cache = nil }
+    if cache == nil { cache = componentClass.init() }
+  }
 }

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -37,6 +37,26 @@ public extension Spotable {
   }
 
   /**
+   - Parameter spot: Spotable
+   */
+  func registerAndPrepare<T: Spotable>(spot: T, @noescape register: (classType: UIView.Type, withIdentifier: String) -> Void) {
+    if component.kind.isEmpty { component.kind = spot.dynamicType.defaultKind }
+
+    for (reuseIdentifier, classType) in T.views.storage {
+      register(classType: classType, withIdentifier: reuseIdentifier)
+    }
+
+    if !T.views.storage.keys.contains(component.kind) {
+      register(classType: T.defaultView, withIdentifier: component.kind)
+    }
+
+    var cached: UIView?
+    for (index, item) in component.items.enumerate() {
+      prepareItem(item, index: index, spot: self, cached: &cached)
+    }
+  }
+
+  /**
    - Parameter index: The index of the item to lookup
    - Returns: A ViewModel at found at the index
    */

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -122,6 +122,12 @@ public extension Spotable {
     }
   }
 
+  /**
+  Cache view for item kind
+
+  - Parameter item: A view model
+  - Parameter cached: An optional UIView, used to reduce the amount of different reusable views that should be prepared.
+  */
   func cachedViewFor(item: ViewModel, inout cache: UIView?) {
     let reuseIdentifer = item.kind.isPresent ? item.kind : component.kind
     let componentClass = self.dynamicType.views.storage[reuseIdentifer] ?? self.dynamicType.defaultView

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -108,13 +108,9 @@ public extension Spotable {
    - Parameter cached: An optional UIView, used to reduce the amount of different reusable views that should be prepared.
    */
   public func prepareItem<T: Spotable>(item: ViewModel, index: Int, spot: T, inout cached: UIView?) {
-    let reuseIdentifer = item.kind.isPresent ? item.kind : component.kind
-    let componentClass = T.views.storage[reuseIdentifer] ?? T.defaultView
+    cachedViewFor(item, cache: &cached)
 
     component.items[index].index = index
-
-    if cached?.isKindOfClass(componentClass) == false { cached = nil }
-    if cached == nil { cached = componentClass.init() }
 
     guard let view = cached as? SpotConfigurable else { return }
 

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -41,20 +41,20 @@ public extension Spotable {
    - Parameter spot: Spotable
    - Parameter register: A closure containing class type and reuse identifer
    */
-  func registerAndPrepare<T: Spotable>(spot: T, @noescape register: (classType: UIView.Type, withIdentifier: String) -> Void) {
-    if component.kind.isEmpty { component.kind = spot.dynamicType.defaultKind }
+  func registerAndPrepare(@noescape register: (classType: UIView.Type, withIdentifier: String) -> Void) {
+    if component.kind.isEmpty { component.kind = Self.defaultKind }
 
-    for (reuseIdentifier, classType) in T.views.storage {
+    Self.views.storage.forEach { reuseIdentifier, classType in
       register(classType: classType, withIdentifier: reuseIdentifier)
     }
 
-    if !T.views.storage.keys.contains(component.kind) {
-      register(classType: T.defaultView, withIdentifier: component.kind)
+    if !Self.views.storage.keys.contains(component.kind) {
+      register(classType: Self.defaultView, withIdentifier: component.kind)
     }
 
     var cached: UIView?
-    for (index, item) in component.items.enumerate() {
-      prepareItem(item, index: index, spot: self, cached: &cached)
+    component.items.enumerate().forEach {
+      prepareItem($1, index: $0, spot: self, cached: &cached)
     }
   }
 

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -137,10 +137,8 @@ extension CarouselSpot: UICollectionViewDataSource {
       if component.items[indexPath.item].size.height == 0.0 {
         component.items[indexPath.item].size = cell.size
       }
-    }
 
-    if let configure = configure, view = cell as? SpotConfigurable {
-      configure(view)
+      configure?(cell)
     }
 
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -7,6 +7,7 @@ public class CarouselSpot: NSObject, Spotable, Gridable {
   public static var views = ViewRegistry()
   public static var configure: ((view: UICollectionView) -> Void)?
   public static var defaultView: UIView.Type = CarouselSpotCell.self
+  public static var defaultKind = "carousel"
 
   public var cachedViews = [String : SpotConfigurable]()
   public var component: Component

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -22,15 +22,12 @@ public class CarouselSpot: NSObject, Spotable, Gridable {
     $0.scrollDirection = .Horizontal
   }
 
-  public lazy var collectionView: UICollectionView = { [unowned self] in
-    let collectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout)
-    collectionView.backgroundColor = UIColor.whiteColor()
-    collectionView.dataSource = self
-    collectionView.delegate = self
-    collectionView.showsHorizontalScrollIndicator = false
-
-    return collectionView
-    }()
+  public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
+    $0.backgroundColor = UIColor.whiteColor()
+    $0.dataSource = self
+    $0.delegate = self
+    $0.showsHorizontalScrollIndicator = false
+  }
 
   public required init(component: Component) {
     self.component = component

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -2,7 +2,7 @@ import UIKit
 import Sugar
 import Brick
 
-public class CarouselSpot: NSObject, Spotable, Gridable {
+public class CarouselSpot: NSObject, Gridable {
 
   public static var views = ViewRegistry()
   public static var configure: ((view: UICollectionView) -> Void)?

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -16,15 +16,12 @@ public class GridSpot: NSObject, Spotable, Gridable {
 
   public lazy var layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
 
-  public lazy var collectionView: UICollectionView = { [unowned self] in
-    let collectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout)
-    collectionView.backgroundColor = UIColor.whiteColor()
-    collectionView.dataSource = self
-    collectionView.delegate = self
-    collectionView.scrollEnabled = false
-
-    return collectionView
-    }()
+  public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
+    $0.backgroundColor = UIColor.whiteColor()
+    $0.dataSource = self
+    $0.delegate = self
+    $0.scrollEnabled = false
+  }
 
   public required init(component: Component) {
     self.component = component

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -29,8 +29,8 @@ public class GridSpot: NSObject, Spotable, Gridable {
     super.init()
   }
 
-  public convenience init(title: String = "", kind: String = "grid") {
-    self.init(component: Component(title: title, kind: kind))
+  public convenience init(title: String = "", kind: String? = nil) {
+    self.init(component: Component(title: title, kind: kind ?? GridSpot.defaultKind))
   }
 
   public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Sugar
 
-public class GridSpot: NSObject, Spotable, Gridable {
+public class GridSpot: NSObject, Gridable {
 
   public static var views = ViewRegistry()
   public static var defaultView: UIView.Type = GridSpotCell.self

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -79,10 +79,7 @@ extension GridSpot: UICollectionViewDataSource {
       if component.items[indexPath.item].size.height == 0.0 {
         component.items[indexPath.item].size = cell.size
       }
-    }
-
-    if let configure = configure, view = cell as? SpotConfigurable {
-      configure(view)
+      configure?(cell)
     }
 
     collectionView.collectionViewLayout.invalidateLayout()

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -5,6 +5,7 @@ public class GridSpot: NSObject, Spotable, Gridable {
 
   public static var views = ViewRegistry()
   public static var defaultView: UIView.Type = GridSpotCell.self
+  public static var defaultKind = "grid"
   public static var configure: ((view: UICollectionView) -> Void)?
 
   public var cachedViews = [String : SpotConfigurable]()

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -15,7 +15,7 @@ public class GridSpot: NSObject, Spotable, Gridable {
 
   public weak var spotsDelegate: SpotsDelegate?
 
-  public lazy var layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+  public lazy var layout = UICollectionViewFlowLayout()
 
   public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
     $0.backgroundColor = UIColor.whiteColor()

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Sugar
 
-public class ListSpot: NSObject, Spotable, Listable {
+public class ListSpot: NSObject, Listable {
 
   public static var views = ViewRegistry()
   public static var configure: ((view: UITableView) -> Void)?

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -29,7 +29,7 @@ public class ListSpot: NSObject, Spotable, Listable {
   public required init(component: Component) {
     self.component = component
     super.init()
-    
+
     setupTableView()
     prepare()
 
@@ -55,7 +55,7 @@ public class ListSpot: NSObject, Spotable, Listable {
     setupTableView()
     prepare()
   }
-  
+
   // MARK: - Setup
 
   public func setup(size: CGSize) {
@@ -71,7 +71,7 @@ public class ListSpot: NSObject, Spotable, Listable {
 
     ListSpot.configure?(view: tableView)
   }
-  
+
   func setupTableView() {
     tableView.dataSource = self
     tableView.delegate = self

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -33,7 +33,7 @@ public class ListSpot: NSObject, Spotable, Listable {
     setupTableView()
     prepare()
 
-    let reuseIdentifer = component.kind.isPresent ? component.kind : "list"
+    let reuseIdentifer = component.kind.isPresent ? component.kind : self.dynamicType.defaultKind
 
     guard let headerType = ListSpot.headers[reuseIdentifer]  else { return }
 

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -143,10 +143,8 @@ extension ListSpot: UITableViewDataSource {
       if component.items[indexPath.item].size.height == 0.0 {
         component.items[indexPath.item].size = cell.size
       }
-    }
 
-    if let configure = configure, view = cell as? SpotConfigurable {
-      configure(view)
+      configure?(cell)
     }
 
     return cell

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -6,6 +6,7 @@ public class ListSpot: NSObject, Spotable, Listable {
   public static var views = ViewRegistry()
   public static var configure: ((view: UITableView) -> Void)?
   public static var defaultView: UIView.Type = ListSpotCell.self
+  public static var defaultKind = "list"
   public static var headers = ViewRegistry()
 
   public var index = 0

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -20,10 +20,10 @@ public class ListSpot: NSObject, Spotable, Listable {
 
   public weak var spotsDelegate: SpotsDelegate?
 
+  public lazy var tableView = UITableView()
+
   private var fetching = false
 
-  public lazy var tableView = UITableView()
-  
   // MARK: - Initializers
 
   public required init(component: Component) {

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -47,13 +47,11 @@ public class ListSpot: NSObject, Spotable, Listable {
     }
   }
 
-  public convenience init(tableView: UITableView? = nil, title: String = "", kind: String = "list") {
-    self.init(component: Component(title: title, kind: kind))
-    
-    if let tableView = tableView {
-      self.tableView = tableView
-    }
-    
+  public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {
+    self.init(component: Component(title: title, kind: kind ?? ListSpot.defaultKind))
+
+    self.tableView ?= tableView
+
     setupTableView()
     prepare()
   }

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -22,7 +22,7 @@ public class ViewSpot: NSObject, Spotable, Viewable {
     prepare()
   }
 
-  public convenience init(title: String = "", kind: String = "view") {
-    self.init(component: Component(title: title, kind: kind))
+  public convenience init(title: String = "", kind: String? = nil) {
+    self.init(component: Component(title: title, kind: kind ?? ViewSpot.defaultKind))
   }
 }

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -6,6 +6,7 @@ public class ViewSpot: NSObject, Spotable, Viewable {
   public static var views = ViewRegistry()
   public static var configure: ((view: UICollectionView) -> Void)?
   public static var defaultView: UIView.Type = UIView.self
+  public static var defaultKind = "view"
 
   public weak var spotsDelegate: SpotsDelegate?
   public var component: Component

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -11,7 +11,7 @@ public class ViewSpot: NSObject, Spotable, Viewable {
   public weak var spotsDelegate: SpotsDelegate?
   public var component: Component
   public var index = 0
-  
+
   public var configure: (SpotConfigurable -> Void)?
 
   public lazy var scrollView = UIScrollView()


### PR DESCRIPTION
This PR refactors the internals protocols of Spots, the public API does not change so it is not breaking anything.

What is does it is refactors the internal core when preparing a Spot by leveraging from a new `registerAndPrepare` that takes a closure for processing. This closure is used so that both `UITableView` and `UICollectionView` can register its components correctly when preparing the interface.

By preparing, I mean registering cells for reuse and adding a default one if the model kind does not match anything that the Spot supports.