### PR TITLE
Minor improvements

### DIFF
--- a/Sources/Shared/Library/SpotsController+DevMode.swift
+++ b/Sources/Shared/Library/SpotsController+DevMode.swift
@@ -25,7 +25,10 @@ extension SpotsController {
           json = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? [String : AnyObject] {
           dispatch_source_cancel(self.source)
           self.source = nil
-          self.reloadIfNeeded(json, compare: { $0 !== $1 })
+          let offset = self.spotsScrollView.contentOffset
+          self.reloadIfNeeded(json, compare: { $0 !== $1 }) {
+            self.spotsScrollView.contentOffset = offset
+          }
         }
       } catch let error {
         dispatch_source_cancel(self.source)

--- a/Sources/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Sources/iOS/Extensions/UICollectionView+Indexes.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+public extension UICollectionView {
+
+  func insert(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.insertItemsAtIndexPaths(indexPaths)
+      }) { _ in
+        completion?()
+    }
+  }
+
+  func reload(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+
+    UIView.performWithoutAnimation {
+      self.reloadItemsAtIndexPaths(indexPaths)
+      completion?()
+    }
+  }
+
+  func delete(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.deleteItemsAtIndexPaths(indexPaths)
+      }) { _ in
+        completion?()
+    }
+  }
+
+  func reloadSection(index: Int = 0, completion: (() -> Void)? = nil) {
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.reloadSections(NSIndexSet(index: index))
+      }) { _ in
+        completion?()
+    }
+  }
+}

--- a/Sources/iOS/Extensions/UITableView+Indexes.swift
+++ b/Sources/iOS/Extensions/UITableView+Indexes.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+public extension UITableView {
+
+  func insert(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .Automatic) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+
+    if animation == .None { UIView.setAnimationsEnabled(false) }
+    performUpdates { insertRowsAtIndexPaths(indexPaths, withRowAnimation: animation) }
+    if animation == .None { UIView.setAnimationsEnabled(true) }
+  }
+
+  func reload(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .Automatic) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+    if animation == .None { UIView.setAnimationsEnabled(false) }
+    performUpdates { reloadRowsAtIndexPaths(indexPaths, withRowAnimation: animation) }
+    if animation == .None { UIView.setAnimationsEnabled(true) }
+  }
+
+  func delete(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .Automatic) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+    if animation == .None { UIView.setAnimationsEnabled(false) }
+    performUpdates { deleteRowsAtIndexPaths(indexPaths, withRowAnimation: animation) }
+    if animation == .None { UIView.setAnimationsEnabled(true) }
+  }
+
+  func reloadSection(section: Int = 0, animation: UITableViewRowAnimation = .Automatic) {
+    if animation == .None { UIView.setAnimationsEnabled(false) }
+    performUpdates {
+      reloadSections(NSIndexSet(index: section), withRowAnimation: animation)
+    }
+    if animation == .None { UIView.setAnimationsEnabled(true) }
+  }
+
+  private func performUpdates(@noescape closure: () -> Void) {
+    beginUpdates()
+    closure()
+    endUpdates()
+  }
+}

--- a/Sources/iOS/Library/Gridable.swift
+++ b/Sources/iOS/Library/Gridable.swift
@@ -331,7 +331,7 @@ public extension Spotable where Self : Gridable {
   private func perform(spotAnimation: SpotsAnimation, withIndex index: Int, completion: () -> Void) {
     guard let cell = collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0))
       else { completion(); return }
-      
+
     let animation = CABasicAnimation()
 
     switch spotAnimation {

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -59,7 +59,6 @@ public class CarouselSpot: NSObject, Gridable {
   }
 
   public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
-    $0.backgroundColor = UIColor.whiteColor()
     $0.dataSource = self.adapter
     $0.delegate = self.adapter
     $0.showsHorizontalScrollIndicator = false

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -82,7 +82,7 @@ public class CarouselSpot: NSObject, Gridable {
 
   public convenience init(cacheKey: String) {
     let stateCache = SpotCache(key: cacheKey)
-    
+
     self.init(component: Component(stateCache.load()))
     self.stateCache = stateCache
 

--- a/Sources/iOS/Spots/Carousel/CarouselSpot.swift
+++ b/Sources/iOS/Spots/Carousel/CarouselSpot.swift
@@ -102,6 +102,8 @@ public class CarouselSpot: NSObject, Gridable {
       }
     }
 
+    paginate ?= component.meta("paginate", type: Bool.self)
+
     CarouselSpot.configure?(view: collectionView, layout: layout)
 
     guard pageIndicator else { return }

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -21,6 +21,7 @@ public class GridSpot: NSObject, Gridable {
   public private(set) var stateCache: SpotCache?
 
   public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
+    $0.backgroundColor = UIColor.whiteColor()
     $0.dataSource = self.adapter
     $0.delegate = self.adapter
     $0.scrollEnabled = false

--- a/Sources/iOS/Spots/Grid/GridSpot.swift
+++ b/Sources/iOS/Spots/Grid/GridSpot.swift
@@ -21,7 +21,6 @@ public class GridSpot: NSObject, Gridable {
   public private(set) var stateCache: SpotCache?
 
   public lazy var collectionView: UICollectionView = UICollectionView(frame: CGRectZero, collectionViewLayout: self.layout).then {
-    $0.backgroundColor = UIColor.whiteColor()
     $0.dataSource = self.adapter
     $0.delegate = self.adapter
     $0.scrollEnabled = false

--- a/Sources/iOS/Views/SpotsScrollView.swift
+++ b/Sources/iOS/Views/SpotsScrollView.swift
@@ -85,12 +85,7 @@ public class SpotsScrollView: UIScrollView {
 
   public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
     if let change = change where context == KVOContext {
-      if let scrollView = object as? UIScrollView,
-        oldContentSize = change[NSKeyValueChangeOldKey]?.CGSizeValue() {
-        guard scrollView.contentSize != oldContentSize else { return }
-        setNeedsLayout()
-        layoutIfNeeded()
-      } else if let view = object as? UIView,
+      if let view = object as? UIView,
         oldContentSize = change[NSKeyValueChangeOldKey]?.CGRectValue {
         guard view.frame != oldContentSize else { return }
         setNeedsLayout()


### PR DESCRIPTION
This PR touches one some smaller bits of the implementation of Spots.

When building layouts based on JSON, the CarouselSpot will enable and disable `paginate` based on a meta property on component. This way it is a whole lot easier to enable and disable features when prototyping.

It improves the live editing by keeping track of the current offset when performing updates. This should reduce the amount of jumping when changing the payload in developer mode.

It adds two extensions that was a part of `Sugar` before. They are tied into Spots so I decided to add them here and to make a pull request on `Sugar` to remove those extensions as they don't fit the regular use case of iOS development.

It improves the behavior when performing updates on a GridSpot, it will reload the index path without performing animations, before it would jump if you mutated the item. This should be fixed now.

Spots will no longer set default background colors for Spotable UI components. This can easily be added by the developer using the configuration closures.

It removes the observing of contentSizes that we have in `SpotsScrollView`.

I think that was it.