### PR TITLE
Feature: reload with/without animation

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -248,10 +248,10 @@ extension SpotsController {
    - Parameter spotAtIndex: The index of the spot that you want to perform updates on
    - Parameter items: An array of view models
    */
-  public func updateIfNeeded(spotAtIndex index: Int = 0, items: [ViewModel]) {
+  public func updateIfNeeded(spotAtIndex index: Int = 0, items: [ViewModel], animated: Bool = true) {
     guard let spot = spot(index, Spotable.self) where !(spot.items == items) else { return }
 
-    update(spotAtIndex: index) {
+    update(spotAtIndex: index, animated: animated) {
       $0.items = items
     }
   }

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -191,12 +191,12 @@ extension SpotsController {
   /**
    - Parameter completion: A closure that will be run after reload has been performed on all spots
    */
-  public func reload(completion: (() -> Void)? = nil) {
+  public func reload(animated: Bool = true, completion: (() -> Void)? = nil) {
     var spotsLeft = spots.count
 
     dispatch { [weak self] in
       self?.spots.forEach { spot in
-        spot.reload([]) {
+        spot.reload([], animated: animated) {
           spotsLeft -= 1
 
           if spotsLeft == 0 {
@@ -223,9 +223,10 @@ extension SpotsController {
 
   /**
    - Parameter spotAtIndex: The index of the spot that you want to perform updates on
+   - Parameter animated: Perform reload animation
    - Parameter closure: A transform closure to perform the proper modification to the target spot before updating the internals
    */
-  public func update(spotAtIndex index: Int = 0, @noescape _ closure: (spot: Spotable) -> Void) {
+  public func update(spotAtIndex index: Int = 0, animated: Bool = true, @noescape _ closure: (spot: Spotable) -> Void) {
     guard let spot = spot(index, Spotable.self) else { return }
     closure(spot: spot)
     spot.refreshIndexes()
@@ -235,7 +236,7 @@ extension SpotsController {
     dispatch { [weak self] in
       guard let weakSelf = self else { return }
 
-      weakSelf.spot(spot.index, Spotable.self)?.reload([index]) {
+      weakSelf.spot(spot.index, Spotable.self)?.reload([index], animated: animated) {
         weakSelf.spotsScrollView.setNeedsDisplay()
         weakSelf.spotsScrollView.forceUpdate = true
       }
@@ -325,10 +326,11 @@ extension SpotsController {
   /**
    - Parameter indexes: An integer array of indexes that you want to update
    - Parameter spotIndex: The index of the spot that you want to update into
+   - Parameter animated: Perform reload animation
    - Parameter closure: A completion closure that will run after the spot has performed updates internally
    */
-  public func update(indexes indexes: [Int], spotIndex: Int = 0, completion: (() -> Void)? = nil) {
-    spot(spotIndex, Spotable.self)?.reload(indexes) {
+  public func update(indexes indexes: [Int], spotIndex: Int = 0, animated: Bool = true, completion: (() -> Void)? = nil) {
+    spot(spotIndex, Spotable.self)?.reload(indexes, animated: animated) {
       completion?()
       self.spotsScrollView.forceUpdate = true
     }

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -239,9 +239,10 @@ public extension Spotable where Self : Gridable {
 
   /**
    - Parameter indexes: An array of integers that you want to reload, default is nil
+   - Parameter animated: Perform reload animation
    - Parameter completion: A completion closure that is executed in the main queue when the view model has been reloaded
    */
-  public func reload(indexes: [Int]? = nil, completion: (() -> Void)?) {
+  public func reload(indexes: [Int]? = nil, animated: Bool = true, completion: (() -> Void)?) {
     let items = component.items
     for (index, item) in items.enumerate() {
       let cellClass = self.dynamicType.views.storage[item.kind] ?? self.dynamicType.defaultView

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -176,9 +176,10 @@ public extension Spotable where Self : Listable {
 
   /**
    - Parameter indexes: An array of integers that you want to reload, default is nil
+   - Parameter animated: Perform reload animation
    - Parameter completion: A completion closure that is executed in the main queue when the view model has been reloaded
    */
-  public func reload(indexes: [Int]? = nil, completion: Completion = nil) {
+  public func reload(indexes: [Int]? = nil, animated: Bool = true, completion: Completion = nil) {
     refreshIndexes()
 
     for (index, _) in component.items.enumerate() {

--- a/Sources/iOS/Library/Listable.swift
+++ b/Sources/iOS/Library/Listable.swift
@@ -194,7 +194,7 @@ public extension Spotable where Self : Listable {
       }
     }
 
-    tableView.reloadSection()
+    animated ? tableView.reloadSection() : tableView.reloadData()
     tableView.setNeedsLayout()
     tableView.layoutIfNeeded()
     UIView.setAnimationsEnabled(true)

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -28,7 +28,7 @@ public protocol Spotable: class {
   func update(item: ViewModel, index: Int, completion: (() -> Void)?)
   func delete(index: Int, completion: (() -> Void)?)
   func delete(indexes: [Int], completion: (() -> Void)?)
-  func reload(indexes: [Int]?, completion: (() -> Void)?)
+  func reload(indexes: [Int]?, animated: Bool, completion: (() -> Void)?)
   func render() -> UIScrollView
   func layout(size: CGSize)
   func prepare()
@@ -104,12 +104,13 @@ public extension Spotable {
   /**
    Reloads spot only if it has changes
    - Parameter items: An array of view models
+   - Parameter animated: Perform reload animation
    */
-  public func reloadIfNeeded(items: [ViewModel]) {
+  public func reloadIfNeeded(items: [ViewModel], animated: Bool = true) {
     guard !(self.items == items) else { return }
 
     self.items = items
-    reload(nil, completion: nil)
+    reload(nil, animated: animated, completion: nil)
   }
 
   /**

--- a/Sources/iOS/Library/Viewable.swift
+++ b/Sources/iOS/Library/Viewable.swift
@@ -139,5 +139,5 @@ public extension Spotable where Self : Viewable {
     }
   }
 
-  func reload(indexes: [Int]? = nil, completion: (() -> Void)? = nil) { }
+  func reload(indexes: [Int]? = nil, animated: Bool = true, completion: (() -> Void)? = nil) { }
 }


### PR DESCRIPTION
@zenangst I see that on some screens I looks better if reload data without any animation. So I've added `animated` attribute on `reloadIfNeeded` and `updateIfNeeded`. It also requires to have `animated` attribute on `Spotable` reload function and all it's specific implementations. I've added default `true` value everywhere, so it's not a breaking change.