### PR TITLE
Spots and SpotsDelegate didSet

### DIFF
--- a/Examples/Spotify/Application/Controllers/AuthController.swift
+++ b/Examples/Spotify/Application/Controllers/AuthController.swift
@@ -5,10 +5,14 @@ import Brick
 
 class AuthController: SpotsController, SpotsDelegate {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+  required init(spots: [Spotable]) {
+    super.init(spots: spots)
 
     self.spotsDelegate = self
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError()
   }
 
   func spotDidSelectItem(spot: Spotable, item: ViewModel) {

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -16,6 +16,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
   /// A collection of Spotable objects
   public private(set) var spots: [Spotable] {
     didSet {
+      spots.forEach { $0.spotsDelegate = spotsDelegate }
       spotsDelegate?.spotsDidChange(spots)
     }
   }
@@ -167,9 +168,6 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
         height: ceil(spot.render().height))
       animated?(view: spot.render())
     }
-
-    guard let spotsDelegate = self.spotsDelegate else { return }
-    self.spotsDelegate = spotsDelegate
   }
 
   /**


### PR DESCRIPTION
- As of http://stackoverflow.com/a/37182411/1418457, as long as we set `spotsDelegate` in subclass of `SpotsController`, its `didSet` will be called. But this leans on  the fact of how `didSet` works in subclass :imp:
- We have 2 things: `spots` and `spotsDelegate`, so updating these in their according `didSet` method, instead of in `setupSpots`. When 1 of these 2 changes, the didSet will trigger and update accordingly.