### PR TITLE
Improve/caching

### DIFF
--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -55,9 +55,11 @@ public protocol SpotsProtocol: class {
 public extension SpotsProtocol {
 
   public var dictionary: JSONDictionary {
-    get {
-      return ["components" : spots.map { $0.component.dictionary }]
-    }
+    get { return dictionary() }
+  }
+
+  public func dictionary(amountOfItems: Int? = nil) -> JSONDictionary {
+    return ["components" : spots.map { $0.component.dictionary(amountOfItems) }]
   }
 
   /**

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -346,7 +346,7 @@ public extension SpotsProtocol {
   /**
    Caches the current state of the spot controller
    */
-  public func cache(items: Int? = nil) {
+  public func cache(items items: Int? = nil) {
     #if DEVMODE
       liveEditing(stateCache)
     #endif

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -346,12 +346,12 @@ public extension SpotsProtocol {
   /**
    Caches the current state of the spot controller
    */
-  public func cache() {
+  public func cache(items: Int? = nil) {
     #if DEVMODE
       liveEditing(stateCache)
     #endif
 
-    stateCache?.save(dictionary)
+    stateCache?.save(dictionary(items))
   }
 
   /**

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -72,8 +72,8 @@ public struct Component: Mappable {
 
     let JSONItems: [JSONDictionary]
 
-    if let amountOfItems = amountOfItems where amountOfItems <= items.count {
-      JSONItems = Array(items[0..<amountOfItems]).map { $0.dictionary }
+    if let amountOfItems = amountOfItems {
+      JSONItems = Array(items[0..<min(amountOfItems, items.count)]).map { $0.dictionary }
     } else {
       JSONItems = items.map { $0.dictionary }
     }

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -59,6 +59,10 @@ public struct Component: Mappable {
 
   /// A dictionary representation of the component
   public var dictionary: JSONDictionary {
+    return dictionary()
+  }
+
+  public func dictionary(amountOfItems: Int? = nil) -> JSONDictionary {
     var width: CGFloat = 0
     var height: CGFloat = 0
     if let size = size {
@@ -66,7 +70,14 @@ public struct Component: Mappable {
       height = size.height
     }
 
-    let JSONItems: [JSONDictionary] = items.map { $0.dictionary }
+    let JSONItems: [JSONDictionary]
+
+    if let amountOfItems = amountOfItems {
+      JSONItems = Array(items[0..<amountOfItems]).map { $0.dictionary }
+    } else {
+      JSONItems = items.map { $0.dictionary }
+    }
+
     let JSONComponents: JSONDictionary = [
       Key.Index.string : index,
       Key.Title.string : title,

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -72,7 +72,7 @@ public struct Component: Mappable {
 
     let JSONItems: [JSONDictionary]
 
-    if let amountOfItems = amountOfItems {
+    if let amountOfItems = amountOfItems where amountOfItems <= items.count {
       JSONItems = Array(items[0..<amountOfItems]).map { $0.dictionary }
     } else {
       JSONItems = items.map { $0.dictionary }


### PR DESCRIPTION
This PR adds some extra functionality when it comes to caching in Spots. Now you can decide the amount of items that you want to cache per Spotable item.

So when calling `cache()` you can now give it a number like;

```swift
cache(items: 20)
```

What this means is that it will save `20` items per `Spotable` item in the controller.