### PR TITLE
Fix crash in update method

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -231,7 +231,6 @@ extension SpotsController {
     closure(spot: spot)
     spot.refreshIndexes()
     spot.prepare()
-    spot.setup(spotsScrollView.bounds.size)
 
     dispatch { [weak self] in
       guard let weakSelf = self else { return }


### PR DESCRIPTION
This PR aims to fix an issue with calling `.update` on `SpotsController`.

Calling `setup` here caused the spot to relayout which in terms caused it to try to access index paths that where no longer accessible.