### PR TITLE
Fix/apple new demo

### DIFF
--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -38,16 +38,16 @@ struct SpotsConfigurator {
       layout.minimumLineSpacing = 10
     }
 
-    ListSpot.headers["search"] = SearchHeaderView.self
-    ListSpot.headers["list"] = ListHeaderView.self
+    ListSpot.register(header: SearchHeaderView.self, withIdentifier: "search")
+    ListSpot.register(header: ListHeaderView.self, withIdentifier: "list")
 
     ListSpot.configure = { tableView in tableView.tableFooterView = UIView(frame: CGRect.zero) }
 
-    ListSpot.views[Cell.Feed] = FeedItemCell.self
-    ListSpot.views[Cell.FeaturedFeed] = FeaturedFeedItemCell.self
-    ListSpot.views[Cell.FeedDetail] = FeedDetailItemCell.self
+    ListSpot.register(view: FeedItemCell.self, withIdentifier: Cell.Feed)
+    ListSpot.register(view: FeaturedFeedItemCell.self, withIdentifier: Cell.FeaturedFeed)
+    ListSpot.register(view: FeedDetailItemCell.self, withIdentifier: Cell.FeedDetail)
 
-    CarouselSpot.views[Cell.Topic] = GridTopicCell.self
-    GridSpot.views[Cell.Topic] = GridTopicCell.self
+    CarouselSpot.register(view: GridTopicCell.self, withIdentifier: Cell.Topic)
+    GridSpot.register(view: GridTopicCell.self, withIdentifier: Cell.Topic)
   }
 }

--- a/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouController.swift
@@ -171,7 +171,7 @@ extension ForYouController: SpotsScrollDelegate {
       guard let spot = self.spot else { return }
 
       spot.items.insertContentsOf(items, at: 0)
-      spot.prepare()
+      spot.registerAndPrepare()
 
       let height = spot.items[0..<items.count].reduce(0, combine: { $0 + $1.size.height })
 

--- a/Examples/Apple News/AppleNews/Controllers/SearchController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/SearchController.swift
@@ -25,9 +25,9 @@ class SearchController: SpotsController {
       }
     }
 
-    if let spot = spot as? ListSpot,
-      searchHeader = spot.cachedHeaders["search"] as? SearchHeaderView {
-        searchHeader.searchField.delegate = self
+    if let headerView = spot(1, ListSpot.self)?.tableView.headerViewForSection(0),
+      searchHeader = headerView as? SearchHeaderView {
+      searchHeader.searchField.delegate = self
     }
   }
 }

--- a/Examples/Apple News/AppleNews/Headers/ListHeaderView.swift
+++ b/Examples/Apple News/AppleNews/Headers/ListHeaderView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Spots
 
-public class ListHeaderView: UIView, Componentable {
+public class ListHeaderView: UITableViewHeaderFooterView, Componentable {
 
   public var defaultHeight: CGFloat = 44
 
@@ -22,9 +22,8 @@ public class ListHeaderView: UIView, Componentable {
     return style
     }()
 
-  public override init(frame: CGRect) {
-    super.init(frame: frame)
-    addSubview(label)
+  public override init(reuseIdentifier: String?) {
+    super.init(reuseIdentifier: reuseIdentifier)
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Examples/Apple News/AppleNews/Headers/SearchHeaderView.swift
+++ b/Examples/Apple News/AppleNews/Headers/SearchHeaderView.swift
@@ -2,7 +2,7 @@ import UIKit
 import Spots
 import Sugar
 
-public class SearchHeaderView: UIView, Componentable {
+public class SearchHeaderView: UITableViewHeaderFooterView, Componentable {
 
   public var defaultHeight: CGFloat = 88
 
@@ -13,7 +13,7 @@ public class SearchHeaderView: UIView, Componentable {
     return label
     }()
 
-  lazy var backgroundView: UIView = {
+  lazy var customBackgroundView: UIView = {
     let view = UITextField(frame: self.bounds)
     view.backgroundColor = UIColor(red:0.961, green:0.961, blue:0.961, alpha: 1)
     view.height = 44
@@ -43,9 +43,9 @@ public class SearchHeaderView: UIView, Componentable {
     return style
     }()
 
-  public override init(frame: CGRect) {
-    super.init(frame: frame)
-    [backgroundView, searchField, label].forEach { addSubview($0) }
+  public override init(reuseIdentifier: String?) {
+    super.init(reuseIdentifier: reuseIdentifier)
+    [customBackgroundView, searchField, label].forEach { addSubview($0) }
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.1.0):
+  - Spots (2.1.2):
     - Brick
     - Cache
     - Hue
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   Fakery: 8e6f7da2feb311a90a956ab9b9b2ce72106d1787
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
+  Spots: 5b9897f602978333ca03b3a1db50f8f13351e062
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -303,4 +303,8 @@ public extension Spotable {
     register()
     prepareItems()
   }
+
+  public static func register(view view: View.Type, withIdentifier identifier: StringConvertible) {
+    self.views.storage[identifier.string] = Registry.Item.classType(view)
+  }
 }

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -254,7 +254,11 @@ public extension Spotable {
     var viewModel = item
     viewModel.index = index
 
-    guard let view = Self.views.make(viewModel.kind) as? SpotConfigurable else { return }
+    let kind = item.kind.isEmpty || Self.views.storage[item.kind] == nil
+      ? Self.views.defaultIdentifier
+      : viewModel.kind
+
+    guard let view = Self.views.make(kind) as? SpotConfigurable else { return }
 
     view.configure(&viewModel)
 

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -102,4 +102,8 @@ public class ListSpot: NSObject, Listable {
       }
     }
   }
+
+  public static func register(header header: View.Type, withIdentifier identifier: StringConvertible) {
+    self.headers.storage[identifier.string] = Registry.Item.classType(header)
+  }
 }


### PR DESCRIPTION
This PR fixes the Apple News demo, it adopts the new register methods and refactors the headers into `UITableViewHeaderFooterView`’s.

There are some minor changes to the core foundation of Spots.

The register method looks like this now;

```swift
  public static func register(view view: View.Type, withIdentifier identifier: StringConvertible) {
    self.views.storage[identifier.string] = Registry.Item.classType(view)
  }
```

And it is used like this;

```swift
ListSpot.register(view: FeedItemCell.self, withIdentifier: "Feed cell")
```

When it comes to item kinds, it now checks if it is empty and if the `kind` is registered on the `Spotable` object. If not, then it uses the default view for that component.

```swift
    let kind = item.kind.isEmpty || Self.views.storage[item.kind] == nil
      ? Self.views.defaultIdentifier
      : viewModel.kind
```