### PR TITLE
Allow delegate to be informed of spots change

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -14,7 +14,11 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   /// Initial content offset for SpotsController, defaults to UIEdgeInsetsZero
   public private(set) var initialContentInset: UIEdgeInsets = UIEdgeInsetsZero
   /// A collection of Spotable objects
-  public private(set) var spots: [Spotable]
+  public private(set) var spots: [Spotable] {
+    didSet {
+      spotsDelegate?.spotsDidChange(spots)
+    }
+  }
 
   /// An array of refresh positions to avoid refreshing multiple times when using infinite scrolling
   public var refreshPositions = [CGFloat]()

--- a/Sources/iOS/Library/SpotsDelegates.swift
+++ b/Sources/iOS/Library/SpotsDelegates.swift
@@ -20,6 +20,11 @@ public protocol SpotsDelegate: class {
   func spotDidSelectItem(spot: Spotable, item: ViewModel)
 }
 
+public extension SpotsDelegate {
+
+  func spotsDidChange(spots: [Spotable]) {}
+}
+
 /// A refresh delegate for handling reloading of a Spot
 public protocol SpotsRefreshDelegate: class {
 

--- a/Sources/iOS/Library/SpotsDelegates.swift
+++ b/Sources/iOS/Library/SpotsDelegates.swift
@@ -1,8 +1,15 @@
 import UIKit
 import Brick
 
-/// A delegate for when an item is tapped within a Spot
+/// A generic delegate for Spots
 public protocol SpotsDelegate: class {
+
+  /**
+   A delegate method that is triggered when spots is changed
+
+   - parameter spots: New collection of Spotable objects
+   */
+  func spotsDidChange(spots: [Spotable])
 
   /**
    A delegate method that is triggered when ever a cell is tapped by the user


### PR DESCRIPTION
There are cases when we would like to interact with the newly `spots`, like setting `configure`, so that these interactions happens in one place. Overriding `setupSpots` may not be a good idea

- Add `spotsDidChange` to `SpotsDelegate`