### PR TITLE
Improve Carousel Spot

### DIFF
--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -24,8 +24,14 @@ struct SpotsConfigurator {
     }
 
     GridSpot.configure = { collectionView, layout in
-      layout.sectionInset = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 10)
-      layout.minimumInteritemSpacing = -5
+      layout.sectionInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+      layout.minimumInteritemSpacing = 0
+      layout.minimumLineSpacing = 0
+    }
+
+    CarouselSpot.configure = { collectionView, layout in
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+      layout.minimumInteritemSpacing = 0
       layout.minimumLineSpacing = 10
     }
 

--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -24,9 +24,10 @@ struct SpotsConfigurator {
     }
 
     GridSpot.configure = { collectionView, layout in
-      layout.sectionInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+      layout.sectionInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 0)
       layout.minimumInteritemSpacing = 0
       layout.minimumLineSpacing = 0
+      collectionView.contentInset.right = 10
     }
 
     CarouselSpot.configure = { collectionView, layout in

--- a/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
@@ -36,7 +36,7 @@ class ExploreController: SpotsController {
       ViewModel(title: "Food")
       ], meta: ["headerHeight" : 33])
 
-    let suggestedSpot = CarouselSpot(suggestedChannels, left: 15, right: 15, itemSpacing: 15)
+    let suggestedSpot = CarouselSpot(suggestedChannels)
     suggestedSpot.pageIndicator = true
     suggestedSpot.paginate = true
 
@@ -44,8 +44,7 @@ class ExploreController: SpotsController {
       ListSpot(component: Component(title : "Suggested Channels", meta: ["headerHeight" : 33])),
       suggestedSpot,
       ListSpot(component: Component(title : "Suggested Topics", meta: ["headerHeight" : 33])),
-      CarouselSpot(suggestedTopics,
-        left: 15, right: 15, itemSpacing: 15),
+      CarouselSpot(suggestedTopics),
       ListSpot(component: browse)
     ]
 

--- a/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
+++ b/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
@@ -9,14 +9,14 @@ struct SpotsConfigurator: Configurator {
       scrollView.backgroundColor = UIColor.blackColor()
     }
 
-    CarouselSpot.configure = { collectionView in
+    CarouselSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
     }
 
     CarouselSpot.views["playlist"] = PlaylistGridSpotCell.self
     CarouselSpot.views["featured"] = FeaturedGridSpotCell.self
 
-    GridSpot.configure = { collectionView in
+    GridSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
     }
 

--- a/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
+++ b/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
@@ -11,6 +11,10 @@ struct SpotsConfigurator: Configurator {
 
     CarouselSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
+
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+      layout.minimumInteritemSpacing = 0
+      layout.minimumLineSpacing = 5
     }
 
     CarouselSpot.views["playlist"] = PlaylistGridSpotCell.self
@@ -18,6 +22,10 @@ struct SpotsConfigurator: Configurator {
 
     GridSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
+
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 5, bottom: 5, right: 5)
+      layout.minimumInteritemSpacing = 0
+      layout.minimumLineSpacing = 0
     }
 
     GridSpot.views["player"] = PlayerGridSpotCell.self

--- a/Examples/tvOS Dashboard/Dashboard/Library/SpotsConfigurator.swift
+++ b/Examples/tvOS Dashboard/Dashboard/Library/SpotsConfigurator.swift
@@ -30,9 +30,9 @@ struct SpotsConfigurator {
       collectionView.contentInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
     }
 
