### PR TITLE
Improve: reload if needed

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -190,8 +190,7 @@ extension SpotsController {
    - Parameter items: An array of view models
    */
   public func updateIfNeeded(spotAtIndex index: Int = 0, items: [ViewModel]) {
-    guard let spot = spot(index, Spotable.self) else { return }
-    guard !(spot.items == items) else { return }
+    guard let spot = spot(index, Spotable.self) where !(spot.items == items) else { return }
 
     update(spotAtIndex: index) {
       $0.items = items

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -185,6 +185,20 @@ extension SpotsController {
   }
 
   /**
+   Updates spot only if the passed view models are not the same with the current ones.
+   - Parameter spotAtIndex: The index of the spot that you want to perform updates on
+   - Parameter items: An array of view models
+   */
+  public func updateIfNeeded(spotAtIndex index: Int = 0, items: [ViewModel]) {
+    guard let spot = spot(index, Spotable.self) else { return }
+    guard !(spot.items == items) else { return }
+
+    update(spotAtIndex: index) {
+      $0.items = items
+    }
+  }
+
+  /**
    - Parameter item: The view model that you want to append
    - Parameter spotIndex: The index of the spot that you want to append to, defaults to 0
    - Parameter closure: A completion closure that will run after the spot has performed updates internally

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -90,6 +90,10 @@ public extension Spotable {
     }
   }
 
+  /**
+   Reloads spot only if it has changes
+   - Parameter items: An array of view models
+   */
   public func reloadIfNeeded(items: [ViewModel]) {
     guard !(self.items == items) else { return }
 

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -90,6 +90,13 @@ public extension Spotable {
     }
   }
 
+  public func reloadIfNeeded(items: [ViewModel]) {
+    guard !(self.items == items) else { return }
+
+    self.items = items
+    reload(nil, completion: nil)
+  }
+
   /**
    TODO: We should probably have a look at this method? Seems silly to always return 0.0 😁
 


### PR DESCRIPTION
@zenangst Helper functions on `Spotable` and `SpotController` to reload spot only if we have some new data to show. If the passed array equals to the current one there is no sense to reload the spot and have this "blink" animation we experience sometimes. If we have changes it's not gonna blink, but will animate updated cells in the nice way.