### PR TITLE
Fix/spots delegate

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -35,13 +35,15 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
 
   /// A delegate for when an item is tapped within a Spot
   weak public var spotsDelegate: SpotsDelegate? {
-    didSet { spots.forEach { $0.spotsDelegate = spotsDelegate } }
+    didSet {
+      spots.forEach { $0.spotsDelegate = spotsDelegate }
+      spotsDelegate?.spotsDidChange(spots)
+    }
   }
 
   /// A convenience method for resolving the first spot
-  /// Note: that this method uses force unwrapping, use with caution
-  public var spot: Spotable {
-    get { return spot(0, Spotable.self)! }
+  public var spot: Spotable? {
+    get { return spot(0, Spotable.self) }
   }
 
 #if os(iOS)

--- a/Sources/iOS/Library/SpotsDelegates.swift
+++ b/Sources/iOS/Library/SpotsDelegates.swift
@@ -22,7 +22,7 @@ public protocol SpotsDelegate: class {
 
 public extension SpotsDelegate {
 
-  func spotDidSelectItem(spot: Spotable, item: ViewModel)
+  func spotDidSelectItem(spot: Spotable, item: ViewModel) {}
   func spotsDidChange(spots: [Spotable]) {}
 }
 

--- a/Sources/iOS/Library/SpotsDelegates.swift
+++ b/Sources/iOS/Library/SpotsDelegates.swift
@@ -22,6 +22,7 @@ public protocol SpotsDelegate: class {
 
 public extension SpotsDelegate {
 
+  func spotDidSelectItem(spot: Spotable, item: ViewModel)
   func spotsDidChange(spots: [Spotable]) {}
 }
 

--- a/SpotsTests/iOS/TestSpotsController.swift
+++ b/SpotsTests/iOS/TestSpotsController.swift
@@ -23,7 +23,7 @@ class SpotsControllerTests : XCTestCase {
       spot.component.items = items
     }
 
-    XCTAssert(spotController.spot.component.items == items)
+    XCTAssert(spotController.spot!.component.items == items)
   }
 
   func testAppendItem() {
@@ -31,22 +31,22 @@ class SpotsControllerTests : XCTestCase {
     let listSpot = ListSpot(component: component)
     let spotController = SpotsController(spot: listSpot)
 
-    XCTAssert(spotController.spot.component.items.count == 0)
+    XCTAssert(spotController.spot!.component.items.count == 0)
 
     let item = ViewModel(title: "title1", kind: "list")
     spotController.append(item, spotIndex: 0)
 
-    XCTAssert(spotController.spot.component.items.count == 1)
+    XCTAssert(spotController.spot!.component.items.count == 1)
 
-    if let testItem = spotController.spot.component.items.first {
+    if let testItem = spotController.spot!.component.items.first {
       XCTAssert(testItem == item)
     }
 
     // Test appending item without kind
     spotController.append(ViewModel(title: "title2"), spotIndex: 0)
 
-    XCTAssert(spotController.spot.component.items.count == 2)
-    XCTAssertEqual(spotController.spot.component.items[1].title, "title2")
+    XCTAssert(spotController.spot!.component.items.count == 2)
+    XCTAssertEqual(spotController.spot!.component.items[1].title, "title2")
   }
 
   func testAppendItems() {
@@ -60,8 +60,8 @@ class SpotsControllerTests : XCTestCase {
     ]
     spotController.append(items, spotIndex: 0)
 
-    XCTAssert(spotController.spot.component.items.count > 0)
-    XCTAssert(spotController.spot.component.items == items)
+    XCTAssert(spotController.spot!.component.items.count > 0)
+    XCTAssert(spotController.spot!.component.items == items)
 
     // Test appending items without kind
     spotController.append([
@@ -69,9 +69,9 @@ class SpotsControllerTests : XCTestCase {
       ViewModel(title: "title4")
       ], spotIndex: 0)
 
-    XCTAssertEqual(spotController.spot.component.items.count, 4)
-    XCTAssertEqual(spotController.spot.component.items[2].title, "title3")
-    XCTAssertEqual(spotController.spot.component.items[3].title, "title4")
+    XCTAssertEqual(spotController.spot!.component.items.count, 4)
+    XCTAssertEqual(spotController.spot!.component.items[2].title, "title3")
+    XCTAssertEqual(spotController.spot!.component.items[3].title, "title4")
   }
 
   func testPrependItems() {
@@ -85,16 +85,16 @@ class SpotsControllerTests : XCTestCase {
     ]
     spotController.prepend(items, spotIndex: 0)
 
-    XCTAssertEqual(spotController.spot.component.items.count, 2)
-    XCTAssert(spotController.spot.component.items == items)
+    XCTAssertEqual(spotController.spot!.component.items.count, 2)
+    XCTAssert(spotController.spot!.component.items == items)
 
     spotController.prepend([
       ViewModel(title: "title3"),
       ViewModel(title: "title4")
       ], spotIndex: 0)
 
-    XCTAssertEqual(spotController.spot.component.items[0].title, "title3")
-    XCTAssertEqual(spotController.spot.component.items[1].title, "title4")
+    XCTAssertEqual(spotController.spot!.component.items[0].title, "title3")
+    XCTAssertEqual(spotController.spot!.component.items[1].title, "title4")
   }
 
   func testDeleteItem() {
@@ -106,19 +106,19 @@ class SpotsControllerTests : XCTestCase {
 
     let spotController = SpotsController(spot: initialListSpot)
 
-    let firstItem = spotController.spot.component.items.first
+    let firstItem = spotController.spot!.component.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let listSpot = (spotController.spot as! ListSpot)
     listSpot.delete(component.items.first!) {
-      let lastItem = spotController.spot.component.items.first
+      let lastItem = spotController.spot!.component.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(spotController.spot.component.items.count, 1)
+      XCTAssertEqual(spotController.spot!.component.items.count, 1)
     }
   }
 
@@ -169,7 +169,7 @@ class SpotsControllerTests : XCTestCase {
       ]
       ])
 
-    XCTAssert(sourceController.spot.component == jsonController.spot.component)
+    XCTAssert(sourceController.spot!.component == jsonController.spot!.component)
   }
 
   func testJSONReload() {
@@ -184,9 +184,9 @@ class SpotsControllerTests : XCTestCase {
     ]
     let jsonController = SpotsController(initialJSON)
 
-    XCTAssert(jsonController.spot.component.kind == "list")
-    XCTAssert(jsonController.spot.component.items.count == 1)
-    XCTAssert(jsonController.spot.component.items.first?.title == "First list item")
+    XCTAssert(jsonController.spot!.component.kind == "list")
+    XCTAssert(jsonController.spot!.component.items.count == 1)
+    XCTAssert(jsonController.spot!.component.items.first?.title == "First list item")
 
     let updateJSON = [
       "components" : [
@@ -201,9 +201,9 @@ class SpotsControllerTests : XCTestCase {
 
     jsonController.reload(updateJSON)
 
-    XCTAssert(jsonController.spot.component.kind == "grid")
-    XCTAssert(jsonController.spot.component.items.count == 2)
-    XCTAssert(jsonController.spot.component.items.first?.title == "First grid item")
+    XCTAssert(jsonController.spot!.component.kind == "grid")
+    XCTAssert(jsonController.spot!.component.items.count == 2)
+    XCTAssert(jsonController.spot!.component.items.first?.title == "First grid item")
   }
 
   func testDictionaryOnSpotsController() {


### PR DESCRIPTION
As a follow up of https://github.com/hyperoslo/Spots/pull/216

- Trigger spotsDidChange when spotsDelegate is set. This acts like KVO Initial mode, and this avoid this issue http://stackoverflow.com/questions/25230780/is-it-possible-to-allow-didset-to-be-called-during-initialization-in-swift