### PR TITLE
Fix/spotify iOS demo + SpotCards demo + SpotsDemo

### DIFF
--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -38,16 +38,16 @@ struct SpotsConfigurator {
       layout.minimumLineSpacing = 10
     }
 
-    ListSpot.register(header: SearchHeaderView.self, withIdentifier: "search")
-    ListSpot.register(header: ListHeaderView.self, withIdentifier: "list")
+    ListSpot.register(header: SearchHeaderView.self, identifier: "search")
+    ListSpot.register(header: ListHeaderView.self, identifier: "list")
 
     ListSpot.configure = { tableView in tableView.tableFooterView = UIView(frame: CGRect.zero) }
 
-    ListSpot.register(view: FeedItemCell.self, withIdentifier: Cell.Feed)
-    ListSpot.register(view: FeaturedFeedItemCell.self, withIdentifier: Cell.FeaturedFeed)
-    ListSpot.register(view: FeedDetailItemCell.self, withIdentifier: Cell.FeedDetail)
+    ListSpot.register(header: FeedItemCell.self, identifier: Cell.Feed)
+    ListSpot.register(header: FeaturedFeedItemCell.self, identifier: Cell.FeaturedFeed)
+    ListSpot.register(header: FeedDetailItemCell.self, identifier: Cell.FeedDetail)
 
-    CarouselSpot.register(view: GridTopicCell.self, withIdentifier: Cell.Topic)
-    GridSpot.register(view: GridTopicCell.self, withIdentifier: Cell.Topic)
+    CarouselSpot.register(view: GridTopicCell.self, identifier: Cell.Topic)
+    GridSpot.register(view: GridTopicCell.self, identifier: Cell.Topic)
   }
 }

