### PR TITLE
Set content size after calling update on ListSpot

### DIFF
--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -160,6 +160,7 @@ extension ListAdapter {
       cell.configure(&spot.component.items[index])
     }
 
+    spot.tableView.contentSize.height = spot.spotHeight()
     spot.tableView.reload([index], section: 0, animation: animation.tableViewAnimation)
     completion?()
   }


### PR DESCRIPTION
This PR fixes a small UI glitch that can occur if you have a sequence of `ListSpot`’s and you perform updates on both. This ensures that the contentHeight is always set to the values of the underlying items inside of the component.