### PR TITLE
Refactor reload and update methods

### DIFF
--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -333,6 +333,29 @@ public extension Spotable {
     }
   }
 
+  /**
+   Configure cell at index
+
+   - Parameter index:    The index of the item that should be configured
+   - Parameter cellType: The View.Type of the cell
+   - Parameter cached:   An optional cache of the SpotConfigurable object
+   - Returns: An optional instance of the SpotConfigurable object
+   */
+  func configure(itemAtIndex index: Int, ofType cellType: View.Type, cached: SpotConfigurable? = nil) -> SpotConfigurable? {
+    var instance: SpotConfigurable? = cached
+
+    if instance == nil {
+      instance = cellType.init() as? SpotConfigurable
+    }
+
+    guard let cell = instance else { return nil }
+
+    component.items[index].index = index
+    cell.configure(&component.items[index])
+
+    return cell
+  }
+
   public func sizeForItemAt(indexPath: NSIndexPath) -> CGSize {
     return render().frame.size
   }

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -181,6 +181,7 @@ extension ListAdapter {
     }
 
     animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()
+    spot.tableView.contentSize.height = spot.spotHeight()
     spot.tableView.setNeedsLayout()
     spot.tableView.layoutIfNeeded()
     UIView.setAnimationsEnabled(true)

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -192,6 +192,8 @@ extension ListAdapter {
         }
       }
     }
