### PR TITLE
Expose cache and cache load method

### DIFF
--- a/Sources/Shared/Library/SpotCache.swift
+++ b/Sources/Shared/Library/SpotCache.swift
@@ -21,7 +21,7 @@ public struct SpotCache {
     SyncCache(cache).add(key, object: JSON.Dictionary(json), expiry: expiry)
   }
 
-  func load() -> JSONDictionary {
+  public func load() -> JSONDictionary {
     return SyncCache(cache).object(key)?.object as? JSONDictionary ?? [:]
   }
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -32,7 +32,7 @@ public class SpotsController: UIViewController, UIScrollViewDelegate {
     }
   }
 
-  var stateCache: SpotCache?
+  public var stateCache: SpotCache?
 
   /// A delegate for when an item is tapped within a Spot
   weak public var spotsDelegate: SpotsDelegate? {


### PR DESCRIPTION
This PR changes the visibility of the `Spots` cache so that you gain more fine-grained control when subclassing a `SpotsController` and using cache.