### PR TITLE
Check for presented view controller

### DIFF
--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -266,6 +266,8 @@ public class SpotsController: UIViewController, SpotsProtocol, SpotsCompositeDel
   public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
+    guard presentedViewController == nil else { return }
+
     coordinator.animateAlongsideTransition({ (UIViewControllerTransitionCoordinatorContext) in
       self.configureView(withSize: size)
       }) { (UIViewControllerTransitionCoordinatorContext) in


### PR DESCRIPTION
I see that `viewWillTransitionToSize` is called when we rotate on the modal view controller as well. Here are the steps

- Main view controller has orientation set to portrait
- Rotate device, `viewWillTransitionToSize` on main controller is not called 👍 
- Present a modal view controller
- Rotate device, `viewWillTransitionToSize` is called on main view controller 😓

So this checks for presented view controller before doing resizing