+    
+    cellCache.removeAll()
 
     animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()
     spot.tableView.contentSize.height = spot.spotHeight()

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -150,16 +150,11 @@ extension ListAdapter {
   public func update(item: ViewModel, index: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot.items[index] = item
 
-    let reuseIdentifier = spot.reuseIdentifierForItem(NSIndexPath(forRow: index, inSection: 0))
-    let cellClass = self.spot.dynamicType.views.storage[reuseIdentifier] ?? self.spot.dynamicType.defaultView
+    let reuseIdentifier: String = spot.reuseIdentifierForItem(NSIndexPath(forRow: index, inSection: 0))
+    let cellType: View.Type = spot.dynamicType.views.storage[reuseIdentifier] ?? spot.dynamicType.defaultView
 
-    spot.tableView.registerClass(cellClass, forCellReuseIdentifier: reuseIdentifier)
-
-    if let cell = cellClass.init() as? SpotConfigurable {
-      spot.component.items[index].index = index
-      cell.configure(&spot.component.items[index])
-    }
-
+    spot.tableView.registerClass(cellType, forCellReuseIdentifier: reuseIdentifier)
+    spot.configure(itemAtIndex: index, ofType: cellType)
     spot.tableView.contentSize.height = spot.spotHeight()
     spot.tableView.reload([index], section: 0, animation: animation.tableViewAnimation)
     completion?()

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -167,16 +167,29 @@ extension ListAdapter {
    */
   public func reload(indexes: [Int]? = nil, withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     spot.refreshIndexes()
+    var cellCache: [String : SpotConfigurable] = [:]
 
-    for (index, _) in spot.component.items.enumerate() {
-      let reuseIdentifier = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
-      let cellClass = self.spot.dynamicType.views.storage[reuseIdentifier] ?? self.spot.dynamicType.defaultView
+    if let indexes = indexes {
+      indexes.forEach { index  in
+        let reuseIdentifier: String = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
+        let cellType: View.Type = spot.dynamicType.views.storage[reuseIdentifier] ?? spot.dynamicType.defaultView
 
-      spot.tableView.registerClass(cellClass, forCellReuseIdentifier: reuseIdentifier)
+        spot.tableView.registerClass(cellType, forCellReuseIdentifier: reuseIdentifier)
 
-      if let cell = cellClass.init() as? SpotConfigurable {
-        spot.component.items[index].index = index
-        cell.configure(&spot.component.items[index])
+        if let cache = spot.configure(itemAtIndex: index, ofType: cellType, cached: cellCache[reuseIdentifier]) {
+          cellCache[reuseIdentifier] = cache
+        }
+      }
+    } else {
+      for (index, _) in spot.component.items.enumerate() {
+        let reuseIdentifier: String = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
+        let cellType: View.Type = spot.dynamicType.views.storage[reuseIdentifier] ?? spot.dynamicType.defaultView
+
+        spot.tableView.registerClass(cellType, forCellReuseIdentifier: reuseIdentifier)
+
+        if let cache = spot.configure(itemAtIndex: index, ofType: cellType, cached: cellCache[reuseIdentifier]) {
+          cellCache[reuseIdentifier] = cache
+        }
       }
     }
 

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -245,6 +245,7 @@ public class CollectionAdapter: NSObject, SpotAdapter {
       }
     }
 
+    cellCache.removeAll()
     spot.collectionView.collectionViewLayout.invalidateLayout()
 
     if let indexes = indexes {

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -216,17 +216,43 @@ public class CollectionAdapter: NSObject, SpotAdapter {
    - Parameter completion: A completion closure that is executed in the main queue when the view model has been reloaded
    */
   public func reload(indexes: [Int]? = nil, withAnimation animation: SpotsAnimation = .None, completion: Completion) {
-    let items = spot.component.items
-    for (index, item) in items.enumerate() {
-      let cellClass = self.spot.dynamicType.views.storage[item.kind] ?? self.spot.dynamicType.defaultView
-      if let cell = cellClass.init() as? SpotConfigurable {
-        spot.component.items[index].index = index
-        cell.configure(&spot.component.items[index])
+    spot.refreshIndexes()
+    var cellCache: [String : SpotConfigurable] = [:]
+
+    if let indexes = indexes {
+      indexes.forEach { index  in
+        let item = spot.component.items[index]
+        let reuseIdentifier: String = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
+        let cellType = spot.dynamicType.views.storage[item.kind] ?? spot.dynamicType.defaultView
+
+        spot.collectionView.registerClass(cellType, forCellWithReuseIdentifier: reuseIdentifier)
+
+        if let cache = spot.configure(itemAtIndex: index, ofType: cellType, cached: cellCache[reuseIdentifier]) {
+          cellCache[reuseIdentifier] = cache
+        }
+      }
+    } else {
+      spot.component.items.enumerate().forEach { index, _  in
+        let item = spot.component.items[index]
+        let reuseIdentifier: String = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
+        let cellType = spot.dynamicType.views.storage[item.kind] ?? spot.dynamicType.defaultView
+
+        spot.collectionView.registerClass(cellType, forCellWithReuseIdentifier: reuseIdentifier)
+
+        if let cache = spot.configure(itemAtIndex: index, ofType: cellType, cached: cellCache[reuseIdentifier]) {
+          cellCache[reuseIdentifier] = cache
+        }
       }
     }
 
     spot.collectionView.collectionViewLayout.invalidateLayout()
-    spot.collectionView.reloadData()
+
+    if let indexes = indexes {
+      spot.collectionView.reload(indexes)
+    } else {
+      spot.collectionView.reloadData()
+    }
+
     spot.setup(spot.collectionView.bounds.size)
     spot.collectionView.layoutIfNeeded()
     completion?()

--- a/Sources/iOS/Library/CollectionAdapter.swift
+++ b/Sources/iOS/Library/CollectionAdapter.swift
@@ -199,13 +199,10 @@ public class CollectionAdapter: NSObject, SpotAdapter {
     spot.items[index] = item
 
     let reuseIdentifier = spot.reuseIdentifierForItem(NSIndexPath(forItem: index, inSection: 0))
-    let cellClass = self.spot.dynamicType.views.storage[reuseIdentifier] ?? self.spot.dynamicType.defaultView
+    let cellType: View.Type = spot.dynamicType.views.storage[reuseIdentifier] ?? spot.dynamicType.defaultView
 
-    spot.collectionView.registerClass(cellClass, forCellWithReuseIdentifier: reuseIdentifier)
-    if let cell = cellClass.init() as? SpotConfigurable {
-      spot.component.items[index].index = index
-      cell.configure(&spot.component.items[index])
-    }
+    spot.collectionView.registerClass(cellType, forCellWithReuseIdentifier: reuseIdentifier)
+    spot.configure(itemAtIndex: index, ofType: cellType)
 
     dispatch { [weak self] in
       guard let weakSelf = self else { return }


### PR DESCRIPTION
This PR aims to improve the performance and accuracy of `update` and `reload` on `ListAdapter` and `CollectionAdapter`.

The performance gains are that `SpotConfigurable` instance are now cached per type meaning that during the preparation of a collection of new items, only one instance per view kind will be created which should reduce the stress during this procedure. The cell cache is emptied as soon as the iteration is done.

`reload` now supports reloading using a collection of indexes, like you would expect it to do.

A small improvement has been added to `ListAdapter` to always ensure that the `contentSize.height` is accurate when mutating the data source.