### PR TITLE
macOS implementation + hard and soft updates for ListSpot

### DIFF
--- a/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
+++ b/Examples/Apple News/AppleNews/Configurators/SpotsConfigurator.swift
@@ -43,9 +43,9 @@ struct SpotsConfigurator {
 
     ListSpot.configure = { tableView in tableView.tableFooterView = UIView(frame: CGRect.zero) }
 
-    ListSpot.register(header: FeedItemCell.self, identifier: Cell.Feed)
-    ListSpot.register(header: FeaturedFeedItemCell.self, identifier: Cell.FeaturedFeed)
-    ListSpot.register(header: FeedDetailItemCell.self, identifier: Cell.FeedDetail)
+    ListSpot.register(view: FeedItemCell.self, identifier: Cell.Feed)
+    ListSpot.register(view: FeaturedFeedItemCell.self, identifier: Cell.FeaturedFeed)
+    ListSpot.register(view: FeedDetailItemCell.self, identifier: Cell.FeedDetail)
 
     CarouselSpot.register(view: GridTopicCell.self, identifier: Cell.Topic)
     GridSpot.register(view: GridTopicCell.self, identifier: Cell.Topic)

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -93,7 +93,7 @@ CHECKOUT OPTIONS:
     :commit: 5273ca100e23bbcd82ff52cde30daec655ef3b75
     :git: https://github.com/hyperoslo/Malibu.git
   OhMyAuth:
-    :commit: fb4af44f38eb3d45887190d5df04a8851ce0c6a6
+    :commit: 3b61b2cc3eeebd5f3a5ff0b178d5b7aa7d0a1631
     :git: https://github.com/hyperoslo/OhMyAuth.git
   Sugar:
     :commit: e66d36a4a36b3114279e35e5b97acb464acba75f

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - JWTDecode
     - Keychain
     - Sugar
-  - Spots (2.1.0):
+  - Spots (2.1.2):
     - Brick
     - Cache
     - Hue
@@ -115,7 +115,7 @@ SPEC CHECKSUMS:
   Keychain: 50cb247cab32e774422741b118af9b598a3fb5b2
   Malibu: 49454a9ce422ad8e230f4699a43d88264a4d7e06
   OhMyAuth: ce16b5e94887376934ea92a3ba252b6f79910699
-  Spots: df1baf3b762d51b1d315ca87a18791da1834053d
+  Spots: 5b9897f602978333ca03b3a1db50f8f13351e062
   Sugar: 556b623f0f8846cf08de7302701892f11d567419
   Tailor: 1f4eaf090bda57c880fbef795133a67270976b15
   When: 033104df132ebfa75f4d3a9ba3e7a9865a573a1c

--- a/Examples/SpotifyMac/Spotify Mac/AppDelegate.swift
+++ b/Examples/SpotifyMac/Spotify Mac/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
   func applicationDidFinishLaunching(aNotification: NSNotification) {
     configurators.forEach { $0.configure() }
 
-    spotsSession.login()
+//    spotsSession.login()
 
     if !spotsSession.isActive {
       spotsSession.login()

--- a/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
@@ -3,19 +3,19 @@ import Spots
 struct SpotsConfigurator: Configurator {
 
   func configure() {
-    CarouselSpot.register(item: ArtistGridItem.self, identifier: "artist")
-    CarouselSpot.register(item: AlbumGridItem.self, identifier: "album")
-    CarouselSpot.register(item: GridSpotItem.self, identifier: "carousel")
-    CarouselSpot.register(item: CategoryGridItem.self, identifier: "category")
-    CarouselSpot.register(item: FeaturedGridItem.self, identifier: "featured")
-    CarouselSpot.register(item: GridListItem.self, identifier: "list")
+    CarouselSpot.register(view: ArtistGridItem.self, identifier: "artist")
+    CarouselSpot.register(view: AlbumGridItem.self, identifier: "album")
+    CarouselSpot.register(view: GridSpotItem.self, identifier: "carousel")
+    CarouselSpot.register(view: CategoryGridItem.self, identifier: "category")
+    CarouselSpot.register(view: FeaturedGridItem.self, identifier: "featured")
+    CarouselSpot.register(view: GridListItem.self, identifier: "list")
 
-    GridSpot.register(item: ArtistGridItem.self, identifier: "artist")
-    GridSpot.register(item: AlbumGridItem.self, identifier: "album")
-    GridSpot.register(item: CategoryGridItem.self, identifier: "category")
-    GridSpot.register(item: FeaturedGridItem.self, identifier: "featured")
-    GridSpot.register(item: GridSpotItem.self, identifier: "grid")
-    GridSpot.register(item: GridListItem.self, identifier: "list")
+    GridSpot.register(view: ArtistGridItem.self, identifier: "artist")
+    GridSpot.register(view: AlbumGridItem.self, identifier: "album")
+    GridSpot.register(view: CategoryGridItem.self, identifier: "category")
+    GridSpot.register(view: FeaturedGridItem.self, identifier: "featured")
+    GridSpot.register(view: GridSpotItem.self, identifier: "grid")
+    GridSpot.register(view: GridListItem.self, identifier: "list")
 
     ListSpot.register(view: HeaderGridItem.self, identifier: "header")
     ListSpot.register(view: TableRow.self, identifier: "list")

--- a/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
@@ -15,7 +15,7 @@ struct SpotsConfigurator: Configurator {
     GridSpot.grids["featured"] = FeaturedGridItem.self
     GridSpot.grids["grid"] = GridSpotItem.self
     GridSpot.grids["list"] = GridListItem.self
-    
+
     ListSpot.register(view: HeaderGridItem.self, identifier: "header")
     ListSpot.register(view: TableRow.self, identifier: "list")
     ListSpot.register(view: TrackRow.self, identifier: "track")

--- a/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
@@ -15,10 +15,12 @@ struct SpotsConfigurator: Configurator {
     GridSpot.grids["featured"] = FeaturedGridItem.self
     GridSpot.grids["grid"] = GridSpotItem.self
     GridSpot.grids["list"] = GridListItem.self
-    ListSpot.views["header"] = HeaderGridItem.self
-    ListSpot.views["list"] = TableRow.self
-    ListSpot.views["track"] = TrackRow.self
-    ListSpot.views["hero"] = HeroGridItem.self
+    
+    ListSpot.register(view: HeaderGridItem.self, identifier: "header")
+    ListSpot.register(view: TableRow.self, identifier: "list")
+    ListSpot.register(view: TrackRow.self, identifier: "track")
+    ListSpot.register(view: HeroGridItem.self, identifier: "hero")
+    ListSpot.register(defaultView: TableRow.self)
 
     CarouselSpot.Default.sectionInsetTop = 0.0
     CarouselSpot.Default.sectionInsetLeft = 10.0

--- a/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Configuration/SpotsConfigurator.swift
@@ -3,18 +3,19 @@ import Spots
 struct SpotsConfigurator: Configurator {
 
   func configure() {
-    CarouselSpot.grids["artist"] = ArtistGridItem.self
-    CarouselSpot.grids["album"] = AlbumGridItem.self
-    CarouselSpot.grids["carousel"] = GridSpotItem.self
-    CarouselSpot.grids["category"] = CategoryGridItem.self
-    CarouselSpot.grids["featured"] = FeaturedGridItem.self
-    CarouselSpot.grids["list"] = GridListItem.self
-    GridSpot.grids["artist"] = ArtistGridItem.self
-    GridSpot.grids["album"] = AlbumGridItem.self
-    GridSpot.grids["category"] = CategoryGridItem.self
-    GridSpot.grids["featured"] = FeaturedGridItem.self
-    GridSpot.grids["grid"] = GridSpotItem.self
-    GridSpot.grids["list"] = GridListItem.self
+    CarouselSpot.register(item: ArtistGridItem.self, identifier: "artist")
+    CarouselSpot.register(item: AlbumGridItem.self, identifier: "album")
+    CarouselSpot.register(item: GridSpotItem.self, identifier: "carousel")
+    CarouselSpot.register(item: CategoryGridItem.self, identifier: "category")
+    CarouselSpot.register(item: FeaturedGridItem.self, identifier: "featured")
+    CarouselSpot.register(item: GridListItem.self, identifier: "list")
+
+    GridSpot.register(item: ArtistGridItem.self, identifier: "artist")
+    GridSpot.register(item: AlbumGridItem.self, identifier: "album")
+    GridSpot.register(item: CategoryGridItem.self, identifier: "category")
+    GridSpot.register(item: FeaturedGridItem.self, identifier: "featured")
+    GridSpot.register(item: GridSpotItem.self, identifier: "grid")
+    GridSpot.register(item: GridListItem.self, identifier: "list")
 
     ListSpot.register(view: HeaderGridItem.self, identifier: "header")
     ListSpot.register(view: TableRow.self, identifier: "list")

--- a/Sources/Mac/Controllers/SpotsController.swift
+++ b/Sources/Mac/Controllers/SpotsController.swift
@@ -195,8 +195,8 @@ public class SpotsController: NSViewController, SpotsProtocol {
       }
 
       spots[index].index = index
+      spot.registerAndPrepare()
       spotsScrollView.spotsContentView.addSubview(spot.render())
-      spot.prepare()
       spot.setup(CGSize(width: view.frame.width,
         height: height))
       spot.component.size = CGSize(

--- a/Sources/Mac/Extensions/Gridable+Mac.swift
+++ b/Sources/Mac/Extensions/Gridable+Mac.swift
@@ -103,11 +103,11 @@ extension Gridable {
     collectionView.deselectAll(nil)
   }
 
-  public static func register(item item: NSCollectionViewItem.Type, identifier: StringConvertible) {
-    self.grids.storage[identifier.string] = GridRegistry.Item.classType(item)
+  public static func register(view view: NSCollectionViewItem.Type, identifier: StringConvertible) {
+    self.grids.storage[identifier.string] = GridRegistry.Item.classType(view)
   }
 
-  public static func register(defaultItem: NSCollectionViewItem.Type) {
-    self.grids.storage[self.grids.defaultIdentifier] = GridRegistry.Item.classType(defaultItem)
+  public static func register(defaultView: NSCollectionViewItem.Type) {
+    self.grids.storage[self.grids.defaultIdentifier] = GridRegistry.Item.classType(defaultView)
   }
 }

--- a/Sources/Mac/Extensions/ListAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/ListAdapter+Mac.swift
@@ -9,7 +9,7 @@ extension ListAdapter {
     spot.component.items.append(item)
 
     var cached: View?
-    spot.prepareItem(item, index: count, cached: &cached)
+    spot.configureItem(count, usesViewSize: true)
 
     dispatch { [weak self] in
       guard let tableView = self?.spot.tableView else { completion?(); return }
@@ -27,8 +27,10 @@ extension ListAdapter {
 
     var cached: NSView?
     items.enumerate().forEach {
-      indexes.append(count + $0.index)
-      spot.prepareItem($0.element, index: count + $0.index, cached: &cached)
+      let index = count + $0.index
+//      indexes.append(count + $0.index)
+      spot.configureItem(index, usesViewSize: true)
+//      spot.prepareItem($0.element, index: count + $0.index, cached: &cached)
     }
 
     dispatch { [weak self] in
@@ -189,9 +191,9 @@ extension ListAdapter: NSTableViewDelegate {
   }
 
   public func tableView(tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    let reuseIdentifier = spot.reuseIdentifierForItem(row)
-    let viewClass = spot.dynamicType.views[reuseIdentifier]
-    let view = viewClass?.init()
+    let reuseIdentifier = spot.identifier(row)
+    let cachedView = spot.dynamicType.views.make(reuseIdentifier)
+    let view = cachedView?.dynamicType.init()
 
     (view as? SpotConfigurable)?.configure(&spot.component.items[row])
     (view as? NSTableRowView)?.identifier = reuseIdentifier

--- a/Sources/Mac/Extensions/ListAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/ListAdapter+Mac.swift
@@ -28,7 +28,7 @@ extension ListAdapter {
     var cached: NSView?
     items.enumerate().forEach {
       let index = count + $0.index
-//      indexes.append(count + $0.index)
+      indexes.append(index)
       spot.configureItem(index, usesViewSize: true)
     }
 

--- a/Sources/Mac/Extensions/ListAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/ListAdapter+Mac.swift
@@ -30,7 +30,6 @@ extension ListAdapter {
       let index = count + $0.index
 //      indexes.append(count + $0.index)
       spot.configureItem(index, usesViewSize: true)
-//      spot.prepareItem($0.element, index: count + $0.index, cached: &cached)
     }
 
     dispatch { [weak self] in

--- a/Sources/Mac/Extensions/Listable+Mac.swift
+++ b/Sources/Mac/Extensions/Listable+Mac.swift
@@ -16,40 +16,6 @@ extension Listable {
     }
   }
 
-  public func prepare() {
-    var cached: View?
-    for (index, item) in component.items.enumerate() {
-      prepareItem(item, index: index, cached: &cached)
-    }
-    cached = nil
-  }
-
-  public func prepareItem(item: ViewModel, index: Int, inout cached: View?) {
-    cachedViewFor(item, cache: &cached)
-
-    component.items[index].index = index
-
-    guard let view = cached as? SpotConfigurable else { return }
-
-    view.configure(&component.items[index])
-
-    if component.items[index].size.height == 0.0 {
-      component.items[index].size.height = view.size.height
-    }
-
-    if component.items[index].size.width == 0.0 {
-      component.items[index].size.width = view.size.width
-    }
-  }
-
-  func cachedViewFor(item: ViewModel, inout cache: View?) {
-    let reuseIdentifer = item.kind.isPresent ? item.kind : component.kind
-    let componentClass = self.dynamicType.views.storage[reuseIdentifer] ?? self.dynamicType.defaultView
-
-    if cache?.isKindOfClass(componentClass) == false { cache = nil }
-    if cache == nil { cache = componentClass.init() }
-  }
-
   func configureLayout(component: Component) {
     let top: CGFloat = component.meta("insetTop", 0.0)
     let left: CGFloat = component.meta("insetLeft", 0.0)

--- a/Sources/Mac/Library/CollectionAdapter.swift
+++ b/Sources/Mac/Library/CollectionAdapter.swift
@@ -193,7 +193,7 @@ extension CollectionAdapter: NSCollectionViewDataSource {
   }
 
   public func collectionView(collectionView: NSCollectionView, itemForRepresentedObjectAtIndexPath indexPath: NSIndexPath) -> NSCollectionViewItem {
-    let reuseIdentifier = spot.reuseIdentifierForItem(indexPath.item)
+    let reuseIdentifier = spot.identifier(indexPath.item)
     let item = collectionView.makeItemWithIdentifier(reuseIdentifier, forIndexPath: indexPath)
 
     (item as? SpotConfigurable)?.configure(&spot.component.items[indexPath.item])

--- a/Sources/Mac/Library/GridRegistry.swift
+++ b/Sources/Mac/Library/GridRegistry.swift
@@ -3,15 +3,31 @@ import Brick
 
 /// A view registry that is used internally when resolving kind to the corresponding spot.
 public struct GridRegistry {
+
+  public enum Item {
+    case classType(NSCollectionViewItem.Type)
+    case nib(Nib)
+  }
+
   /// A Key-value dictionary of registred types
-  var storage = [String : NSCollectionViewItem.Type]()
+  var storage = [String : Item]()
+
+  var defaultItem: Item? {
+    didSet {
+      storage[defaultIdentifier] = defaultItem
+    }
+  }
+
+  var defaultIdentifier: String {
+    return String(defaultItem)
+  }
 
   /**
    A subscripting method for getting a value from storage using a StringConvertible key
 
    - Returns: An optional UIView type
    */
-  public subscript(key: StringConvertible) -> NSCollectionViewItem.Type? {
+  public subscript(key: StringConvertible) -> Item? {
     get {
       return storage[key.string]
     }

--- a/Sources/Mac/Spots/CarouselSpot.swift
+++ b/Sources/Mac/Spots/CarouselSpot.swift
@@ -114,7 +114,7 @@ public class CarouselSpot: NSObject, Gridable {
     self.init(component: Component(stateCache.load()))
     self.stateCache = stateCache
 
-    prepare()
+    registerAndPrepare()
   }
 
   deinit {

--- a/Sources/Mac/Spots/CarouselSpot.swift
+++ b/Sources/Mac/Spots/CarouselSpot.swift
@@ -30,7 +30,7 @@ public class CarouselSpot: NSObject, Gridable {
     public static var minimumLineSpacing: CGFloat = 0.0
   }
 
-  public static var views = ViewRegistry()
+  public static var views = Registry()
   public static var grids = GridRegistry()
   public static var configure: ((view: NSCollectionView) -> Void)?
   public static var defaultGrid: NSCollectionViewItem.Type = NSCollectionViewItem.self

--- a/Sources/Mac/Spots/GridSpot.swift
+++ b/Sources/Mac/Spots/GridSpot.swift
@@ -43,7 +43,7 @@ public class GridSpot: NSObject, Gridable {
     public static var sectionInsetBottom: CGFloat = 0.0
   }
 
-  public static var views = ViewRegistry()
+  public static var views = Registry()
   public static var grids = GridRegistry()
   public static var configure: ((view: NSCollectionView) -> Void)?
   public static var defaultView: View.Type = NSView.self

--- a/Sources/Mac/Spots/GridSpot.swift
+++ b/Sources/Mac/Spots/GridSpot.swift
@@ -99,6 +99,7 @@ public class GridSpot: NSObject, Gridable {
     self.component = component
     self.layout = GridSpot.setupLayout(component)
     super.init()
+    registerAndPrepare()
     setupCollectionView()
     scrollView.addSubview(titleView)
     scrollView.addSubview(lineView)

--- a/Sources/Mac/Spots/ListSpot.swift
+++ b/Sources/Mac/Spots/ListSpot.swift
@@ -29,7 +29,7 @@ public class ListSpot: NSObject, Listable {
     public static var contentInsetsRight: CGFloat = 0.0
   }
 
-  public static var views = ViewRegistry()
+  public static var views = Registry()
   public static var configure: ((view: NSTableView) -> Void)?
   public static var defaultView: View.Type = ListSpotItem.self
   public static var defaultKind: StringConvertible = Component.Kind.List.string

--- a/Sources/Mac/Spots/ListSpot.swift
+++ b/Sources/Mac/Spots/ListSpot.swift
@@ -179,8 +179,7 @@ public class ListSpot: NSObject, Listable {
   public func register() {
     for (identifier, item) in self.dynamicType.views.storage {
       switch item {
-      case .classType(let classType):
-        break
+      case .classType(let classType): break
       case .nib(let nib):
         self.tableView.registerNib(nib, forIdentifier: identifier)
       }

--- a/Sources/Mac/Spots/ListSpot.swift
+++ b/Sources/Mac/Spots/ListSpot.swift
@@ -175,4 +175,15 @@ public class ListSpot: NSObject, Listable {
     lineView.frame.origin.x = component.meta(Key.titleLeftInset, Default.titleLeftInset)
     lineView.frame.origin.y = titleView.frame.maxY + 8
   }
+
+  public func register() {
+    for (identifier, item) in self.dynamicType.views.storage {
+      switch item {
+      case .classType(let classType):
+        break
+      case .nib(let nib):
+        self.tableView.registerNib(nib, forIdentifier: identifier)
+      }
+    }
+  }
 }

--- a/Sources/Shared/Library/Gridable.swift
+++ b/Sources/Shared/Library/Gridable.swift
@@ -23,7 +23,7 @@ public protocol Gridable: Spotable {
   func sizeForItemAt(indexPath: NSIndexPath) -> CGSize
 
   #if os(OSX)
-  static var grids: GridRegistry { get }
+  static var grids: GridRegistry { get set }
   static var defaultGrid: NSCollectionViewItem.Type { get }
   #endif
 }

--- a/Sources/Shared/Library/Gridable.swift
+++ b/Sources/Shared/Library/Gridable.swift
@@ -1,0 +1,82 @@
+#if os(OSX)
+  import Cocoa
+#else
+  import UIKit
+#endif
+import Sugar
+import Brick
+
+/// Gridable is protocol for Spots that are based on UICollectionView
+public protocol Gridable: Spotable {
+
+  /// The layout object used to initialize the collection spot controller.
+  var layout: CollectionLayout { get }
+  /// The collection view object managed by this gridable object.
+  var collectionView: CollectionView { get }
+
+  /**
+   Asks the data source for the size of an item in a particular location.
+
+   - Parameter indexPath: The index path of the
+   - Returns: Size of the object at index path as CGSize
+   */
+  func sizeForItemAt(indexPath: NSIndexPath) -> CGSize
+
+  #if os(OSX)
+  static var grids: GridRegistry { get }
+  static var defaultGrid: NSCollectionViewItem.Type { get }
+  #endif
+}
+
+/// A Spotable extension for Gridable objects
+public extension Spotable where Self : Gridable {
+
+  /**
+   - Returns: UIScrollView: Returns a UICollectionView as a UIScrollView
+   */
+   #if os(OSX)
+  public func render() -> CollectionView {
+    return collectionView
+  }
+  #else
+  public func render() -> ScrollView {
+  return collectionView
+  }
+  #endif
+
+  /**
+   - Parameter size: A CGSize to set the size of the collection view
+   */
+  public func setup(size: CGSize) {
+    collectionView.frame.size = size
+    #if os(OSX)
+      #else
+      GridSpot.configure?(view: collectionView, layout: layout)
+    #endif
+  }
+
+  /**
+   - Parameter size: A CGSize to set the width and height of the collection view
+   */
+  public func layout(size: CGSize) {
+    layout.invalidateLayout()
+    collectionView.frame.size.width = size.width
+    guard let componentSize = component.size else { return }
+    collectionView.frame.size.height = componentSize.height
+  }
+
+  public func prepareItems() {
+    component.items.enumerate().forEach { (index: Int, _) in
+      configureItem(index, usesViewSize: true)
+      if component.span > 0 {
+        #if os(OSX)
+          if let layout = layout as? NSCollectionViewFlowLayout where component.span > 0 {
+            component.items[index].size.width = collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
+          }
+        #else
+          component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
+        #endif
+      }
+    }
+  }
+}

--- a/Sources/Shared/Library/Registry.swift
+++ b/Sources/Shared/Library/Registry.swift
@@ -58,7 +58,10 @@ public class Registry {
     case .classType(let classType):
       view = classType.init()
     case .nib(let nib):
+      #if os(OSX)
+      #else
       view = nib.instantiateWithOwner(nil, options: nil).first as? View
+      #endif
     }
 
     if let view = view {

--- a/Sources/Shared/Library/Registry.swift
+++ b/Sources/Shared/Library/Registry.swift
@@ -52,7 +52,7 @@ public class Registry {
       return view
     }
 
-    let view: View?
+    var view: View? = nil
 
     switch item {
     case .classType(let classType):

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -283,7 +283,7 @@ public extension Spotable {
 
   func identifier(indexPath: NSIndexPath) -> String {
     #if os(OSX)
-      return identifier(index: indexPath.item)
+      return identifier(indexPath.item)
     #else
       return identifier(indexPath.row)
     #endif

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -80,6 +80,7 @@ public extension SpotsProtocol {
 
           if spotsLeft == 0 {
             completion?()
+            self?.spotsScrollView.forceUpdate = true
           }
         }
       }
@@ -118,6 +119,7 @@ public extension SpotsProtocol {
       weakSelf.setupSpots(animated)
 
       closure?()
+      self?.spotsScrollView.forceUpdate = true
     }
   }
 
@@ -140,6 +142,7 @@ public extension SpotsProtocol {
       weakSelf.setupSpots(animated)
 
       closure?()
+      self?.spotsScrollView.forceUpdate = true
     }
   }
 
@@ -149,7 +152,10 @@ public extension SpotsProtocol {
    - Parameter closure: A transform closure to perform the proper modification to the target spot before updating the internals
    */
   public func update(spotAtIndex index: Int = 0, withAnimation animation: SpotsAnimation = .Automatic, withCompletion completion: Completion = nil, @noescape _ closure: (spot: Spotable) -> Void) {
-    guard let spot = spot(index, Spotable.self) else { completion?(); return }
+    guard let spot = spot(index, Spotable.self) else {
+      completion?()
+      self.spotsScrollView.forceUpdate = true
+      return }
     closure(spot: spot)
     spot.refreshIndexes()
     spot.registerAndPrepare() // FIXME: Why call again?
@@ -159,6 +165,7 @@ public extension SpotsProtocol {
 
       weakSelf.spot(index, Spotable.self)?.reload(nil, withAnimation: animation) {
         completion?()
+        weakSelf.spotsScrollView.forceUpdate = true
       }
     }
   }
@@ -171,11 +178,13 @@ public extension SpotsProtocol {
   public func updateIfNeeded(spotAtIndex index: Int = 0, items: [ViewModel], withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     guard let spot = spot(index, Spotable.self) where !(spot.items == items) else {
       completion?()
+      self.spotsScrollView.forceUpdate = true
       return
     }
 
     update(spotAtIndex: index, withAnimation: animation, withCompletion: completion, {
       $0.items = items
+      self.spotsScrollView.forceUpdate = true
     })
   }
 
@@ -187,6 +196,7 @@ public extension SpotsProtocol {
   public func append(item: ViewModel, spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(item, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -199,6 +209,7 @@ public extension SpotsProtocol {
   public func append(items: [ViewModel], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(items, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -211,6 +222,7 @@ public extension SpotsProtocol {
   public func prepend(items: [ViewModel], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.prepend(items, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -224,6 +236,7 @@ public extension SpotsProtocol {
   public func insert(item: ViewModel, index: Int = 0, spotIndex: Int, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.insert(item, index: index, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -239,11 +252,13 @@ public extension SpotsProtocol {
       else {
         spot(spotIndex, Spotable.self)?.refreshIndexes()
         completion?()
+        self.spotsScrollView.forceUpdate = true
         return
     }
 
     spot(spotIndex, Spotable.self)?.update(item, index: index, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -257,6 +272,7 @@ public extension SpotsProtocol {
   public func update(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.reload(indexes, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -282,6 +298,7 @@ public extension SpotsProtocol {
   public func delete(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.delete(indexes, withAnimation: animation) {
       completion?()
+      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -119,7 +119,7 @@ public extension SpotsProtocol {
       weakSelf.setupSpots(animated)
 
       closure?()
-      self?.spotsScrollView.forceUpdate = true
+      weakSelf.spotsScrollView.forceUpdate = true
     }
   }
 
@@ -142,7 +142,7 @@ public extension SpotsProtocol {
       weakSelf.setupSpots(animated)
 
       closure?()
-      self?.spotsScrollView.forceUpdate = true
+      weakSelf.spotsScrollView.forceUpdate = true
     }
   }
 

--- a/Sources/Shared/Library/TypeAlias.swift
+++ b/Sources/Shared/Library/TypeAlias.swift
@@ -13,10 +13,14 @@ public typealias Completion = (() -> Void)?
   public typealias TableView = NSTableView
   public typealias CollectionView = NSCollectionView
   public typealias Nib = NSNib
+  public typealias CollectionLayout = NSCollectionViewLayout
+  public typealias EdgeInsets = NSEdgeInsets
 #else
   public typealias View = UIView
   public typealias ScrollView = UIScrollView
   public typealias TableView = UITableView
   public typealias CollectionView = UICollectionView
   public typealias Nib = UINib
+  public typealias CollectionLayout = UICollectionViewFlowLayout
+  public typealias EdgeInsets = UIEdgeInsets
 #endif

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -162,6 +162,7 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
     setupSpots()
 
     SpotsController.configure?(container: spotsScrollView)
+    spotsScrollView.forceUpdate = true
   }
 
   /**

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -183,6 +183,7 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
 
     spotsScrollView.insertSubview(refreshControl, atIndex: 0)
 #endif
+    spotsScrollView.forceUpdate = true
   }
 
   /**
@@ -212,6 +213,7 @@ public class SpotsController: UIViewController, SpotsProtocol, UIScrollViewDeleg
         height: ceil(spot.render().height))
       animated?(view: spot.render())
     }
+    spotsScrollView.forceUpdate = true
   }
 
   #if os(iOS)

--- a/Sources/iOS/Extensions/Gridable+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+iOS.swift
@@ -1,26 +1,6 @@
 import UIKit
-import Sugar
-import Brick
 
-/// Gridable is protocol for Spots that are based on UICollectionView
-public protocol Gridable: Spotable {
-
-  /// The layout object used to initialize the collection spot controller.
-  var layout: UICollectionViewFlowLayout { get }
-  /// The collection view object managed by this gridable object.
-  var collectionView: UICollectionView { get }
-
-  /**
-   Asks the data source for the size of an item in a particular location.
-
-   - Parameter indexPath: The index path of the
-   - Returns: Size of the object at index path as CGSize
-   */
-  func sizeForItemAt(indexPath: NSIndexPath) -> CGSize
-}
-
-/// A Spotable extension for Gridable objects
-public extension Spotable where Self : Gridable {
+extension Gridable {
 
   /**
    Initializes a Gridable container and configures the Spot with the provided component and optional layout properties.
@@ -35,33 +15,8 @@ public extension Spotable where Self : Gridable {
   public init(_ component: Component, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0) {
     self.init(component: component)
 
-    layout.sectionInset = UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
+    layout.sectionInset = EdgeInsets(top: top, left: left, bottom: bottom, right: right)
     layout.minimumInteritemSpacing = itemSpacing
-  }
-
-  /**
-   - Returns: UIScrollView: Returns a UICollectionView as a UIScrollView
-   */
-  public func render() -> UIScrollView {
-    return collectionView
-  }
-
-  /**
-   - Parameter size: A CGSize to set the size of the collection view
-   */
-  public func setup(size: CGSize) {
-    collectionView.frame.size = size
-    GridSpot.configure?(view: collectionView, layout: layout)
-  }
-
-  /**
-   - Parameter size: A CGSize to set the width and height of the collection view
-   */
-  public func layout(size: CGSize) {
-    collectionView.collectionViewLayout.invalidateLayout()
-    collectionView.width = size.width
-    guard let componentSize = component.size else { return }
-    collectionView.height = componentSize.height
   }
 
   /**
@@ -72,7 +27,7 @@ public extension Spotable where Self : Gridable {
    */
   public func sizeForItemAt(indexPath: NSIndexPath) -> CGSize {
     if component.span > 0 {
-      component.items[indexPath.item].size.width = collectionView.width / CGFloat(component.span) - layout.minimumInteritemSpacing
+      component.items[indexPath.item].size.width = collectionView.frame.width / CGFloat(component.span) - layout.minimumInteritemSpacing
     }
 
     let width = (item(indexPath)?.size.width ?? 0) - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
@@ -85,6 +40,16 @@ public extension Spotable where Self : Gridable {
       width: floor(width),
       height: ceil(height)
     )
+  }
+
+  /**
+   - Parameter size: A CGSize to set the width and height of the collection view
+   */
+  public func layout(size: CGSize) {
+    collectionView.collectionViewLayout.invalidateLayout()
+    collectionView.frame.size.width = size.width
+    guard let componentSize = component.size else { return }
+    collectionView.frame.size.height = componentSize.height
   }
 
   public func prepareItems() {

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -149,9 +149,26 @@ extension ListAdapter {
    - Parameter completion: A completion closure that is executed in the main queue when the view model has been updated
    */
   public func update(item: ViewModel, index: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
+    let oldItem = spot.items[index]
+
     spot.items[index] = item
     spot.configureItem(index)
-    spot.tableView.reload([index], section: 0, animation: animation.tableViewAnimation)
+
+    let newItem = spot.items[index]
+    let indexPath = NSIndexPath(forRow: index, inSection: 0)
+
+    if newItem.kind != oldItem.kind || newItem.size.height != oldItem.size.height {
+      if let cell = spot.tableView.cellForRowAtIndexPath(indexPath) as? SpotConfigurable {
+        spot.tableView.beginUpdates()
+        cell.configure(&spot.items[index])
+        spot.tableView.endUpdates()
+      } else {
+        spot.tableView.reload([index], section: 0, animation: animation.tableViewAnimation)
+      }
+    } else if let cell = spot.tableView.cellForRowAtIndexPath(indexPath) as? SpotConfigurable {
+      cell.configure(&spot.items[index])
+    }
+
     completion?()
   }
 

--- a/Spots.podspec
+++ b/Spots.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Spots"
   s.summary          = "Spots is a view controller framework that makes your setup and future development blazingly fast."
-  s.version          = "2.1.2"
+  s.version          = "3.0.0"
   s.homepage         = "https://github.com/hyperoslo/Spots"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		BD38DC601D1854D700094941 /* UICollectionView+Indexes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC321D1854D700094941 /* UICollectionView+Indexes.swift */; };
 		BD38DC621D1854D700094941 /* UITableView+Indexes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC331D1854D700094941 /* UITableView+Indexes.swift */; };
 		BD38DC641D1854D700094941 /* CollectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC351D1854D700094941 /* CollectionAdapter.swift */; };
-		BD38DC661D1854D700094941 /* Gridable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC361D1854D700094941 /* Gridable.swift */; };
 		BD38DC681D1854D700094941 /* Listable+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC371D1854D700094941 /* Listable+iOS.swift */; };
 		BD38DC7C1D1854D700094941 /* CarouselSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC431D1854D700094941 /* CarouselSpot.swift */; };
 		BD38DC7E1D1854D700094941 /* CarouselSpotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC441D1854D700094941 /* CarouselSpotCell.swift */; };
@@ -36,6 +35,9 @@
 		BD38DC9F1D18550900094941 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD38DC5B1D1854D700094941 /* Component.swift */; };
 		BD48BEC91C459B4800317D76 /* ViewSpotSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48BEC81C459B4800317D76 /* ViewSpotSpec.swift */; };
 		BD48BECB1C459D2A00317D76 /* CarouselSpotSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48BECA1C459D2A00317D76 /* CarouselSpotSpec.swift */; };
+		BD4AA20A1D5E6E6D00DD0208 /* Gridable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4AA2091D5E6E6D00DD0208 /* Gridable.swift */; };
+		BD4AA20B1D5E6E6D00DD0208 /* Gridable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4AA2091D5E6E6D00DD0208 /* Gridable.swift */; };
+		BD4AA20D1D5E6FD000DD0208 /* Gridable+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4AA20C1D5E6FD000DD0208 /* Gridable+iOS.swift */; };
 		BD6A1F2B1D2B8C5200E85FD3 /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6A1F151D2B8C5200E85FD3 /* SpotsController.swift */; };
 		BD6A1F2C1D2B8C5200E85FD3 /* Listable+Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6A1F171D2B8C5200E85FD3 /* Listable+Mac.swift */; };
 		BD6A1F2D1D2B8C5200E85FD3 /* ListAdapter+Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6A1F181D2B8C5200E85FD3 /* ListAdapter+Mac.swift */; };
@@ -127,7 +129,6 @@
 		BD38DC321D1854D700094941 /* UICollectionView+Indexes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Indexes.swift"; sourceTree = "<group>"; };
 		BD38DC331D1854D700094941 /* UITableView+Indexes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Indexes.swift"; sourceTree = "<group>"; };
 		BD38DC351D1854D700094941 /* CollectionAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionAdapter.swift; sourceTree = "<group>"; };
-		BD38DC361D1854D700094941 /* Gridable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Gridable.swift; sourceTree = "<group>"; };
 		BD38DC371D1854D700094941 /* Listable+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Listable+iOS.swift"; sourceTree = "<group>"; };
 		BD38DC431D1854D700094941 /* CarouselSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpot.swift; sourceTree = "<group>"; };
 		BD38DC441D1854D700094941 /* CarouselSpotCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpotCell.swift; sourceTree = "<group>"; };
@@ -144,6 +145,8 @@
 		BD38DC5B1D1854D700094941 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD48BEC81C459B4800317D76 /* ViewSpotSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewSpotSpec.swift; sourceTree = "<group>"; };
 		BD48BECA1C459D2A00317D76 /* CarouselSpotSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpotSpec.swift; sourceTree = "<group>"; };
+		BD4AA2091D5E6E6D00DD0208 /* Gridable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Gridable.swift; sourceTree = "<group>"; };
+		BD4AA20C1D5E6FD000DD0208 /* Gridable+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Gridable+iOS.swift"; sourceTree = "<group>"; };
 		BD6A1F151D2B8C5200E85FD3 /* SpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsController.swift; sourceTree = "<group>"; };
 		BD6A1F171D2B8C5200E85FD3 /* Listable+Mac.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Listable+Mac.swift"; sourceTree = "<group>"; };
 		BD6A1F181D2B8C5200E85FD3 /* ListAdapter+Mac.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ListAdapter+Mac.swift"; sourceTree = "<group>"; };
@@ -286,6 +289,7 @@
 				BD38DC321D1854D700094941 /* UICollectionView+Indexes.swift */,
 				BD38DC331D1854D700094941 /* UITableView+Indexes.swift */,
 				BDE8FBC21D1BEC4300C5A212 /* ListAdapter+iOS.swift */,
+				BD4AA20C1D5E6FD000DD0208 /* Gridable+iOS.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -294,7 +298,6 @@
 			isa = PBXGroup;
 			children = (
 				BD38DC351D1854D700094941 /* CollectionAdapter.swift */,
-				BD38DC361D1854D700094941 /* Gridable.swift */,
 				BD38DC371D1854D700094941 /* Listable+iOS.swift */,
 			);
 			path = Library;
@@ -359,6 +362,7 @@
 		BD38DC521D1854D700094941 /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				BD4AA2091D5E6E6D00DD0208 /* Gridable.swift */,
 				BD980E281D190A26007284DD /* Viewable.swift */,
 				BD980E211D1904E0007284DD /* SpotsProtocol.swift */,
 				BD980E1C1D18A8C2007284DD /* SpotsDelegates.swift */,
@@ -864,6 +868,7 @@
 				BD38DC601D1854D700094941 /* UICollectionView+Indexes.swift in Sources */,
 				BD980DEA1D18A5FA007284DD /* Parser.swift in Sources */,
 				BD38DC921D1854D700094941 /* SpotConfigurable.swift in Sources */,
+				BD4AA20A1D5E6E6D00DD0208 /* Gridable.swift in Sources */,
 				BD980DF01D18A726007284DD /* SpotFactory.swift in Sources */,
 				BD38DC981D1854D700094941 /* Component.swift in Sources */,
 				BD980DED1D18A6ED007284DD /* Spotable.swift in Sources */,
@@ -871,7 +876,6 @@
 				BDE8FBBA1D1BD26100C5A212 /* SpotAdapter.swift in Sources */,
 				BDE8FBC31D1BEC4300C5A212 /* ListAdapter+iOS.swift in Sources */,
 				BD38DC801D1854D700094941 /* GridSpot.swift in Sources */,
-				BD38DC661D1854D700094941 /* Gridable.swift in Sources */,
 				BD980E261D1909E3007284DD /* ViewSpot.swift in Sources */,
 				BD38DC941D1854D700094941 /* SpotCache.swift in Sources */,
 				BDE8FBCA1D1BF11500C5A212 /* Listable.swift in Sources */,
@@ -879,6 +883,7 @@
 				BD980E221D1904E0007284DD /* SpotsProtocol.swift in Sources */,
 				BD980E1D1D18A8C2007284DD /* SpotsDelegates.swift in Sources */,
 				BD38DC5C1D1854D700094941 /* SpotsController+UIScrollViewDelegate.swift in Sources */,
+				BD4AA20D1D5E6FD000DD0208 /* Gridable+iOS.swift in Sources */,
 				BD38DC821D1854D700094941 /* GridSpotCell.swift in Sources */,
 				BD38DC5E1D1854D700094941 /* SpotsController.swift in Sources */,
 				BD38DC681D1854D700094941 /* Listable+iOS.swift in Sources */,
@@ -939,6 +944,7 @@
 				BD6A1F2E1D2B8C5200E85FD3 /* NSCollectionView+Indexes.swift in Sources */,
 				BD6A1F2C1D2B8C5200E85FD3 /* Listable+Mac.swift in Sources */,
 				BD980E231D1904E0007284DD /* SpotsProtocol.swift in Sources */,
+				BD4AA20B1D5E6E6D00DD0208 /* Gridable.swift in Sources */,
 				BD980DEB1D18A5FA007284DD /* Parser.swift in Sources */,
 				D259D0F91D5BD1930003ACFA /* Registry.swift in Sources */,
 			);


### PR DESCRIPTION
This PR fixes the mac implementation and addresses som issue in the Spotify for Mac demo.

Also, a minor fix for the Apple News demo.

Core changes are that we reintroduce the `forceUpdate` when performing mutating processes.

This PR also adds soft updates for when updating an item, Spots will not take three different actions depending on the change that took place.

- If the `kind` changes, it will call `reloadRowsAtIndexPaths`
- If the height changes, it will try to run `configure` on the cell in a `UITableView` update context.
- If the above doesn't happened it will fall back to use `reloadRowsAtIndexPaths`.

This should fix a lot of flickering and wonky screen updates when mutating the state of the cells.