### PR TITLE
Restrict to only run liveEditing in simulator

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -500,7 +500,7 @@ extension SpotsController {
 
   #if DEVMODE
   private func liveEditing(stateCache: SpotCache?) {
-    guard let stateCache = stateCache where source == nil else { return }
+    guard let stateCache = stateCache where source == nil && Simulator.isRunning else { return }
     CacheJSONOptions.writeOptions = .PrettyPrinted
 
     let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory,


### PR DESCRIPTION
Has discussed in https://github.com/hyperoslo/Spots/pull/241, it does not make sens to run the code on the phone so now the liveEditing method returns early if the application is not run in the simulator.