### PR TITLE
Introduce reloadIfNeeded with components

### DIFF
--- a/Sources/Mac/Controllers/SpotsController.swift
+++ b/Sources/Mac/Controllers/SpotsController.swift
@@ -218,8 +218,7 @@ public class SpotsController: NSViewController, SpotsProtocol {
     spots[index].component.index = index
     spot.registerAndPrepare()
     spotsScrollView.spotsContentView.addSubview(spot.render())
-    spot.setup(CGSize(width: view.frame.width,
-      height: height))
+    spot.setup(CGSize(width: view.frame.width, height: height))
     spot.component.size = CGSize(
       width: view.frame.width,
       height: ceil(spot.render().frame.height))

--- a/Sources/Mac/Controllers/SpotsController.swift
+++ b/Sources/Mac/Controllers/SpotsController.swift
@@ -199,25 +199,30 @@ public class SpotsController: NSViewController, SpotsProtocol {
    - Parameter animated: An optional animation closure that runs when a spot is being rendered
    */
   public func setupSpots(animated: ((view: View) -> Void)? = nil) {
+    compositeSpots = [:]
     spots.enumerate().forEach { index, spot in
-      #if !os(OSX)
-        spot.spotsCompositeDelegate = self
-      #endif
-      var height = spot.spotHeight()
-      if let componentSize = spot.component.size where componentSize.height > height {
-        height = componentSize.height
-      }
-
-      spots[index].component.index = index
-      spot.registerAndPrepare()
-      spotsScrollView.spotsContentView.addSubview(spot.render())
-      spot.setup(CGSize(width: view.frame.width,
-        height: height))
-      spot.component.size = CGSize(
-        width: view.frame.width,
-        height: ceil(spot.render().frame.height))
+      setupSpot(index, spot: spot)
       animated?(view: spot.render())
     }
+  }
+
+  public func setupSpot(index: Int, spot: Spotable) {
+    #if !os(OSX)
+      spot.spotsCompositeDelegate = self
+    #endif
+    var height = spot.spotHeight()
+    if let componentSize = spot.component.size where componentSize.height > height {
+      height = componentSize.height
+    }
+
+    spots[index].component.index = index
+    spot.registerAndPrepare()
+    spotsScrollView.spotsContentView.addSubview(spot.render())
+    spot.setup(CGSize(width: view.frame.width,
+      height: height))
+    spot.component.size = CGSize(
+      width: view.frame.width,
+      height: ceil(spot.render().frame.height))
   }
 
   public override func viewDidLayout() {

--- a/Sources/Mac/Library/CollectionViewLeftLayout.swift
+++ b/Sources/Mac/Library/CollectionViewLeftLayout.swift
@@ -13,7 +13,7 @@ class CollectionViewLeftLayout: NSCollectionViewFlowLayout {
     var x: CGFloat = sectionInset.left
     var y: CGFloat = 0
     for attributes in defaultAttributes {
-      var attributes = attributes
+      let attributes = attributes
 
       if attributes.frame.origin.y != y {
         x = sectionInset.left

--- a/Sources/Shared/Library/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Library/Extensions/SpotsProtocol+LiveEditing.swift
@@ -40,9 +40,12 @@ import Cache
                 (gridable.layout as? GridableLayout)?.yOffset = gridable.render().frame.origin.y
               }
             }
+            print("Spots reloaded: \(self.spots.count)")
           }
-        } catch let error {
+        } catch let error as NSError {
           self.source = nil
+
+          print("Error: \(error.localizedDescription)")
           self.liveEditing(self.stateCache)
         }
       })
@@ -60,7 +63,9 @@ import Cache
 
       let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory,
                                                       NSSearchPathDomainMask.UserDomainMask, true)
-      NSLog("-----[\(stateCache.key)]-----\n\nfile://\(stateCache.path)\n\n")
+      print("🎍 SPOTS: Caching...")
+      print("Cache key: \(stateCache.key)")
+      print("File path: file://\(stateCache.path)\n")
       delay(0.5) { self.monitor(stateCache.path) }
     }
   }

