### PR TITLE
Improve list spot

### DIFF
--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -3,7 +3,7 @@ import Brick
 
 enum Header: String, StringConvertible {
   case Search, List
-  
+
   var string: String {
     return rawValue
   }
@@ -11,7 +11,7 @@ enum Header: String, StringConvertible {
 
 enum Cell: String, StringConvertible {
   case Feed, FeaturedFeed, FeedDetail, Topic
-  
+
   var string: String {
     return rawValue
   }
@@ -25,9 +25,9 @@ struct SpotsConfigurator {
 
     ListSpot.headers["search"] = SearchHeaderView.self
     ListSpot.headers["list"] = ListHeaderView.self
-    
+
     ListSpot.configure = { tableView in tableView.tableFooterView = UIView(frame: CGRect.zero) }
-    
+
     ListSpot.views[Cell.Feed] = FeedItemCell.self
     ListSpot.views[Cell.FeaturedFeed] = FeaturedFeedItemCell.self
     ListSpot.views[Cell.FeedDetail] = FeedDetailItemCell.self

--- a/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
@@ -31,10 +31,10 @@ class ExploreController: SpotsController {
       ], meta: ["headerHeight" : 44])
 
     let spots: [Spotable] = [
-      ListSpot(title: "Suggested Channels").then { $0.component.meta["headerHeight"] = 44 },
+      ListSpot(component: Component(title : "Suggested Channels", meta: ["headerHeight" : 44])),
       CarouselSpot(suggestedChannels,
         top: 5, left: 15, bottom: 5, right: 15, itemSpacing: 15),
-      ListSpot(title: "Suggested Topics").then { $0.component.meta["headerHeight"] = 44 },
+      ListSpot(component: Component(title : "Suggested Topics", meta: ["headerHeight" : 44])),
       CarouselSpot(suggestedTopics,
         top: 5, left: 15, bottom: 5, right: 15, itemSpacing: 15),
       ListSpot(component: browse)

--- a/Examples/Apple News/AppleNews/Controllers/SearchController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SearchController.swift
@@ -5,11 +5,11 @@ class SearchController: SpotsController {
 
   convenience init(title: String) {
 
-    let results = Component(title: "Search", kind: "search")
+    let results = Component(title: "Search", kind: "search", meta: ["headerHeight" : 44])
 
     let spots: [Spotable] = [
-      ListSpot(component: results).then { $0.component.meta["headerHeight"] = 88 },
-      ListSpot(title: "Suggestions").then { $0.component.meta["headerHeight"] = 44 },
+      ListSpot(component: results),
+      ListSpot(component: Component(title: "Suggestions", meta: ["headerHeight" : 44])),
       ListSpot()
     ]
 

--- a/Examples/Apple News/AppleNews/Headers/ListHeaderView.swift
+++ b/Examples/Apple News/AppleNews/Headers/ListHeaderView.swift
@@ -28,7 +28,7 @@ public class ListHeaderView: UIView, Componentable {
   }
 
   public required init?(coder aDecoder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
+    fatalError("init(coder:) has not been implemented")
   }
 
   public func configure(component: Component) {

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -41,7 +41,6 @@ public class ListSpot: NSObject, Listable {
     if let configurable = header as? Componentable {
       configurable.configure(component)
       cachedHeaders[reuseIdentifer] = configurable
-      self.component.meta["headerHeight"] = configurable.defaultHeight
     }
   }
 

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -15,8 +15,6 @@ public class ListSpot: NSObject, Listable {
   public var cachedCells = [String : SpotConfigurable]()
   public var configure: (SpotConfigurable -> Void)?
 
-  public let itemHeight: CGFloat = 44
-
   public weak var spotsDelegate: SpotsDelegate?
 
   public lazy var adapter: ListAdapter = ListAdapter(spot: self)


### PR DESCRIPTION
This is a general cleanup PR, we were setting default header height in ListSpot, this is kinda weird in my opinion, Spots should not decide what should be set, it is up to the developer to decide.

Also, this PR fixes the Apple News demo by setting the header height to 44 where it is needed.