### PR TITLE
Refactor internal components

### DIFF
--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -25,9 +25,11 @@ public extension Spotable where Self : Gridable {
    - Parameter size: A CGSize to set the size of the collection view
    */
   public func setup(size: CGSize) {
-    collectionView.frame.size = size
-    #if os(OSX)
-    #else
+    layout.prepareLayout()
+    collectionView.frame.size.width = size.width
+    collectionView.frame.size.height = layout.contentSize.height
+    component.size = collectionView.frame.size
+    #if !os(OSX)
       GridSpot.configure?(view: collectionView, layout: layout)
     #endif
   }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -137,7 +137,7 @@ public extension Spotable {
    - Parameter items:     A collection of ViewModels
    - Parameter animation: The animation that should be used (only works for Listable objects)
    */
-  public func reloadIfNeeded(items: [ViewModel], withAnimation animation: SpotsAnimation = .Automatic) {
+  public func reloadIfNeeded(items: [ViewModel], withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     guard !(self.items == items) else {
       cache()
       return
@@ -158,6 +158,7 @@ public extension Spotable {
 
     reload(indexes, withAnimation: animation) {
       self.cache()
+      completion?()
     }
   }
 

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -66,6 +66,8 @@ public protocol Spotable: class {
   func delete(indexes: [Int], withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view model indexes with animation in a Spotable object
   func reload(indexes: [Int]?, withAnimation animation: SpotsAnimation, completion: Completion)
+
+  func reloadIfNeeded(items: [ViewModel], withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view models if needed using change set
   func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion)
 

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -47,7 +47,7 @@ public struct Component: Mappable, Equatable {
   }
 
   // Identifier
-  public var identifier: Int?
+  public var identifier: String?
   /// The index of the ViewModel when appearing in a list, should be computed and continuously updated by the data source
   public var index = 0
   /// The title for the component
@@ -138,7 +138,7 @@ public struct Component: Mappable, Equatable {
    - Parameter items: A collection of view models
    - Parameter meta: A key-value dictionary for any additional information
    */
-  public init(identifier: Int? = nil,
+  public init(identifier: String? = nil,
               title: String = "",
               header: String = "",
               kind: String = "",

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -95,6 +95,7 @@ public class CarouselSpot: NSObject, Gridable {
     $0.delegate = self.collectionAdapter
     $0.showsHorizontalScrollIndicator = false
     $0.backgroundView = self.backgroundView
+    $0.alwaysBounceHorizontal = true
   }
 
   public lazy var backgroundView = UIView()

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -7,9 +7,11 @@ public class CarouselSpot: NSObject, Gridable {
   public struct Key {
     public static let minimumInteritemSpacing = "item-spacing"
     public static let minimumLineSpacing = "line-spacing"
+    public static let dynamicSpan = "dynamic-span"
   }
 
   public struct Default {
+    public static var dynamicSpan: Bool = false
     public static var sectionInsetTop: CGFloat = 0.0
     public static var sectionInsetLeft: CGFloat = 0.0
     public static var sectionInsetRight: CGFloat = 0.0
@@ -17,6 +19,8 @@ public class CarouselSpot: NSObject, Gridable {
     public static var minimumInteritemSpacing: CGFloat = 0.0
     public static var minimumLineSpacing: CGFloat = 0.0
   }
+
+  public var dynamicSpan = false
 
   public static var views: Registry = Registry().then {
     $0.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
@@ -34,6 +38,7 @@ public class CarouselSpot: NSObject, Gridable {
   public var component: Component {
     willSet(value) {
       #if os(iOS)
+        dynamicSpan ?= component.meta(Key.dynamicSpan, Default.dynamicSpan)
         if component.items.count > 1 && component.span > 0 {
           pageControl.numberOfPages = Int(floor(CGFloat(component.items.count) / component.span))
         }

--- a/Sources/iOS/Classes/CollectionAdapter.swift
+++ b/Sources/iOS/Classes/CollectionAdapter.swift
@@ -271,10 +271,16 @@ public class CollectionAdapter: NSObject, SpotAdapter {
   public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
     spot.collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        self.process(changes.updatedChildren, completion: completion)
+        self.process(changes.updatedChildren) {
+          completion?()
+          self.spot.layout(self.spot.collectionView.bounds.size)
+        }
       } else {
         self.process(changes.updates) {
-          self.process(changes.updatedChildren, completion: completion)
+          self.process(changes.updatedChildren) {
+            completion?()
+            self.spot.layout(self.spot.collectionView.bounds.size)
+          }
         }
       }
     }
@@ -300,7 +306,6 @@ public class CollectionAdapter: NSObject, SpotAdapter {
     }
 
     cellCache.removeAll()
-    spot.collectionView.collectionViewLayout.invalidateLayout()
 
     if let indexes = indexes {
       spot.collectionView.reload(indexes)

--- a/Sources/iOS/Extensions/CarouselSpot+iOS.swift
+++ b/Sources/iOS/Extensions/CarouselSpot+iOS.swift
@@ -10,12 +10,19 @@ extension CarouselSpot {
   }
 
   public func sizeForItemAt(indexPath: NSIndexPath) -> CGSize {
+    guard indexPath.item < component.items.count else { return CGSize.zero }
     var width = collectionView.width
 
     if component.span > 0 {
-      width = collectionView.width / CGFloat(component.span)
-      width -= layout.sectionInset.left / component.span
-      width -= layout.minimumInteritemSpacing
+      if dynamicSpan && CGFloat(component.items.count) < component.span  {
+        width = collectionView.width / CGFloat(component.items.count)
+        width -= layout.sectionInset.left / CGFloat(component.items.count)
+        width -= layout.minimumInteritemSpacing
+      } else {
+        width = collectionView.width / CGFloat(component.span)
+        width -= layout.sectionInset.left / component.span
+        width -= layout.minimumInteritemSpacing
+      }
     }
 
     component.items[indexPath.item].size.width = width

--- a/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
@@ -41,8 +41,6 @@ extension CollectionAdapter : UICollectionViewDataSource {
       spot.configure?(cell)
     }
 
-    collectionView.collectionViewLayout.invalidateLayout()
-
     return cell
   }
 }

--- a/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
@@ -2,6 +2,17 @@ import UIKit
 
 extension CollectionAdapter : UICollectionViewDataSource {
 
+  public func collectionView(collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, atIndexPath indexPath: NSIndexPath) -> UICollectionReusableView {
+    let header = spot.component.header.isEmpty
+      ? spot.dynamicType.headers.defaultIdentifier
+      : spot.component.header
+
+    let view = collectionView.dequeueReusableSupplementaryViewOfKind(UICollectionElementKindSectionHeader, withReuseIdentifier: header, forIndexPath: indexPath)
+    (view as? Componentable)?.configure(spot.component)
+
+    return view
+  }
+
   /**
    Asks the data source for the number of items in the specified section. (required)
 

--- a/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDelegate.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDelegate.swift
@@ -2,17 +2,6 @@ import UIKit
 
 extension CollectionAdapter : UICollectionViewDelegate {
 
-  public func collectionView(collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, atIndexPath indexPath: NSIndexPath) -> UICollectionReusableView {
-    let header = spot.component.header.isEmpty
-      ? spot.dynamicType.headers.defaultIdentifier
-      : spot.component.header
-
-    let view = collectionView.dequeueReusableSupplementaryViewOfKind(UICollectionElementKindSectionHeader, withReuseIdentifier: header, forIndexPath: indexPath)
-    (view as? Componentable)?.configure(spot.component)
-
-    return view
-  }
-
   /**
    Asks the delegate for the size of the specified item’s cell.
 

--- a/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDelegate.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDelegate.swift
@@ -21,9 +21,8 @@ extension CollectionAdapter : UICollectionViewDelegate {
    - Parameter indexPath: The index path of the cell that was selected.
    */
   public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-    if let item = spot.item(indexPath) {
-      spot.spotsDelegate?.spotDidSelectItem(spot, item: item)
-    }
+    guard let item = spot.item(indexPath) else { return }
+    spot.spotsDelegate?.spotDidSelectItem(spot, item: item)
   }
 
   /**

--- a/Sources/iOS/Extensions/CollectionAdapter+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UIScrollViewDelegate.swift
@@ -26,6 +26,8 @@ extension CollectionAdapter : UIScrollViewDelegate {
    - Parameter scrollView: The scroll-view object in which the scrolling occurred.
    */
   public func scrollViewDidScroll(scrollView: UIScrollView) {
+    // This is a weird workaround to get the carousel to scroll more smoothly... weird I know.
+    let _ = spot.layout.layoutAttributesForElementsInRect(scrollView.frame)
     (spot as? CarouselSpot)?.scrollViewDidScroll(scrollView)
   }
 }

--- a/Sources/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Sources/iOS/Extensions/UICollectionView+Indexes.swift
@@ -73,8 +73,8 @@ public extension UICollectionView {
       self.reloadItemsAtIndexPaths(reloads)
       self.deleteItemsAtIndexPaths(deletions)
       }) { _ in
-        completion?()
     }
+    completion?()
   }
 
   /**


### PR DESCRIPTION
This PR adds a some various improvements;

- [x] Adds a completion block to `reloadIfNeeded` on `Spotable`
- [x] Refactors `GridableLayout` to fix a crash when trying to render index paths that where not in `rect`
- [x] Adds `dynamicSpan` to `CarouselSpot`
- [x] Removes some unnecessary `invalidateLayout` calls
- [x] Improves the usage of using headers in `GridableLayout`