### PR TITLE
Set layer frame when updating

### DIFF
--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -166,8 +166,7 @@ public extension SpotsProtocol {
     dispatch { [weak self] in
       guard let weakSelf = self else { return }
 
-      #if os(OSX)
-      #else
+      #if !os(OSX)
       if animation != .None { spot.render().layer.frame.size.height = spotHeight }
       #endif
 

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -161,9 +161,15 @@ public extension SpotsProtocol {
     closure(spot: spot)
     spot.refreshIndexes()
     spot.registerAndPrepare()
+    let spotHeight = spot.spotHeight()
 
     dispatch { [weak self] in
       guard let weakSelf = self else { return }
+
+      #if os(OSX)
+      #else
+      if animation != .None { spot.render().layer.frame.size.height = spotHeight }
+      #endif
 
       weakSelf.spot(index, Spotable.self)?.reload(nil, withAnimation: animation) {
         completion?()


### PR DESCRIPTION
This PR fixes and issue where you don't get any animations when mutating an empty data source. This has to do with the frame not being set until the data source has been updated so all animations to the UI components are performed without them being visible on screen. This should be fixed now by using the `spotHeight()` to set the value of the frame before adding the items to screen.