-    CarouselSpot.configure = {
-      $0.backgroundColor = UIColor.clearColor()
-      $0.contentInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+    CarouselSpot.configure = { collectionView, layout in
+      collectionView.backgroundColor = UIColor.clearColor()
+      collectionView.contentInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
     }
 
     ListSpot.configure = {

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -109,7 +109,7 @@ extension CollectionAdapter : UICollectionViewDataSource  {
     spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.reuseIdentifierForItem(indexPath)
-    let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath)
+    let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
 
     if let cell = cell as? SpotConfigurable {
       cell.configure(&spot.component.items[indexPath.item])

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -125,3 +125,24 @@ extension CollectionAdapter : UICollectionViewDataSource  {
     return cell
   }
 }
+
+extension CollectionAdapter: UICollectionViewDelegateFlowLayout {
+
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAtIndex section: Int) -> CGFloat {
+    guard spot.layout.scrollDirection == .Horizontal else { return spot.layout.sectionInset.bottom }
+
+    return spot.layout.minimumLineSpacing
+  }
+
+  public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAtIndex section: Int) -> UIEdgeInsets {
+    guard spot.layout.scrollDirection == .Horizontal else { return spot.layout.sectionInset }
+
+    let left = spot.layout.minimumLineSpacing / 2
+    let right = spot.layout.minimumLineSpacing / 2
+
+    return UIEdgeInsets(top: spot.layout.sectionInset.top,
+                        left: left,
+                        bottom: spot.layout.sectionInset.bottom,
+                        right: right)
+  }
+}

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -109,7 +109,11 @@ extension CollectionAdapter : UICollectionViewDataSource  {
     spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.reuseIdentifierForItem(indexPath)
-    let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath).then { $0.optimize() }
+    let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath)
+
+    #if os(iOS)
+      cell.optimize()
+    #endif
 
     if let cell = cell as? SpotConfigurable {
       cell.configure(&spot.component.items[indexPath.item])

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -297,7 +297,7 @@ public extension Spotable where Self : Gridable {
     let width = item(indexPath).size.width - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
 
     return CGSize(
-      width: ceil(width),
+      width: floor(width),
       height: ceil(item(indexPath).size.height))
   }
 }

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -294,7 +294,7 @@ public extension Spotable where Self : Gridable {
       component.items[indexPath.item].size.width = collectionView.width / CGFloat(component.span) - layout.minimumInteritemSpacing
     }
 
