### PR TITLE
Feature/dictionary on controller and spotable

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -20,6 +20,12 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   /// A bool value to indicate if the SpotsController is refeshing
   public var refreshing = false
 
+  public var dictionary: JSONDictionary {
+    get {
+      return ["components" : spots.map { $0.component.dictionary }]
+    }
+  }
+
   /// A delegate for when an item is tapped within a Spot
   weak public var spotsDelegate: SpotsDelegate? {
     didSet { spots.forEach { $0.spotsDelegate = spotsDelegate } }

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Brick
+import Sugar
 
 /// A class protocol that is used for all components inside of SpotsController
 public protocol Spotable: class {
@@ -39,6 +40,12 @@ public extension Spotable {
   var items: [ViewModel] {
     set(items) { component.items = items }
     get { return component.items }
+  }
+
+  public var dictionary: JSONDictionary {
+    get {
+      return component.dictionary
+    }
   }
 
   /**

--- a/SpotsTests/iOS/GridSpotSpec.swift
+++ b/SpotsTests/iOS/GridSpotSpec.swift
@@ -32,6 +32,20 @@ class GridSpotSpec: QuickSpec {
           expect(gridSpot.layout.minimumInteritemSpacing).to(equal(5))
         }
       }
+
+      describe("can be represented as dictionary") {
+        let component = Component(title: "GridSpot", kind: "grid", span: 3, meta: ["headerHeight" : 44.0])
+        let listSpot = GridSpot(component: component)
+
+        it ("represent GridSpot as a dictionary") {
+          expect(component.dictionary["index"] as? Int).to(equal(listSpot.dictionary["index"] as? Int))
+          expect(component.dictionary["title"] as? String).to(equal(listSpot.dictionary["title"] as? String))
+          expect(component.dictionary["kind"] as? String).to(equal(listSpot.dictionary["kind"] as? String))
+          expect(component.dictionary["span"] as? Int).to(equal(listSpot.dictionary["span"] as? Int))
+          expect((component.dictionary["meta"] as! [String : AnyObject])["headerHeight"] as? CGFloat)
+            .to(equal((listSpot.dictionary["meta"] as! [String : AnyObject])["headerHeight"] as? CGFloat))
+        }
+      }
     }
   }
 }

--- a/SpotsTests/iOS/ListSpotSpec.swift
+++ b/SpotsTests/iOS/ListSpotSpec.swift
@@ -31,6 +31,20 @@ class ListSpotSpec: QuickSpec {
           expect(listSpot.component.kind).to(equal("list"))
         }
       }
+
+      describe("can be represented as dictionary") {
+        let component = Component(title: "ListSpot", kind: "list", span: 1, meta: ["headerHeight" : 44.0])
+        let listSpot = ListSpot(component: component)
+
+        it ("represent ListSpot as a dictionary") {
+          expect(component.dictionary["index"] as? Int).to(equal(listSpot.dictionary["index"] as? Int))
+          expect(component.dictionary["title"] as? String).to(equal(listSpot.dictionary["title"] as? String))
+          expect(component.dictionary["kind"] as? String).to(equal(listSpot.dictionary["kind"] as? String))
+          expect(component.dictionary["span"] as? Int).to(equal(listSpot.dictionary["span"] as? Int))
+          expect((component.dictionary["meta"] as! [String : AnyObject])["headerHeight"] as? CGFloat)
+            .to(equal((listSpot.dictionary["meta"] as! [String : AnyObject])["headerHeight"] as? CGFloat))
+        }
+      }
     }
   }
 }

--- a/SpotsTests/iOS/TestSpotsController.swift
+++ b/SpotsTests/iOS/TestSpotsController.swift
@@ -205,4 +205,20 @@ class SpotsControllerTests : XCTestCase {
     XCTAssert(jsonController.spot.component.items.count == 2)
     XCTAssert(jsonController.spot.component.items.first?.title == "First grid item")
   }
+
+  func testDictionaryOnSpotsController() {
+    let initialJSON = [
+      "components" : [
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ]
+      ]
+    ]
+    let firstController = SpotsController(initialJSON)
+    let secondController = SpotsController(firstController.dictionary)
+
+    XCTAssertTrue(firstController.spots.first!.component == secondController.spots.first!.component)
+  }
 }


### PR DESCRIPTION
This PR adds `.dictionary` on both `SpotsController` and the `Spotable` protocol extension so that you can get a JSON representation of the entire controller or just a single spot.