### PR TITLE
Improve scrollTo on SpotsController

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -444,7 +444,12 @@ extension SpotsController {
     guard let itemY = spot(index, Spotable.self)?.scrollTo(includeElement) else { return }
 
     if spot(index, Spotable.self)?.spotHeight() > spotsScrollView.height - spotsScrollView.contentInset.bottom {
-      let y = itemY - spotsScrollView.height + spotsScrollView.contentInset.bottom
+      var initialHeight: CGFloat = 0.0
+      if index > 0 {
+        initialHeight += spots[0..<index].reduce(0, combine: { $0 + $1.spotHeight() })
+      }
+
+      let y = itemY - spotsScrollView.height + spotsScrollView.contentInset.bottom + initialHeight
       spotsScrollView.setContentOffset(CGPoint(x: CGFloat(0.0), y: y), animated: true)
     }
   }


### PR DESCRIPTION
If you run scroll to on a spot with a higher index than 0, it will calculated based on the height of the preceding spots.