-    let width = item(indexPath).size.width - layout.sectionInset.left - collectionView.contentInset.left - collectionView.contentInset.right
+    let width = item(indexPath).size.width - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
 
     return CGSize(
       width: ceil(width),

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -294,7 +294,7 @@ public extension Spotable where Self : Gridable {
       component.items[indexPath.item].size.width = collectionView.width / CGFloat(component.span) - layout.minimumInteritemSpacing
     }
 
-    let width = item(indexPath).size.width - layout.sectionInset.left - layout.sectionInset.right - collectionView.contentInset.left - collectionView.contentInset.right
+    let width = item(indexPath).size.width - layout.sectionInset.left - collectionView.contentInset.left - collectionView.contentInset.right
 
     return CGSize(
       width: ceil(width),

--- a/Sources/iOS/Library/ListAdapter.swift
+++ b/Sources/iOS/Library/ListAdapter.swift
@@ -125,7 +125,10 @@ indexPath
     let reuseIdentifier = spot.reuseIdentifierForItem(indexPath)
     let cell: UITableViewCell = tableView
       .dequeueReusableCellWithIdentifier(reuseIdentifier, forIndexPath: indexPath)
-      .then { $0.optimize() }
+
+    #if os(iOS)
+      cell.optimize()
+    #endif
 
     if let cell = cell as? SpotConfigurable where indexPath.item < spot.component.items.count {
       cell.configure(&spot.component.items[indexPath.item])

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -151,7 +151,6 @@ extension CarouselSpot {
     var width = component.span > 0
       ? collectionView.width / CGFloat(component.span)
       : collectionView.width
-    var height = component.items[indexPath.item].size.height
 
     width -= layout.sectionInset.left - layout.sectionInset.right
     width -= layout.minimumInteritemSpacing
@@ -159,7 +158,6 @@ extension CarouselSpot {
     width -= collectionView.contentInset.left + collectionView.contentInset.right
 
     component.items[indexPath.item].size.width = width
-    component.items[indexPath.item].size.height = height
 
     return CGSize(
       width: ceil(component.items[indexPath.item].size.width),

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -35,10 +35,8 @@ public class CarouselSpot: NSObject, Gridable {
         pageControl.currentPage = 1
         pageControl.width = backgroundView.frame.width
         collectionView.backgroundView?.addSubview(pageControl)
-        layout.sectionInset.bottom = pageControl.height
       } else {
         pageControl.removeFromSuperview()
-        layout.sectionInset.bottom = 0
       }
     }
   }
@@ -79,6 +77,7 @@ public class CarouselSpot: NSObject, Gridable {
 
     layout.sectionInset = UIEdgeInsetsMake(top, left, bottom, right)
     layout.minimumInteritemSpacing = itemSpacing
+    layout.minimumLineSpacing = itemSpacing
   }
 
   public func setup(size: CGSize) {
@@ -94,10 +93,12 @@ public class CarouselSpot: NSObject, Gridable {
       }
     }
 
-    CarouselSpot.configure?(view: collectionView)
+    CarouselSpot.configure?(view: collectionView, layout: layout)
 
     guard pageIndicator else { return }
-    pageControl.frame.origin.y = collectionView.height - pageControl.frame.size.height
+    layout.sectionInset.bottom = layout.sectionInset.bottom + pageControl.height
+    collectionView.height += layout.sectionInset.top + layout.sectionInset.bottom
+    pageControl.frame.origin.y = collectionView.height - pageControl.height
   }
 }
 

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -72,12 +72,12 @@ public class CarouselSpot: NSObject, Gridable {
     super.init()
   }
 
-  public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0) {
+  public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
     self.init(component: component)
 
     layout.sectionInset = UIEdgeInsetsMake(top, left, bottom, right)
     layout.minimumInteritemSpacing = itemSpacing
-    layout.minimumLineSpacing = itemSpacing
+    layout.minimumLineSpacing = lineSpacing
   }
 
   public func setup(size: CGSize) {

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -5,7 +5,7 @@ import Brick
 public class CarouselSpot: NSObject, Gridable {
 
   public static var views = ViewRegistry()
-  public static var configure: ((view: UICollectionView) -> Void)?
+  public static var configure: ((view: UICollectionView, layout: UICollectionViewFlowLayout) -> Void)?
   public static var defaultView: UIView.Type = CarouselSpotCell.self
   public static var defaultKind: StringConvertible = "carousel"
 

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -150,11 +150,15 @@ extension CarouselSpot {
     var width = component.span > 0
       ? collectionView.width / CGFloat(component.span)
       : collectionView.width
+    var height = component.items[indexPath.item].size.height
 
-    width -= layout.sectionInset.left
+    width -= layout.sectionInset.left - layout.sectionInset.right
+    width -= layout.minimumInteritemSpacing
+    width -= layout.minimumLineSpacing
     width -= collectionView.contentInset.left + collectionView.contentInset.right
 
     component.items[indexPath.item].size.width = width
+    component.items[indexPath.item].size.height = height
 
     return CGSize(
       width: ceil(component.items[indexPath.item].size.width),


### PR DESCRIPTION
There were some issues with `Gridable` objects and their layout, this PR aims to solve that for both `GridSpot` and `CarouselSpot`.

Paginated layouts with the Carousel was not working as it should, it didn't calculate the offset correctly so it was a bit off for all pages except for the first one. This should be fixed now.

- `CarouselSpot.configure` now returns the layout to open up for a more centralized configuration.
- `.optimize()`l is only run for iOS and ignore for tvOS
- Demos have been updated to support the new behavior
- `CollectionAdapter` has two new `UICollectionViewDelegateFlowLayout` methods
- `sizeForItemAt` for both core `Gridable` objects now give back a more accurate size for the item based on `sectionInset` and `contentInset`.
- `paginate` has been refactored to layout the views more accurately when `pageControl` is visible.