### PR TITLE
Make defaultKind a StringConvertible

### DIFF
--- a/Sources/iOS/Library/ListAdapter.swift
+++ b/Sources/iOS/Library/ListAdapter.swift
@@ -65,7 +65,7 @@ extension ListAdapter: UITableViewDelegate {
   public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
     let reuseIdentifer = spot.component.kind.isPresent ? spot.component.kind : spot.dynamicType.defaultKind
 
-    if let listSpot = spot as? ListSpot, cachedHeader = listSpot.cachedHeaders[reuseIdentifer] {
+    if let listSpot = spot as? ListSpot, cachedHeader = listSpot.cachedHeaders[reuseIdentifer.string] {
       cachedHeader.configure(spot.component)
       return cachedHeader as? UIView
     } else if let header = ListSpot.headers[reuseIdentifer] {

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -10,7 +10,7 @@ public protocol Spotable: class {
   /// The default view type for the spotable object
   static var defaultView: UIView.Type { get set }
   /// The default kind to fall back to if the view model kind does not exist when trying to display the spotable item
-  static var defaultKind: String { get }
+  static var defaultKind: StringConvertible { get }
 
   weak var spotsDelegate: SpotsDelegate? { get set }
 
@@ -53,7 +53,7 @@ public extension Spotable {
    - Parameter register: A closure containing class type and reuse identifer
    */
   func registerAndPrepare(@noescape register: (classType: UIView.Type, withIdentifier: String) -> Void) {
-    if component.kind.isEmpty { component.kind = Self.defaultKind }
+    if component.kind.isEmpty { component.kind = Self.defaultKind.string }
 
     Self.views.storage.forEach { reuseIdentifier, classType in
       register(classType: classType, withIdentifier: reuseIdentifier)
@@ -170,7 +170,7 @@ public extension Spotable {
     } else if self.dynamicType.views.storage[component.kind] != nil {
       return component.kind
     } else {
-      return self.dynamicType.defaultKind
+      return self.dynamicType.defaultKind.string
     }
   }
 }

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -7,7 +7,7 @@ public class CarouselSpot: NSObject, Gridable {
   public static var views = ViewRegistry()
   public static var configure: ((view: UICollectionView) -> Void)?
   public static var defaultView: UIView.Type = CarouselSpotCell.self
-  public static var defaultKind = "carousel"
+  public static var defaultKind: StringConvertible = "carousel"
 
   public var cachedViews = [String : SpotConfigurable]()
 

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -1,11 +1,12 @@
 import UIKit
 import Sugar
+import Brick
 
 public class GridSpot: NSObject, Gridable {
 
   public static var views = ViewRegistry()
   public static var defaultView: UIView.Type = GridSpotCell.self
-  public static var defaultKind = "grid"
+  public static var defaultKind: StringConvertible = "grid"
   public static var configure: ((view: UICollectionView, layout: UICollectionViewFlowLayout) -> Void)?
 
   public var cachedViews = [String : SpotConfigurable]()
@@ -31,7 +32,7 @@ public class GridSpot: NSObject, Gridable {
   }
 
   public convenience init(title: String = "", kind: String? = nil) {
-    self.init(component: Component(title: title, kind: kind ?? GridSpot.defaultKind))
+    self.init(component: Component(title: title, kind: kind ?? GridSpot.defaultKind.string))
   }
 
   public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -1,12 +1,13 @@
 import UIKit
 import Sugar
+import Brick
 
 public class ListSpot: NSObject, Listable {
 
   public static var views = ViewRegistry()
   public static var configure: ((view: UITableView) -> Void)?
   public static var defaultView: UIView.Type = ListSpotCell.self
-  public static var defaultKind = "list"
+  public static var defaultKind: StringConvertible = "list"
   public static var headers = ViewRegistry()
 
   public var index = 0
@@ -40,12 +41,12 @@ public class ListSpot: NSObject, Listable {
 
     if let configurable = header as? Componentable {
       configurable.configure(component)
-      cachedHeaders[reuseIdentifer] = configurable
+      cachedHeaders[reuseIdentifer.string] = configurable
     }
   }
 
   public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {
-    self.init(component: Component(title: title, kind: kind ?? ListSpot.defaultKind))
+    self.init(component: Component(title: title, kind: kind ?? ListSpot.defaultKind.string))
 
     self.tableView ?= tableView
 

--- a/Sources/iOS/Spots/View/ViewSpot.swift
+++ b/Sources/iOS/Spots/View/ViewSpot.swift
@@ -1,12 +1,13 @@
 import UIKit
 import Sugar
+import Brick
 
 public class ViewSpot: NSObject, Spotable, Viewable {
 
   public static var views = ViewRegistry()
   public static var configure: ((view: UICollectionView) -> Void)?
   public static var defaultView: UIView.Type = UIView.self
-  public static var defaultKind = "view"
+  public static var defaultKind: StringConvertible = "view"
 
   public weak var spotsDelegate: SpotsDelegate?
   public var component: Component
@@ -23,6 +24,6 @@ public class ViewSpot: NSObject, Spotable, Viewable {
   }
 
   public convenience init(title: String = "", kind: String? = nil) {
-    self.init(component: Component(title: title, kind: kind ?? ViewSpot.defaultKind))
+    self.init(component: Component(title: title, kind: kind ?? ViewSpot.defaultKind.string))
   }
 }


### PR DESCRIPTION
This PR changes the `defaultKind` on `Spotable` objects to be a `StringConvertible` type instead of a normal string. Now it works the same way as `ViewRegistry`.