--- a/Sources/Shared/Library/Parser.swift
+++ b/Sources/Shared/Library/Parser.swift
@@ -11,6 +11,7 @@ public struct Parser {
    */
   public static func parse(json: JSONDictionary, key: String = "components") -> [Spotable] {
     var components: [Component] = parse(json, key: key)
+
     for (index, _) in components.enumerate() {
       components[index].index = index
     }

--- a/Sources/Shared/Library/Parser.swift
+++ b/Sources/Shared/Library/Parser.swift
@@ -10,11 +10,18 @@ public struct Parser {
    - Returns: A collection of spotable objects
    */
   public static func parse(json: JSONDictionary, key: String = "components") -> [Spotable] {
+    var components: [Component] = parse(json, key: key)
+    for (index, component) in components.enumerate() {
+      components[index].index = index
+    }
+
+    return components.map { SpotFactory.resolve($0) }
+  }
+
+  public static func parse(json: JSONDictionary, key: String = "components") -> [Component] {
     guard let components = json[key] as? JSONArray else { return [] }
 
-    return components.map {
-      SpotFactory.resolve(Component($0))
-    }
+    return components.map { Component($0) }
   }
 
   public static func parse(json: JSONArray?) -> [Spotable] {

--- a/Sources/Shared/Library/Parser.swift
+++ b/Sources/Shared/Library/Parser.swift
@@ -11,7 +11,7 @@ public struct Parser {
    */
   public static func parse(json: JSONDictionary, key: String = "components") -> [Spotable] {
     var components: [Component] = parse(json, key: key)
-    for (index, component) in components.enumerate() {
+    for (index, _) in components.enumerate() {
       components[index].index = index
     }
 

--- a/Sources/Shared/Library/Spotable.swift
+++ b/Sources/Shared/Library/Spotable.swift
@@ -224,10 +224,16 @@ public extension Spotable {
     }
 
     var indexes: [Int]? = nil
+    let oldItems = self.items
     self.items = items
 
-    for (index, _) in items.enumerate() {
-      indexes?.append(index)
+    if items.count == oldItems.count {
+      for (index, item) in items.enumerate() {
+        guard !(item == oldItems[index]) else { continue }
+
+        if indexes == nil { indexes = [Int]() }
+        indexes?.append(index)
+      }
     }
 
     reload(indexes, withAnimation: animation) {

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -230,7 +230,7 @@ public extension SpotsProtocol {
     dispatch { [weak self] in
       guard let weakSelf = self else { closure?(); return }
 
-      let newSpots = Parser.parse(json)
+      let newSpots: [Spotable] = Parser.parse(json)
       let newComponents = newSpots.map { $0.component }
       let oldComponents = weakSelf.spots.map { $0.component }
 

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -43,6 +43,7 @@ public protocol SpotsProtocol: class {
   #endif
 
   func setupSpots(animated: ((view: View) -> Void)?)
+  func setupSpot(index: Int, spot: Spotable)
   func spot<T>(index: Int, _ type: T.Type) -> T?
   func spot(@noescape closure: (index: Int, spot: Spotable) -> Bool) -> Spotable?
 

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -148,11 +148,14 @@ public extension SpotsProtocol {
 
   #if !os(OSX)
   public func reloadIfNeeded(components: [Component], closure: Completion = nil) {
+
+    dispatch(queue: .Interactive) {
+
     let newComponents = components
-    let oldComponents = spots.map { $0.component }
+    let oldComponents = self.spots.map { $0.component }
 
     guard newComponents !== oldComponents else {
-      closure?()
+      dispatch { closure?() }
       return
     }
 
@@ -174,50 +177,53 @@ public extension SpotsProtocol {
       }
     }
 
-    var yOffset: CGFloat = 0.0
-    for (index, change) in changes.enumerate() {
-      switch change {
-      case .Identifier, .Kind, .Span, .Header, .Meta:
-        let spot = SpotFactory.resolve(newComponents[index])
+      dispatch {
+        var yOffset: CGFloat = 0.0
+        for (index, change) in changes.enumerate() {
+          switch change {
+          case .Identifier, .Kind, .Span, .Header, .Meta:
+            let spot = SpotFactory.resolve(newComponents[index])
 
-        for (_, cSpots) in compositeSpots {
-          for (_, spots) in cSpots.enumerate() {
-            for spot in spots.1 {
-              spot.render().removeFromSuperview()
+            for (_, cSpots) in self.compositeSpots {
+              for (_, spots) in cSpots.enumerate() {
+                for spot in spots.1 {
+                  spot.render().removeFromSuperview()
+                }
+              }
             }
+
+            self.spots[index].render().removeFromSuperview()
+            self.spots[index] = spot
+            self.setupSpot(index, spot: spot)
+            self.spotsScrollView.contentView.insertSubview(spot.render(), atIndex: index)
+            (spot as? Gridable)?.layout.yOffset = yOffset
+            yOffset += spot.render().frame.size.height
+          case .New:
+            let spot = SpotFactory.resolve(newComponents[index])
+            self.spots.append(spot)
+            self.setupSpot(index, spot: spot)
+            (spot as? Gridable)?.layout.yOffset = yOffset
+            self.spotsScrollView.contentView.addSubview(spot.render())
+            yOffset += spot.render().frame.size.height
+          case .Removed:
+            self.spots.removeAtIndex(index)
+          case .Items:
+            if let spot = self.spot(index, Spotable.self) {
+              for item in newComponents[index].items {
+                if item.kind == "composite" {
+                  spot.update(item, index: item.index, withAnimation: .None)
+                } else {
+                  spot.update(item, index: item.index, withAnimation: .Automatic)
+                }
+              }
+            }
+          case .None: break
           }
         }
 
-        spots[index].render().removeFromSuperview()
-        spots[index] = spot
-        setupSpot(index, spot: spot)
-        spotsScrollView.contentView.insertSubview(spot.render(), atIndex: index)
-        (spot as? Gridable)?.layout.yOffset = yOffset
-        yOffset += spot.render().frame.size.height
-      case .New:
-        let spot = SpotFactory.resolve(newComponents[index])
-        spots.append(spot)
-        setupSpot(index, spot: spot)
-        (spot as? Gridable)?.layout.yOffset = yOffset
-        spotsScrollView.contentView.addSubview(spot.render())
-        yOffset += spot.render().frame.size.height
-      case .Removed:
-        spots.removeAtIndex(index)
-      case .Items:
-        if let spot = spot(index, Spotable.self) {
-          for item in newComponents[index].items {
-            if item.kind == "composite" {
-              spot.update(item, index: item.index, withAnimation: .None)
-            } else {
-              spot.update(item, index: item.index, withAnimation: .Automatic)
-            }
-          }
-        }
-      case .None: break
+        closure?()
       }
     }
-
-    closure?()
   }
   #endif
 
@@ -266,7 +272,7 @@ public extension SpotsProtocol {
         for (spotIndex, spot) in foundContainer.enumerate() {
           guard let rootContainer = oldComposite[index],
             itemContainer = rootContainer[itemIndex]
-            where spotIndex <= itemContainer.count else { continue }
+            where spotIndex < itemContainer.count else { continue }
 
           spot.render().contentOffset = itemContainer[spotIndex].render().contentOffset
         }

--- a/Sources/Shared/Library/SpotsProtocol.swift
+++ b/Sources/Shared/Library/SpotsProtocol.swift
@@ -146,6 +146,7 @@ public extension SpotsProtocol {
     }
   }
 
+  #if !os(OSX)
   public func reloadIfNeeded(components: [Component], closure: Completion = nil) {
     let newComponents = components
     let oldComponents = spots.map { $0.component }
@@ -218,6 +219,7 @@ public extension SpotsProtocol {
 
     closure?()
   }
+  #endif
 
   /**
    - Parameter json: A JSON dictionary that gets parsed into UI elements

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -179,20 +179,6 @@ public struct Component: Mappable, Equatable {
   }
 
   /**
-   Check if component properties are equal, it excludes items and setting related properties
-
-   - parameter component: A Component used for the comparison
-
-   - returns: Returns true if they are equal
-   */
-  public func equalTo(component component: Component) -> Bool {
-    return kind == component.kind &&
-      identifier == component.identifier &&
-      span == component.span &&
-      header == component.header
-  }
-
-  /**
    Compare two components
 
    - parameter component: A Component used for comparison

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -241,9 +241,12 @@ public func !== (lhs: [Component], rhs: [Component]) -> Bool {
  - Returns: A boolean value, true if both Components are no equal
  */
 public func == (lhs: Component, rhs: Component) -> Bool {
+  guard lhs.identifier == rhs.identifier else { return false }
+
   return lhs.title == rhs.title &&
     lhs.kind == rhs.kind &&
     lhs.span == rhs.span &&
+    lhs.header == rhs.header &&
     (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary) &&
     lhs.items == rhs.items
 }
@@ -255,9 +258,12 @@ public func == (lhs: Component, rhs: Component) -> Bool {
  - Returns: A boolean value, true if both Components are no equal
  */
 public func === (lhs: Component, rhs: Component) -> Bool {
+  guard lhs.identifier == rhs.identifier else { return false }
+
   return lhs.title == rhs.title &&
     lhs.kind == rhs.kind &&
     lhs.span == rhs.span &&
+    lhs.header == rhs.header &&
     (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary) &&
     lhs.items === rhs.items
 }

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -178,6 +178,13 @@ public struct Component: Mappable, Equatable {
     return meta[key] as? T
   }
 
+  /**
+   Check if component properties are equal, it excludes items and setting related properties
+
+   - parameter component: A Component used for the comparison
+
+   - returns: Returns true if they are equal
+   */
   public func equalTo(component component: Component) -> Bool {
     return kind == component.kind &&
       identifier == component.identifier &&
@@ -185,12 +192,25 @@ public struct Component: Mappable, Equatable {
       header == component.header
   }
 
+  /**
+   Compare two components
+
+   - parameter component: A Component used for comparison
+
+   - returns: A ComponentDiff value, see ComponentDiff for values.
+   */
   public func diff(component component: Component) -> ComponentDiff {
+    // Determine if the UI component is the same, used when SpotsController needs to replace the entire UI component
     if kind != component.kind { return .Kind }
+    // Determine if the unqiue identifier for the component changed
     if identifier != component.identifier { return .Identifier }
+    // Determine if the component span layout changed, this can be used to trigger layout related processes
     if span != component.span { return .Span }
+    // Determine if the header for the component has changed
     if header != component.header { return .Kind }
+    // Check if meta data for the component changed, this can be up to the developer to decide what course of action to take.
     if !(meta as NSDictionary).isEqual(component.meta as NSDictionary) { return .Meta }
+    // Check if the items have changed
     if !(items == component.items) { return .Items }
 
     return .None

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -8,6 +8,10 @@ import Tailor
 import Sugar
 import Brick
 
+public enum ComponentDiff {
+  case Identifier, Kind, Span, Header, Meta, Items, New, Removed, None
+}
+
 /// The Component struct is used to configure a Spotable object
 public struct Component: Mappable {
 

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -177,6 +177,24 @@ public struct Component: Mappable, Equatable {
   public func meta<T>(key: String, type: T.Type) -> T? {
     return meta[key] as? T
   }
+
+  public func equalTo(component component: Component) -> Bool {
+    return kind == component.kind &&
+      identifier == component.identifier &&
+      span == component.span &&
+      header == component.header
+  }
+
+  public func diff(component component: Component) -> ComponentDiff {
+    if kind != component.kind { return .Kind }
+    if identifier != component.identifier { return .Identifier }
+    if span != component.span { return .Span }
+    if header != component.header { return .Kind }
+    if !(meta as NSDictionary).isEqual(component.meta as NSDictionary) { return .Meta }
+    if !(items == component.items) { return .Items }
+
+    return .None
+  }
 }
 
 // Compare a collection of view models

--- a/Sources/Shared/Models/Component.swift
+++ b/Sources/Shared/Models/Component.swift
@@ -13,7 +13,7 @@ public enum ComponentDiff {
 }
 
 /// The Component struct is used to configure a Spotable object
-public struct Component: Mappable {
+public struct Component: Mappable, Equatable {
 
   /**
    An enum with all the string keys used in the view model

--- a/Sources/iOS/Controllers/SpotsController.swift
+++ b/Sources/iOS/Controllers/SpotsController.swift
@@ -283,20 +283,23 @@ public class SpotsController: UIViewController, SpotsProtocol, SpotsCompositeDel
     var yOffset: CGFloat = 0.0
     compositeSpots = [:]
     spots.enumerate().forEach { index, spot in
-      spot.spotsCompositeDelegate = self
-      spots[index].component.index = index
-      spot.render().optimize()
+      setupSpot(index, spot: spot)
       spotsScrollView.contentView.addSubview(spot.render())
-      spot.registerAndPrepare()
-      spot.setup(spotsScrollView.frame.size)
-      spot.component.size = CGSize(
-        width: view.width,
-        height: ceil(spot.render().height))
       animated?(view: spot.render())
-
       (spot as? Gridable)?.layout.yOffset = yOffset
       yOffset += spot.render().frame.size.height
     }
+  }
+
+  public func setupSpot(index: Int, spot: Spotable) {
+    spot.spotsCompositeDelegate = self
+    spots[index].component.index = index
+    spot.render().optimize()
+    spot.registerAndPrepare()
+    spot.setup(spotsScrollView.frame.size)
+    spot.component.size = CGSize(
+      width: view.width,
+      height: ceil(spot.render().height))
   }
 
   #if os(iOS)

--- a/Sources/iOS/Extensions/ListAdapter+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+iOS.swift
@@ -211,7 +211,9 @@ extension ListAdapter {
     if let indexes = indexes {
       spot.tableView.reload(indexes)
     } else {
-      animation != .None ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation) : spot.tableView.reloadData()
+      animation != .None
+        ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation)
+        : spot.tableView.reloadData()
     }
 
     UIView.setAnimationsEnabled(true)

--- a/Sources/iOS/Extensions/SpotComposable.swift
+++ b/Sources/iOS/Extensions/SpotComposable.swift
@@ -25,6 +25,7 @@ public extension SpotComposable where Self : View {
         : spot.layout(contentView.frame.size)
 
       contentView.addSubview(spot.render())
+      spot.render().frame.origin.y = height
       spot.render().layoutIfNeeded()
       height += spot.render().contentSize.height
     }

--- a/Sources/iOS/Views/SpotsScrollView.swift
+++ b/Sources/iOS/Views/SpotsScrollView.swift
@@ -47,7 +47,8 @@ public class SpotsScrollView: UIScrollView {
   func didAddSubviewToContainer(subview: UIView) {
     subview.autoresizingMask = [.None]
 
-    subviewsInLayoutOrder.append(subview)
+    guard let index = contentView.subviews.indexOf(subview) else { return }
+    subviewsInLayoutOrder.insert(subview, atIndex: index)
 
     if subview.superview == contentView && !(subview is UIScrollView) {
       subview.addObserver(self, forKeyPath: "frame", options: .Old, context: subviewContext)

--- a/SpotsTests/Shared/TestComponent.swift
+++ b/SpotsTests/Shared/TestComponent.swift
@@ -68,4 +68,42 @@ class ComponentTests : XCTestCase {
     XCTAssertEqual((jsonComponent.dictionary["items"] as! [JSONDictionary])[0]["title"] as? String, json["items"]![0]["title"])
     XCTAssertEqual((jsonComponent.dictionary["items"] as! [JSONDictionary]).count, json["items"]!.count)
   }
+
+  func testComponentDiffing() {
+    let initialJSON: [String : AnyObject] = [
+      "components" : [
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ],
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ]
+      ]
+    ]
+
+    let newJSON: [String : AnyObject] = [
+      "components" : [
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item 2"]
+          ]
+        ],
+        ["kind" : "grid",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ]
+      ]
+    ]
+
+    let lhs: [Component] = Parser.parse(initialJSON)
+    let rhs: [Component] = Parser.parse(newJSON)
+
+    XCTAssertTrue(lhs.first?.diff(component: rhs.first!) == .Items)
+    XCTAssertTrue(lhs[1].diff(component: rhs[1]) == .Kind)
+  }
 }

--- a/SpotsTests/iOS/TestSpotsController.swift
+++ b/SpotsTests/iOS/TestSpotsController.swift
@@ -221,4 +221,74 @@ class SpotsControllerTests : XCTestCase {
 
     XCTAssertTrue(firstController.spots.first!.component == secondController.spots.first!.component)
   }
+
+  func testReloadIfNeededWithComponents() {
+    let initialJSON: [String : AnyObject] = [
+      "components" : [
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ],
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ]
+      ]
+    ]
+
+    let newJSON: [String : AnyObject] = [
+      "components" : [
+        ["kind" : "list",
+          "items" : [
+            ["title" : "First list item 2"],
+            [
+              "kind" : "composite",
+              "items" : [
+                ["kind" : "grid",
+                  "items" : [
+                    ["title" : "First list item"]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ],
+        ["kind" : "grid",
+          "items" : [
+            ["title" : "First list item"]
+          ]
+        ]
+      ]
+    ]
+
+    let controller = SpotsController(initialJSON)
+    XCTAssertTrue(controller.spots[0] is ListSpot)
+    XCTAssertEqual(controller.spots[0].items.first?.title, "First list item")
+    XCTAssertEqual(controller.spots[1].items.first?.title, "First list item")
+    XCTAssertTrue(controller.spots[1] is ListSpot)
+    XCTAssertTrue(controller.spots.count == 2)
+    XCTAssertTrue(controller.compositeSpots.count == 0)
+
+    controller.reloadIfNeeded(newJSON) {
+      XCTAssertEqual(controller.spots.count, 3)
+      XCTAssertTrue(controller.spots[0] is ListSpot)
+      XCTAssertTrue(controller.spots[1] is GridSpot)
+      XCTAssertEqual(controller.spots[0].items.first?.title, "First list item 2")
+      XCTAssertEqual(controller.spots[1].items.first?.title, "First list item")
+
+      XCTAssertEqual(controller.spots[0].items[1].kind, "composite")
+      XCTAssertTrue(controller.compositeSpots.count == 1)
+
+      controller.reloadIfNeeded(initialJSON) {
+        XCTAssertTrue(controller.spots[0] is ListSpot)
+        XCTAssertEqual(controller.spots[0].items.first?.title, "First list item")
+        XCTAssertEqual(controller.spots[1].items.first?.title, "First list item")
+        XCTAssertTrue(controller.spots[1] is ListSpot)
+        XCTAssertTrue(controller.spots.count == 2)
+        XCTAssertTrue(controller.compositeSpots.count == 0)
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR improves the way you work with `Spots` using `Components`. Now you can parse json payloads into a collection of components and then execute `reloadIfNeeded` with those components. `Spots` will then do an internal diffing process to calculate which `Spotable` objects were inserted, updated, removed.

- [x] Adds a `ComponentDiff` enum to indicate the impact of the change
- [x] `Component` is now `Equatable`
- [x] Comparison on `Component` is now more accurate as it takes the newly introduces properties into account
- [x] Fixes a layout-bug when using multiple composed objects
- [x] Logging when using live reloading has gotten some love
- [x] `subviewsInLayoutOrder` indexes is now in sync with the view hierarchy