### PR TITLE
Fix dispatch updates

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -247,12 +247,12 @@ extension SpotsController {
    - Parameter completion: A closure that will be run after reload has been performed on all spots
   */
   public func reloadIfNeeded(json: [String : AnyObject], animated: ((view: UIView) -> Void)? = nil, closure: Completion = nil) {
-    let newSpots = Parser.parse(json)
-    let newComponents = newSpots.map { $0.component }
-    let oldComponents = spots.map { $0.component }
-
     dispatch { [weak self] in
       guard let weakSelf = self else { closure?(); return }
+
+      let newSpots = Parser.parse(json)
+      let newComponents = newSpots.map { $0.component }
+      let oldComponents = weakSelf.spots.map { $0.component }
 
       guard oldComponents != newComponents else {
         weakSelf.cache()


### PR DESCRIPTION
I didn't realize that the parse method actually creates UI, so what happened is that it got all crazy and started screaming things like:

> This application is modifying the autolayout engine from a background thread, which can lead to engine corruption and weird crashes.  This will cause an exception in a future release.

This PR should fix that issue.