--- a/Examples/Apple News/AppleNews/Headers/SearchHeaderView.swift
+++ b/Examples/Apple News/AppleNews/Headers/SearchHeaderView.swift
@@ -23,7 +23,7 @@ public class SearchHeaderView: UITableViewHeaderFooterView, Componentable {
     }()
 
   public lazy var searchField: UITextField = { [unowned self] in
-    let searchField = UITextField(frame: self.frame)
+    let searchField = UITextField(frame: self.bounds)
     searchField.width -= 30
     searchField.height = 44
     searchField.y = 0

--- a/Examples/Spotify/Application/Cells/ListHeaderView.swift
+++ b/Examples/Spotify/Application/Cells/ListHeaderView.swift
@@ -2,14 +2,9 @@ import UIKit
 import Spots
 import Sugar
 
-public class ListHeaderView: UIView, Componentable {
+public class ListHeaderView: UITableViewHeaderFooterView, Componentable {
 
   public var defaultHeight: CGFloat = 44
-
-  lazy var label: UILabel = UILabel().then { [unowned self] in
-    $0.frame = self.frame
-    $0.font = UIFont.boldSystemFontOfSize(11)
-  }
 
   lazy var paddedStyle: NSParagraphStyle = NSMutableParagraphStyle().then {
     $0.alignment = .Left
@@ -18,9 +13,9 @@ public class ListHeaderView: UIView, Componentable {
     $0.tailIndent = -15.0
   }
 
-  public override init(frame: CGRect) {
-    super.init(frame: frame)
-    addSubview(label)
+  public override init(reuseIdentifier: String?) {
+    super.init(reuseIdentifier: reuseIdentifier)
+    contentView.backgroundColor = UIColor.blackColor()
   }
 
   public required init?(coder aDecoder: NSCoder) {
@@ -28,9 +23,13 @@ public class ListHeaderView: UIView, Componentable {
   }
 
   public func configure(component: Component) {
-    label.textColor = UIColor.grayColor()
-    label.attributedText = NSAttributedString(string: component.title.uppercaseString,
-      attributes: [NSParagraphStyleAttributeName : paddedStyle])
-    label.height = component.meta("headerHeight", 0.0)
+    textLabel?.textColor = UIColor.grayColor()
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    textLabel?.font = UIFont.boldSystemFontOfSize(11)
+    textLabel?.text = textLabel?.text?.uppercaseString
   }
 }

--- a/Examples/Spotify/Application/Cells/SearchHeaderView.swift
+++ b/Examples/Spotify/Application/Cells/SearchHeaderView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Spots
 
-public class SearchHeaderView: UIView, Componentable {
+public class SearchHeaderView: UITableViewHeaderFooterView, Componentable {
 
   public var defaultHeight: CGFloat = 88
 
@@ -11,7 +11,7 @@ public class SearchHeaderView: UIView, Componentable {
     $0.frame.size.height = 44
   }
 
-  lazy var backgroundView: UIView = UIView(frame: self.frame).then {
+  lazy var customBackgroundView: UIView = UIView(frame: self.frame).then {
     $0.backgroundColor = UIColor.darkGrayColor().alpha(0.5)
     $0.height = 44
     $0.y = 44
@@ -34,9 +34,11 @@ public class SearchHeaderView: UIView, Componentable {
     $0.tailIndent = -15.0
   }
 
-  public override init(frame: CGRect) {
-    super.init(frame: frame)
-    [backgroundView, searchField, label].forEach { addSubview($0) }
+  public override init(reuseIdentifier: String?) {
+    super.init(reuseIdentifier: reuseIdentifier)
+    [customBackgroundView, searchField, label].forEach {
+      contentView.addSubview($0)
+    }
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
+++ b/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
@@ -17,8 +17,8 @@ struct SpotsConfigurator: Configurator {
       layout.minimumLineSpacing = 5
     }
 
-    CarouselSpot.views["playlist"] = PlaylistGridSpotCell.self
-    CarouselSpot.views["featured"] = FeaturedGridSpotCell.self
+    CarouselSpot.register(view: PlaylistGridSpotCell.self, withIdentifier: "playlist")
+    CarouselSpot.register(view: FeaturedGridSpotCell.self, withIdentifier: "featured")
 
     GridSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
@@ -28,9 +28,9 @@ struct SpotsConfigurator: Configurator {
       layout.minimumLineSpacing = 0
     }
 
-    GridSpot.views["player"] = PlayerGridSpotCell.self
-    GridSpot.views["playlist"] = PlaylistGridSpotCell.self
-    GridSpot.views["featured"] = FeaturedGridSpotCell.self
+    GridSpot.register(view: PlayerGridSpotCell.self, withIdentifier: "player")
+    GridSpot.register(view: PlaylistGridSpotCell.self, withIdentifier: "playlist")
+    GridSpot.register(view: FeaturedGridSpotCell.self, withIdentifier: "featured")
 
     ListSpot.configure = { tableView in
       let inset: CGFloat = 15
@@ -44,13 +44,15 @@ struct SpotsConfigurator: Configurator {
         right: inset)
       tableView.separatorColor = UIColor.hex("FFF").alpha(0.2)
     }
+    
+    ListSpot.register(header: SearchHeaderView.self, withIdentifier: "search")
+    ListSpot.register(header: ListHeaderView.self, withIdentifier: "list")
+    ListSpot.register(defaultHeader: ListHeaderView.self)
 
-    ListSpot.headers["search"] = SearchHeaderView.self
-    ListSpot.headers["list"] = ListHeaderView.self
-
-    ListSpot.views["default"] = DefaultListSpotCell.self
-    ListSpot.views["playlist"] = PlaylistListSpotCell.self
-    ListSpot.views["player"] = PlayerListSpotCell.self
-    ListSpot.defaultView = DefaultListSpotCell.self
+    ListSpot.register(view: PlaylistListSpotCell.self, withIdentifier: "playlist")
+    ListSpot.register(view: PlayerListSpotCell.self, withIdentifier: "player")
+    ListSpot.register(view: DefaultListSpotCell.self, withIdentifier: "default")
+    ListSpot.register(defaultView: DefaultListSpotCell.self)
+    
   }
 }

--- a/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
+++ b/Examples/Spotify/Application/Configurators/SpotsConfigurator.swift
@@ -17,8 +17,8 @@ struct SpotsConfigurator: Configurator {
       layout.minimumLineSpacing = 5
     }
 
-    CarouselSpot.register(view: PlaylistGridSpotCell.self, withIdentifier: "playlist")
-    CarouselSpot.register(view: FeaturedGridSpotCell.self, withIdentifier: "featured")
+    CarouselSpot.register(view: PlaylistGridSpotCell.self, identifier: "playlist")
+    CarouselSpot.register(view: FeaturedGridSpotCell.self, identifier: "featured")
 
     GridSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor.clearColor()
@@ -28,9 +28,9 @@ struct SpotsConfigurator: Configurator {
       layout.minimumLineSpacing = 0
     }
 
-    GridSpot.register(view: PlayerGridSpotCell.self, withIdentifier: "player")
-    GridSpot.register(view: PlaylistGridSpotCell.self, withIdentifier: "playlist")
-    GridSpot.register(view: FeaturedGridSpotCell.self, withIdentifier: "featured")
+    GridSpot.register(view: PlayerGridSpotCell.self, identifier: "player")
+    GridSpot.register(view: PlaylistGridSpotCell.self, identifier: "playlist")
+    GridSpot.register(view: FeaturedGridSpotCell.self, identifier: "featured")
 
     ListSpot.configure = { tableView in
       let inset: CGFloat = 15
@@ -45,13 +45,13 @@ struct SpotsConfigurator: Configurator {
       tableView.separatorColor = UIColor.hex("FFF").alpha(0.2)
     }
     
-    ListSpot.register(header: SearchHeaderView.self, withIdentifier: "search")
-    ListSpot.register(header: ListHeaderView.self, withIdentifier: "list")
+    ListSpot.register(header: SearchHeaderView.self, identifier: "search")
+    ListSpot.register(header: ListHeaderView.self, identifier: "list")
     ListSpot.register(defaultHeader: ListHeaderView.self)
 
-    ListSpot.register(view: PlaylistListSpotCell.self, withIdentifier: "playlist")
-    ListSpot.register(view: PlayerListSpotCell.self, withIdentifier: "player")
-    ListSpot.register(view: DefaultListSpotCell.self, withIdentifier: "default")
+    ListSpot.register(header: PlaylistListSpotCell.self, identifier: "playlist")
+    ListSpot.register(header: PlayerListSpotCell.self, identifier: "player")
+    ListSpot.register(header: DefaultListSpotCell.self, identifier: "default")
     ListSpot.register(defaultView: DefaultListSpotCell.self)
     
   }

--- a/Examples/Spotify/Application/Controllers/PlayerController.swift
+++ b/Examples/Spotify/Application/Controllers/PlayerController.swift
@@ -240,6 +240,8 @@ extension PlayerController: SpotsDelegate {
 
 extension PlayerController: SpotsCarouselScrollDelegate {
 
+  func spotDidScroll(spot: Spotable) { }
+
   func spotDidEndScrolling(spot: Spotable, item: ViewModel) {
     guard let urn = item.action, lastItem = lastItem
       where item.action != lastItem.action

--- a/Examples/Spotify/Application/Controllers/PlaylistController.swift
+++ b/Examples/Spotify/Application/Controllers/PlaylistController.swift
@@ -236,7 +236,7 @@ extension PlaylistController: SpotsDelegate {
       let murmur = Murmur(title: notification,
         backgroundColor: UIColor(red:0.063, green:0.063, blue:0.063, alpha: 1),
         titleColor: UIColor.whiteColor())
-      Whistle(murmur)
+      show(whistle: murmur)
     }
   }
 }

--- a/Examples/Spotify/Application/Controllers/SearchController.swift
+++ b/Examples/Spotify/Application/Controllers/SearchController.swift
@@ -19,8 +19,8 @@ class SearchController: SpotsController {
     self.title = title
     self.spotsDelegate = self
 
-    guard let spot = spot as? ListSpot,
-      searchHeader = spot.cachedHeaders["search"] as? SearchHeaderView else { return }
+    guard let headerView = spot(0, ListSpot.self)?.tableView.headerViewForSection(0),
+      searchHeader = headerView as? SearchHeaderView else { return }
 
     searchHeader.searchField.delegate = self
   }
@@ -28,9 +28,8 @@ class SearchController: SpotsController {
   override func scrollViewDidScroll(scrollView: UIScrollView) {
     super.scrollViewDidScroll(scrollView)
 
-    guard let spot = spot as? ListSpot,
-      searchHeader = spot.cachedHeaders["search"] as? SearchHeaderView else { return }
-
+    guard let headerView = spot(0, ListSpot.self)?.tableView.headerViewForSection(0),
+      searchHeader = headerView as? SearchHeaderView else { return }
     searchHeader.searchField.resignFirstResponder()
   }
 }

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - Imaginary (0.1.0):
     - Cache
   - Keychain (1.0.0)
-  - Spots (2.1.0):
+  - Spots (2.1.2):
     - Brick
     - Cache
     - Hue
@@ -65,7 +65,7 @@ SPEC CHECKSUMS:
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
-  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
+  Spots: 5b9897f602978333ca03b3a1db50f8f13351e062
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
   Whisper: 74decae53daf8caff5acf8628e24b92d3f05a453

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.1.0):
+  - Spots (2.1.2):
     - Brick
     - Cache
     - Hue
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
+  Spots: 5b9897f602978333ca03b3a1db50f8f13351e062
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
 

--- a/Examples/SpotsCards/SpotsCards/AppDelegate.swift
+++ b/Examples/SpotsCards/SpotsCards/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     window = UIWindow(frame: UIScreen.mainScreen().bounds)
 
     SpotFactory.register("cards", spot: CardSpot.self)
-    CarouselSpot.views["card"] = CardSpotCell.self
+    CarouselSpot.register(view: CardSpotCell.self, identifier: "card")
 
     CarouselSpot.configure = { collectionView, layout in
       collectionView.backgroundColor = UIColor(red:0.110, green:0.110, blue:0.110, alpha: 1)

--- a/Examples/SpotsCards/SpotsCards/components.json
+++ b/Examples/SpotsCards/SpotsCards/components.json
@@ -4,20 +4,21 @@
     "meta" : {
        "background-color" : "252525"
      },
-    "type" : "cards",
+    "kind" : "cards",
+    "span" : 1,
     "items" : [
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@thuygia",
         "subtitle" : "I held an inspirational talk yesterday at Norges Krestive Høyskole for around 50 students about BEING A CREATOR and what it took and what possibilities it gave me as a designer. What a rush it was! #hyperoslo #kreativhoyskole #nkh #norgeskreativehøyskole @norgeskreativehoyskole @hyper_oslo"
       },
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@mattibernitz",
         "subtitle" : "Det dukker stadig opp gamle prosjekter i arbeidet med ny nettside www.bernitz.no. Throwback til 2002, fra et kokebok og utstillingsprosjekt med #hyperoslo og @superkjos. #bluefish #flashphotography #foodphotography #canonphotos #canon20d"
       },
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@thuygia",
         "subtitle" : "I held an inspirational talk yesterday at Norges Krestive Høyskole for around 50 students about BEING A CREATOR and what it took and what possibilities it gave me as a designer. What a rush it was! #hyperoslo #kreativhoyskole #nkh #norgeskreativehøyskole @norgeskreativehoyskole @hyper_oslo"
       }
@@ -27,10 +28,11 @@
     "meta" : {
        "background-color" : "252525"
      },
-    "type" : "cards",
+    "kind" : "cards",
+    "span" : 1,
     "items" : [
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@superkjos",
         "subtitle" : "#dagensdittto at #hyperoslo",
         "meta" : {
@@ -44,10 +46,11 @@
     "meta" : {
        "background-color" : "252525"
      },
-    "type" : "cards",
+    "kind" : "cards",
+    "span" : 1,
     "items" : [
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@superkjos",
         "subtitle" : "@madsfrantzen enjoying work. And life. #hyperoslo",
 
@@ -58,10 +61,11 @@
     "meta" : {
        "background-color" : "252525"
      },
-    "type" : "cards",
+    "kind" : "cards",
+    "span" : 1,
     "items" : [
       {
-        "type"     : "card",
+        "kind"     : "card",
         "title" : "@superkjos",
         "subtitle" : "Dukkefilm in the making hos #hyperoslo #hyperlab #hyperfilm",
         "meta" : {

--- a/Examples/SpotsDemo/Demo/AppDelegate.swift
+++ b/Examples/SpotsDemo/Demo/AppDelegate.swift
@@ -10,12 +10,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
     window = UIWindow(frame: UIScreen.mainScreen().bounds)
 
-    GridSpot.views["header"] = GridSpotHeader.self
-    GridSpot.views["titles"] = GridSpotCellTitles.self
-    GridSpot.views["circle"] = GridSpotCellCircle.self
+    GridSpot.register(view: GridSpotHeader.self, identifier: "header")
+    GridSpot.register(view: GridSpotCellTitles.self, identifier: "titles")
+    GridSpot.register(view: GridSpotCellCircle.self, identifier: "circle")
 
     SpotsController.configure = {
       $0.backgroundColor = UIColor.whiteColor()
+    }
+    
+    GridSpot.configure = { collectionView, layout in
+      collectionView.backgroundColor = UIColor.whiteColor()
     }
 
     let controller = JSONController()

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (2.1.0):
+  - Spots (2.1.2):
     - Brick
     - Cache
     - Hue
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   CryptoSwift: c1ef79f901b86099a6fe8b3c7524cf9f3f3c8c40
   Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
+  Spots: 5b9897f602978333ca03b3a1db50f8f13351e062
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 135708d29cef05d8f83e61ce8c07171c8fcfc865
 

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -307,4 +307,8 @@ public extension Spotable {
   public static func register(view view: View.Type, withIdentifier identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
   }
+
+  public static func register(defaultView view: View.Type) {
+    self.views.storage[self.views.defaultIdentifier] = Registry.Item.classType(view)
+  }
 }

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -304,7 +304,7 @@ public extension Spotable {
     prepareItems()
   }
 
-  public static func register(view view: View.Type, withIdentifier identifier: StringConvertible) {
+  public static func register(view view: View.Type, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
   }
 

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -229,6 +229,7 @@ extension ListAdapter: UITableViewDelegate {
 
     let view = tableView.dequeueReusableHeaderFooterViewWithIdentifier(spot.component.kind)
     view?.height = spot.component.meta("headerHeight", 0.0)
+    view?.width = spot.tableView.width
     (view as? Componentable)?.configure(spot.component)
 
     return view

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -103,7 +103,7 @@ public class ListSpot: NSObject, Listable {
     }
   }
 
-  public static func register(header header: View.Type, withIdentifier identifier: StringConvertible) {
+  public static func register(header header: View.Type, identifier: StringConvertible) {
     self.headers.storage[identifier.string] = Registry.Item.classType(header)
   }
 

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -106,4 +106,8 @@ public class ListSpot: NSObject, Listable {
   public static func register(header header: View.Type, withIdentifier identifier: StringConvertible) {
     self.headers.storage[identifier.string] = Registry.Item.classType(header)
   }
+
+  public static func register(defaultHeader header: View.Type) {
+    self.headers.storage[self.views.defaultIdentifier] = Registry.Item.classType(header)
+  }
 }

--- a/Sources/iOS/Spots/List/ListSpot.swift
+++ b/Sources/iOS/Spots/List/ListSpot.swift
@@ -36,8 +36,8 @@ public class ListSpot: NSObject, Listable {
       self.component.kind = "list"
     }
 
-    setupTableView()
     registerAndPrepare()
+    setupTableView()
   }
 
   public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {


### PR DESCRIPTION
This PR fixes the Spotify demo so that it works with the new version of Spots.

It migrates to the new registry API and updates the corresponding views.

It adds a new method on `ListSpot` to register a `defaultHeader` to a `UITableView` based component. It looks like this;

```swift
  public static func register(defaultHeader header: View.Type) {
    self.headers.storage[self.views.defaultIdentifier] = Registry.Item.classType(header)
  }
```

And you use it like this;

```swift
ListSpot.register(defaultHeader: ListHeaderView.self)
```

### Screenshot

![simulator screen shot aug 12 2016 20 45 24](https://cloud.githubusercontent.com/assets/57446/17633618/7cbde92e-60ce-11e6-8dc3-82220b220217.png)
