### PR TITLE
Set delegate to spots when in setupSpots

### DIFF
--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
@@ -10,13 +10,13 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.5.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
+  - Sugar (1.1.1)
   - SwiftyJSON (2.3.2)
-  - Tailor (0.12.0):
+  - Tailor (1.1.1):
     - Sugar
   - Transition (0.1.0)
 
@@ -61,18 +61,18 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Transition
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Fakery: ff6a27c3688a05c055d3e64c5fa9d78684796749
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  Spots: 0c23f11e5a6d5ecbf9d867ceac5815138328066e
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
   Transition: 66d86e3ae1b8f0b3d9ba2000c7a45fbc17b066f2
 
 PODFILE CHECKSUM: b5990c672d7c25f24324197d1aa40668c01b8dd7
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
@@ -9,12 +9,12 @@ PODS:
   - Imaginary (0.1.0):
     - Cache
   - Keychain (1.0.0)
-  - Spots (1.4.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
-  - Tailor (0.12.0):
+  - Sugar (1.1.1)
+  - Tailor (1.1.1):
     - Sugar
   - Whisper (2.1)
 
@@ -54,17 +54,17 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Keychain
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
-  Spots: a6ba983b32d47869c3566881d272c970abf6c0f9
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
   Whisper: 18b574de21a089c0d664b115f26e0d9ccbbadbab
 
 PODFILE CHECKSUM: 3a2aeebe9f05ae88ecc097c1abc9e12147b4f281
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
@@ -8,12 +8,12 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.4.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
-  - Tailor (0.12.0):
+  - Sugar (1.1.1)
+  - Tailor (1.1.1):
     - Sugar
 
 DEPENDENCIES:
@@ -50,15 +50,15 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  Spots: a6ba983b32d47869c3566881d272c970abf6c0f9
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
 
 PODFILE CHECKSUM: e34ff9f2f0af8d3a15a0ab02c1e69180312dbce3
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
@@ -8,12 +8,12 @@ PODS:
   - Hue (1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.4.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
-  - Tailor (0.12.0):
+  - Sugar (1.1.1)
+  - Tailor (1.1.1):
     - Sugar
 
 DEPENDENCIES:
@@ -50,15 +50,15 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Hue: c7d6a7206bac669ed69e78cc6c14a4d7bd28277c
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  Spots: a6ba983b32d47869c3566881d272c970abf6c0f9
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
 
 PODFILE CHECKSUM: 1dc2800aa90fc3f2870ee03ab115d0d6cc1b8876
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
@@ -9,13 +9,13 @@ PODS:
     - SwiftyJSON
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.4.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
+  - Sugar (1.1.1)
   - SwiftyJSON (2.3.2)
-  - Tailor (0.12.0):
+  - Tailor (1.1.1):
     - Sugar
 
 DEPENDENCIES:
@@ -42,16 +42,16 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Compass: f4b8c37f9b315f0ee4f5e4f71888c54c92992d5d
   Fakery: ff6a27c3688a05c055d3e64c5fa9d78684796749
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  Spots: a6ba983b32d47869c3566881d272c970abf6c0f9
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
 
 PODFILE CHECKSUM: 28ab223e09938592306da973d1540467e2cd0128
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Examples/tvOS Dashboard/Podfile.lock
+++ b/Examples/tvOS Dashboard/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Brick (0.5.0):
+  - Brick (0.6.1):
     - Sugar (~> 1.0)
     - Tailor
   - Cache (1.1.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (1.4.0):
+  - Spots (1.5.2):
     - Brick
     - Sugar
     - Tailor
-  - Sugar (1.1.0)
-  - Tailor (0.12.0):
+  - Sugar (1.1.1)
+  - Tailor (1.1.1):
     - Sugar
 
 DEPENDENCIES:
@@ -32,13 +32,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Imaginary
 
 SPEC CHECKSUMS:
-  Brick: 585fdfc3a5dae686790a519eaea220b8338b91a7
+  Brick: 009193c09e0dbf4c61bef193230f0625fc97d6ad
   Cache: e40d243efe7172ce3eda44287ada2b95b5a7bd7b
   Imaginary: 5317b8d2dc8ecf20455232226bf8a277abdd37d5
-  Spots: a6ba983b32d47869c3566881d272c970abf6c0f9
-  Sugar: 65f2987353aa6249889e122631b2573e84849126
-  Tailor: 4b9d3a6e386f3e743bada55e380721e25ef07c58
+  Spots: 0cc9e14d928df1088875b01cca553385ba98b6ff
+  Sugar: bed396c924fd089feee7c780778cca2a124f580c
+  Tailor: 38a9f1ed1fa804856583396a55ed764d832eeca8
 
 PODFILE CHECKSUM: bd5e841a31421a747421c1f55933ab31e60c19f5
 
-COCOAPODS: 1.0.0.beta.8
+COCOAPODS: 1.0.0.beta.5

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -125,8 +125,8 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
       animated?(view: spot.render())
     }
 
-    guard let delegate = spotsDelegate else { return }
-    self.spotsDelegate = delegate
+    guard let spotsDelegate = spotsDelegate else { return }
+    self.spotsDelegate = spotsDelegate
   }
 }
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -124,6 +124,9 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
         height: ceil(spot.render().height))
       animated?(view: spot.render())
     }
+
+    guard let delegate = spotsDelegate else { return }
+    self.spotsDelegate = delegate
   }
 }
 


### PR DESCRIPTION
This PR improves the behavior when using dynamic spot creation. So if you decide to reload the controller with JSON, it will now set `spotsDelegate` to all underlaying spots inside `spots`.