### PR TITLE
Avoid accessing view inside lazy block

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -64,7 +64,6 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
   lazy public var spotsScrollView: SpotsScrollView = SpotsScrollView().then { [weak self] in
     guard let strongSelf = self else { return }
 
-    $0.frame = strongSelf.view.frame
     $0.alwaysBounceVertical = true
     $0.clipsToBounds = true
     $0.delegate = strongSelf
@@ -158,6 +157,7 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
   public override func viewDidLoad() {
     super.viewDidLoad()
     view.addSubview(spotsScrollView)
+    spotsScrollView.frame = bounds
 
     setupSpots()
 


### PR DESCRIPTION
#### PROBLEM
Recently, there is an issue of having 2 `spotsScrollView` inside `SpotsController`. The result is the `view` accessing inside lazy block.

#### STEPS TO REPRODUCE

- Create new instance of `SpotsController`
- Access `spotsScrollView`

```
let controller = SpotsController()
let _ = controller.spotsScrollView
```

This is the trace

```
spotsScrollView.getter
viewDidLoad
spotsScrollView.getter
```

Because `lazy` is `nonatomic`

- We 'll have 2 instances of `SpotsScrollView` with these 2 `spotsScrollView.getter` calls
- The 1st instance of `SpotsScrollView` gets added to `view`
- The 2nd instance of `SpotsScrollView` gets assigned to `spotsScrollView` variable. This instance is of course not in any view hierarchy
- In `viewWillAppear`, `refreshControl` will get added to `spotsScrollView` variable

#### SOLUTION
We should remove `view` accessing inside lazy block.

#### LESSON LEARNED
We should never access `view` inside lazy block

![sturridge](https://cloud.githubusercontent.com/assets/2284279/16302146/df6770e2-3949-11e6-990c-c11a857ab973.gif)
