### PR TITLE
Improve updating method on SpotsController

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -386,6 +386,7 @@ extension SpotsController {
     guard let oldItem = spot(spotIndex, Spotable.self)?.item(index) where item != oldItem
       else {
         spot(spotIndex, Spotable.self)?.refreshIndexes()
+        completion?()
         return
     }
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -383,6 +383,12 @@ extension SpotsController {
    - Parameter closure: A completion closure that will run after the spot has performed updates internally
    */
   public func update(item: ViewModel, index: Int = 0, spotIndex: Int, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
+    guard let oldItem = spot(spotIndex, Spotable.self)?.item(index) where item != oldItem
+      else {
+        spot(spotIndex, Spotable.self)?.refreshIndexes()
+        return
+    }
+
     spot(spotIndex, Spotable.self)?.update(item, index: index, withAnimation: animation)  {
       completion?()
       self.spotsScrollView.forceUpdate = true


### PR DESCRIPTION
This PR adds a small comparison condition to when to update a view model. If nothing has changed then there is no need to update the view.