### PR TITLE
Refactor layout code in SpotsScrollView

### DIFF
--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   Fakery: 8e6f7da2feb311a90a956ab9b9b2ce72106d1787
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - Imaginary (0.1.0):
     - Cache
   - Keychain (1.0.0)
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -65,7 +65,7 @@ SPEC CHECKSUMS:
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
   Whisper: 74decae53daf8caff5acf8628e24b92d3f05a453

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - JWTDecode
     - Keychain
     - Sugar
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -115,7 +115,7 @@ SPEC CHECKSUMS:
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
   Malibu: 49454a9ce422ad8e230f4699a43d88264a4d7e06
   OhMyAuth: ce16b5e94887376934ea92a3ba252b6f79910699
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 1f4eaf090bda57c880fbef795133a67270976b15
   When: 033104df132ebfa75f4d3a9ba3e7a9865a573a1c

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
 

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
 

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - SwiftyJSON
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -52,7 +52,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Fakery: 8e6f7da2feb311a90a956ab9b9b2ce72106d1787
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865

--- a/Examples/tvOS Dashboard/Podfile.lock
+++ b/Examples/tvOS Dashboard/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - CryptoSwift (0.5.2)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.0.3):
+  - Spots (2.1.0):
     - Brick
     - Cache
     - Hue
@@ -40,7 +40,7 @@ SPEC CHECKSUMS:
   Cache: 87b48b059429d3b53238533830c53941f8aa85f0
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: bed67b01b0cbeea7a7b68cc4a2c357d2c7e0e549
+  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
 

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -199,8 +199,11 @@ public extension Spotable {
    Refreshes the indexes of all items within the component
    */
   public func refreshIndexes() {
-    items.enumerate().forEach {
-      items[$0.index].index = $0.index
+    dispatch(queue: .Interactive) { [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.items.enumerate().forEach {
+        weakSelf.items[$0.index].index = $0.index
+      }
     }
   }
 

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -116,7 +116,6 @@ public extension SpotsProtocol {
 
       weakSelf.reloadSpotsScrollView()
       weakSelf.setupSpots(animated)
-      weakSelf.spotsScrollView.forceUpdate = true
 
       closure?()
     }
@@ -139,7 +138,6 @@ public extension SpotsProtocol {
 
       weakSelf.reloadSpotsScrollView()
       weakSelf.setupSpots(animated)
-      weakSelf.spotsScrollView.forceUpdate = true
 
       closure?()
     }
@@ -160,10 +158,6 @@ public extension SpotsProtocol {
       guard let weakSelf = self else { return }
 
       weakSelf.spot(index, Spotable.self)?.reload(nil, withAnimation: animation) {
-#if os(iOS)
-        weakSelf.spotsScrollView.setNeedsDisplay()
-#endif
-        weakSelf.spotsScrollView.forceUpdate = true
         completion?()
       }
     }
@@ -182,7 +176,6 @@ public extension SpotsProtocol {
 
     update(spotAtIndex: index, withAnimation: animation, withCompletion: completion, {
       $0.items = items
-      self.spotsScrollView.forceUpdate = true
     })
   }
 
@@ -194,7 +187,6 @@ public extension SpotsProtocol {
   public func append(item: ViewModel, spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(item, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -207,7 +199,6 @@ public extension SpotsProtocol {
   public func append(items: [ViewModel], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(items, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -220,7 +211,6 @@ public extension SpotsProtocol {
   public func prepend(items: [ViewModel], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.prepend(items, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -234,7 +224,6 @@ public extension SpotsProtocol {
   public func insert(item: ViewModel, index: Int = 0, spotIndex: Int, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.insert(item, index: index, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -255,7 +244,6 @@ public extension SpotsProtocol {
 
     spot(spotIndex, Spotable.self)?.update(item, index: index, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -269,7 +257,6 @@ public extension SpotsProtocol {
   public func update(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.reload(indexes, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -295,7 +282,6 @@ public extension SpotsProtocol {
   public func delete(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.delete(indexes, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -345,6 +331,7 @@ public extension SpotsProtocol {
     #if DEVMODE
       liveEditing(stateCache)
     #endif
+
     stateCache?.save(dictionary)
   }
 

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -183,8 +183,6 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
 
     spotsScrollView.insertSubview(refreshControl, atIndex: 0)
 #endif
-
-    spotsScrollView.forceUpdate = true
   }
 
   /**

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -195,8 +195,6 @@ extension ListAdapter {
     cellCache.removeAll()
 
     animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()
-    spot.tableView.setNeedsLayout()
-    spot.tableView.layoutIfNeeded()
     UIView.setAnimationsEnabled(true)
     completion?()
   }

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -191,7 +191,7 @@ extension ListAdapter {
         }
       }
     }
-    
+
     cellCache.removeAll()
 
     animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -155,7 +155,6 @@ extension ListAdapter {
 
     spot.tableView.registerClass(cellType, forCellReuseIdentifier: reuseIdentifier)
     spot.configure(itemAtIndex: index, ofType: cellType)
-    spot.tableView.contentSize.height = spot.spotHeight()
     spot.tableView.reload([index], section: 0, animation: animation.tableViewAnimation)
     completion?()
   }
@@ -196,7 +195,6 @@ extension ListAdapter {
     cellCache.removeAll()
 
     animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()
-    spot.tableView.contentSize.height = spot.spotHeight()
     spot.tableView.setNeedsLayout()
     spot.tableView.layoutIfNeeded()
     UIView.setAnimationsEnabled(true)


### PR DESCRIPTION
This PR aims to adress the layout code in SpotsScrollView, it should no longer require using `forceUpdate` when doing mutations to the data source.

It should also fix https://github.com/hyperoslo/Spots/issues/258 by refactoring the KVO implementation. Seems like we were trying to resolve the wrong type of values when resolving `change` in `observeValueForKeyPath`.

Doesn't explain that it only happened on one device but I cannot replicate the crash anymore.