### PR TITLE
Improve layout

### DIFF
--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -172,8 +172,6 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
 
-    spotsScrollView.forceUpdate = true
-
     if let tabBarController = self.tabBarController
       where tabBarController.tabBar.translucent {
         spotsScrollView.contentInset.bottom = tabBarController.tabBar.height
@@ -185,6 +183,8 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
 
     spotsScrollView.insertSubview(refreshControl, atIndex: 0)
 #endif
+
+    spotsScrollView.forceUpdate = true
   }
 
   /**

--- a/Sources/iOS/Views/SpotsScrollView.swift
+++ b/Sources/iOS/Views/SpotsScrollView.swift
@@ -119,7 +119,7 @@ public class SpotsScrollView: UIScrollView {
 
         // TODO: Fix this properly...
         // This should also apply for UICollectionView but I haven't figured out a way to resize them properly without it going ape-shit over that the layout is incorrect.
-        if subview is UITableView && scrollView.contentSize.height > bounds.height {
+        if subview is UITableView {
           let remainingBoundsHeight = fmax(bounds.maxY - frame.minY, 0.0)
           let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
           frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))


### PR DESCRIPTION
This PR fixes a layout issue that appeared when transitioning between screens with multiple ListSpots.

- Force an update after modifying insets
- Remove content height based if condition for updating the frame height in SpotsScrollView.