### PR TITLE
Improve Caching for Spotable

### DIFF
--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -139,6 +139,17 @@ public extension Spotable {
     }
   }
 
+  public func reloadIfNeeded(json: JSONDictionary) {
+    let newComponent = Component(json)
+
+    guard component != newComponent else { cache(); return }
+
+    component = newComponent
+    reload(nil, withAnimation: .Automatic) { [weak self] in
+      self?.cache()
+    }
+  }
+
   /**
    Caches the current state of the spot
   */

--- a/Sources/iOS/Library/Spotable.swift
+++ b/Sources/iOS/Library/Spotable.swift
@@ -139,13 +139,13 @@ public extension Spotable {
     }
   }
 
-  public func reloadIfNeeded(json: JSONDictionary) {
+  public func reloadIfNeeded(json: JSONDictionary, withAnimation animation: SpotsAnimation = .Automatic) {
     let newComponent = Component(json)
 
     guard component != newComponent else { cache(); return }
 
     component = newComponent
-    reload(nil, withAnimation: .Automatic) { [weak self] in
+    reload(nil, withAnimation: animation) { [weak self] in
       self?.cache()
     }
   }

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -81,6 +81,15 @@ public class CarouselSpot: NSObject, Gridable {
     layout.minimumLineSpacing = lineSpacing
   }
 
+  public convenience init(cacheKey: String) {
+    let stateCache = SpotCache(key: cacheKey)
+    
+    self.init(component: Component(stateCache.load()))
+    self.stateCache = stateCache
+
+    prepare()
+  }
+
   public func setup(size: CGSize) {
     collectionView.frame.size = size
 

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -36,6 +36,15 @@ public class GridSpot: NSObject, Gridable {
     self.init(component: Component(title: title, kind: kind ?? GridSpot.defaultKind.string))
   }
 
+  public convenience init(cacheKey: String) {
+    let stateCache = SpotCache(key: cacheKey)
+
+    self.init(component: Component(stateCache.load()))
+    self.stateCache = stateCache
+
+    prepare()
+  }
+
   public convenience init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
     self.init(component: component)
 

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -55,9 +55,10 @@ public class ListSpot: NSObject, Listable {
     prepare()
   }
 
-  public convenience init(stateCache: SpotCache, tableView: UITableView? = nil) {
+  public convenience init(cacheKey: String, tableView: UITableView? = nil) {
+    let stateCache = SpotCache(key: cacheKey)
+    
     self.init(component: Component(stateCache.load()))
-
     self.stateCache = stateCache
     self.tableView ?= tableView
 


### PR DESCRIPTION
This PR aims to improve caching of Spots

- [x] Add init with `cacheKey` on `GridSpot` and `CarouselSpot`
- [x] Add `reloadIfNeeded(json: JSONDictionary)` on `Spotable`
- [x] Refactor cache init for `ListSpot` to use `cacheKey` instead of `SpotCache`
