### PR TITLE
Improve/live editing

### DIFF
--- a/Sources/Shared/Library/SpotsController+DevMode.swift
+++ b/Sources/Shared/Library/SpotsController+DevMode.swift
@@ -23,7 +23,7 @@ extension SpotsController {
           json = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? [String : AnyObject] {
           dispatch_source_cancel(self.source)
           self.source = nil
-          self.reload(json)
+          self.reloadIfNeeded(json)
         }
       } catch let error {
         dispatch_source_cancel(self.source)
@@ -33,7 +33,7 @@ extension SpotsController {
           "title" : "JSON parsing error",
           "subtitle" : "\(error)"]]
           ]
-        ]])
+          ]])
       }
     })
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -251,24 +251,28 @@ extension SpotsController {
     let newComponents = newSpots.map { $0.component }
     let oldComponents = spots.map { $0.component }
 
-    guard oldComponents != newComponents else {
-      cache()
+    dispatch { [weak self] in
+      guard let weakSelf = self else { closure?(); return }
+
+      guard oldComponents != newComponents else {
+        weakSelf.cache()
+        closure?()
+        return
+      }
+
+      weakSelf.spots = newSpots
+      weakSelf.cache()
+
+      if weakSelf.spotsScrollView.superview == nil {
+        weakSelf.view.addSubview(weakSelf.spotsScrollView)
+      }
+
+      weakSelf.spotsScrollView.contentView.subviews.forEach { $0.removeFromSuperview() }
+      weakSelf.setupSpots(animated)
+      weakSelf.spotsScrollView.forceUpdate = true
+
       closure?()
-      return
     }
-
-    spots = newSpots
-    cache()
-
-    if spotsScrollView.superview == nil {
-      view.addSubview(spotsScrollView)
-    }
-
-    spotsScrollView.contentView.subviews.forEach { $0.removeFromSuperview() }
-    setupSpots(animated)
-    spotsScrollView.forceUpdate = true
-
-    closure?()
   }
 
   /**


### PR DESCRIPTION
This PR aims to improve the live editing mode that was introduced in the previous PR.

Now `reloadIfNeeded(json)` will always dispatch into the main thread before updating UI components and `monitor` will no use the same method so that it won’t update UI just because the file changes in some way. This should reduce blinking when running `Spots` in `DEVMODE`