### PR TITLE
Improve reload if needed code on adapters

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -60,9 +60,6 @@ public extension Spotable {
   func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
     adapter?.reloadIfNeeded(changes, updateDataSource: updateDataSource, completion: completion)
   }
-}
-
-public extension Spotable {
 
   /// A collection of view models
   var items: [ViewModel] {

--- a/Sources/iOS/Classes/CollectionAdapter.swift
+++ b/Sources/iOS/Classes/CollectionAdapter.swift
@@ -251,7 +251,7 @@ public class CollectionAdapter: NSObject, SpotAdapter {
     completion?()
   }
 
-  public func updateItem(updates: [Int], completion: Completion) {
+  public func process(updates: [Int], completion: Completion) {
     guard !updates.isEmpty else {
       completion?()
       return
@@ -271,10 +271,10 @@ public class CollectionAdapter: NSObject, SpotAdapter {
   public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
     spot.collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        self.updateItem(changes.updatedChildren, completion: completion)
+        self.process(changes.updatedChildren, completion: completion)
       } else {
-        self.updateItem(changes.updates) {
-          self.updateItem(changes.updatedChildren, completion: completion)
+        self.process(changes.updates) {
+          self.process(changes.updatedChildren, completion: completion)
         }
       }
     }

--- a/Sources/iOS/Classes/CollectionAdapter.swift
+++ b/Sources/iOS/Classes/CollectionAdapter.swift
@@ -251,44 +251,30 @@ public class CollectionAdapter: NSObject, SpotAdapter {
     completion?()
   }
 
+  public func updateItem(updates: [Int], completion: Completion) {
+    guard !updates.isEmpty else {
+      completion?()
+      return
+    }
+
+    let lastUpdate = updates.last
+    for index in updates {
+      guard let item = self.spot.item(index) else { completion?(); continue }
+      self.update(item, index: index, withAnimation: .Automatic) {
+        if index == lastUpdate {
+          completion?()
+        }
+      }
+    }
+  }
+
   public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
     spot.collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        guard !changes.updatedChildren.isEmpty else {
-          completion?()
-          return
-        }
-
-        for index in changes.updatedChildren {
-          guard let item = self.spot.item(index) else { continue }
-          self.spot.update(item, index: index, withAnimation: .Automatic) {
-            if changes.updatedChildren.last == index {
-              completion?()
-            }
-          }
-        }
-
+        self.updateItem(changes.updatedChildren, completion: completion)
       } else {
-        for index in changes.updates {
-          guard let item = self.spot.item(index) else { continue }
-
-          self.spot.update(item, index: index, withAnimation: .Automatic) {
-            if changes.updates.last == index {
-              guard !changes.updatedChildren.isEmpty else {
-                completion?()
-                return
-              }
-
-              for index in changes.updatedChildren {
-                guard let item = self.spot.item(index) else { continue }
-                self.spot.update(item, index: index, withAnimation: .Automatic) {
-                  if changes.updatedChildren.last == index {
-                    completion?()
-                  }
-                }
-              }
-            }
-          }
+        self.updateItem(changes.updates) {
+          self.updateItem(changes.updatedChildren, completion: completion)
         }
       }
     }

--- a/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
@@ -232,7 +232,7 @@ extension ListAdapter {
     completion?()
   }
 
-  public func updateItem(updates: [Int], completion: Completion) {
+  public func process(updates: [Int], completion: Completion) {
     guard !updates.isEmpty else { completion?(); return }
 
     let lastUpdate = updates.last
@@ -249,10 +249,10 @@ extension ListAdapter {
   public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
     spot.tableView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        self.updateItem(changes.updatedChildren, completion: completion)
+        self.process(changes.updatedChildren, completion: completion)
       } else {
-        self.updateItem(changes.updates) {
-          self.updateItem(changes.updatedChildren, completion: completion)
+        self.process(changes.updates) {
+          self.process(changes.updatedChildren, completion: completion)
         }
       }
     }

--- a/Sources/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Sources/iOS/Extensions/UICollectionView+Indexes.swift
@@ -60,6 +60,14 @@ public extension UICollectionView {
     let deletions = changes.deletions.map { NSIndexPath(forRow: $0, inSection: section) }
 
     updateDataSource()
+
+    if insertions.isEmpty &&
+      reloads.isEmpty &&
+      deletions.isEmpty {
+      completion?()
+      return
+    }
+
     performBatchUpdates({
       self.insertItemsAtIndexPaths(insertions)
       self.reloadItemsAtIndexPaths(reloads)


### PR DESCRIPTION
The adapter code for `reloadIfNeeded` was suffering from a pyramid of doom syndrom, this PR aims to adress that by cleaning up the code quiet a lot. Now it will use a method called `process` that takes and array of changes and updates the items that are affected.

I also found an interesting thing with `performBatchUpdates` on `UICollectionView`.

If there are no updates applied in the method, the completion will never be called.

I solved this by doing the following;

```swift
    let insertions = changes.insertions.map { NSIndexPath(forRow: $0, inSection: section) }
    let reloads = changes.reloads.map { NSIndexPath(forRow: $0, inSection: section) }
    let deletions = changes.deletions.map { NSIndexPath(forRow: $0, inSection: section) }

    updateDataSource()

    if insertions.isEmpty &&
      reloads.isEmpty &&
      deletions.isEmpty {
      completion?()
      return
    }

    performBatchUpdates({
      self.insertItemsAtIndexPaths(insertions)
      self.reloadItemsAtIndexPaths(reloads)
      self.deleteItemsAtIndexPaths(deletions)
      }) { _ in
        completion?()
    }
```