### PR TITLE
Improve SpotsScrollView with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 - brew update
 - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 - if brew outdated | grep -qx carthage; then brew upgrade carthage; fi
-- carthage bootstrap --platform iOS,Mac
+- travis_wait 35 carthage bootstrap --platform iOS,Mac
 
 script:
 - xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator

--- a/Sources/Mac/Classes/CarouselSpot.swift
+++ b/Sources/Mac/Classes/CarouselSpot.swift
@@ -87,7 +87,7 @@ public class CarouselSpot: NSObject, Gridable {
     setupCollectionView()
     configureLayoutInsets(component)
 
-    if let layout = layout as? NSCollectionViewFlowLayout where component.title.isPresent {
+    if let layout = layout as? NSCollectionViewFlowLayout where !component.title.isEmpty {
       configureTitleView(layout.sectionInset)
     }
     scrollView.addSubview(titleView)
@@ -144,7 +144,7 @@ public class CarouselSpot: NSObject, Gridable {
     collectionView.frame.size.height = scrollView.frame.size.height
     gradientLayer?.frame.size.height = scrollView.frame.size.height
 
-    if component.title.isPresent {
+    if !component.title.isEmpty {
       configureTitleView(layoutInsets)
     }
 

--- a/Sources/Mac/Classes/GridSpot.swift
+++ b/Sources/Mac/Classes/GridSpot.swift
@@ -106,7 +106,7 @@ public class GridSpot: NSObject, Gridable {
     scrollView.addSubview(lineView)
     scrollView.contentView.addSubview(collectionView)
 
-    if let layout = layout as? NSCollectionViewFlowLayout where component.title.isPresent {
+    if let layout = layout as? NSCollectionViewFlowLayout where !component.title.isEmpty {
       configureTitleView(layout.sectionInset)
     }
   }
@@ -201,7 +201,7 @@ public class GridSpot: NSObject, Gridable {
 
     GridSpot.configure?(view: collectionView)
 
-    if component.title.isPresent {
+    if !component.title.isEmpty {
       configureTitleView(layoutInsets)
     }
   }

--- a/Sources/Mac/Classes/GridSpotItem.swift
+++ b/Sources/Mac/Classes/GridSpotItem.swift
@@ -77,7 +77,7 @@ public class GridSpotItem: NSCollectionViewItem, SpotConfigurable {
     titleLabel.stringValue = item.title
     titleLabel.frame.origin.x = 8
     titleLabel.sizeToFit()
-    if item.subtitle.isPresent {
+    if !item.subtitle.isEmpty {
       titleLabel.frame.origin.y = 8
       titleLabel.font = NSFont.boldSystemFontOfSize(14)
       titleLabel.sizeToFit()

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -129,7 +129,7 @@ public class ListSpot: NSObject, Listable {
     scrollView.contentInsets.bottom = component.meta(Key.contentInsetsBottom, Default.contentInsetsBottom)
     scrollView.contentInsets.right = component.meta(Key.contentInsetsRight, Default.contentInsetsRight)
 
-    if component.title.isPresent {
+    if !component.title.isEmpty {
       configureTitleView()
     }
 
@@ -151,7 +151,7 @@ public class ListSpot: NSObject, Listable {
     tableView.doubleAction = #selector(self.doubleAction(_:))
     tableView.sizeToFit()
 
-    if component.title.isPresent {
+    if !component.title.isEmpty {
       scrollView.addSubview(titleView)
       if component.meta(Key.titleSeparator, Default.titleSeparator) {
         scrollView.addSubview(lineView)

--- a/Sources/Mac/Classes/ListSpotItem.swift
+++ b/Sources/Mac/Classes/ListSpotItem.swift
@@ -66,7 +66,7 @@ public class ListSpotItem: NSTableRowView, SpotConfigurable {
     titleLabel.frame.origin.x = 8
 
     titleLabel.sizeToFit()
-    if item.subtitle.isPresent {
+    if !item.subtitle.isEmpty {
       titleLabel.frame.origin.y = 8
       titleLabel.font = NSFont.boldSystemFontOfSize(14)
     } else {

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -29,10 +29,7 @@ public class CarouselSpot: NSObject, Gridable {
   public var dynamicSpan = false
 
   /// A Registry object that holds identifiers and classes for cells used in the CarouselSpot
-  public static var views: Registry = Registry().then {
-    $0.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
-    $0.composite =  Registry.Item.classType(CarouselComposite.self)
-  }
+  public static var views: Registry = Registry()
 
   /// A configuration closure that is run in setup(_:)
   public static var configure: ((view: UICollectionView, layout: UICollectionViewFlowLayout) -> Void)?

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -132,6 +132,8 @@ public class CarouselSpot: NSObject, Gridable {
     self.component = component
     super.init()
     configureLayout()
+    CarouselSpot.views.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
+    CarouselSpot.views.composite =  Registry.Item.classType(CarouselComposite.self)
   }
 
   /**

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -18,13 +18,8 @@ public class GridSpot: NSObject, Gridable {
     public static var minimumLineSpacing: CGFloat = 0.0
   }
 
-  public static var views: Registry = Registry().then {
-    $0.defaultItem = Registry.Item.classType(GridSpotCell.self)
-    $0.composite =  Registry.Item.classType(GridComposite.self)
-  }
-
+  public static var views: Registry = Registry()
   public static var configure: ((view: UICollectionView, layout: UICollectionViewFlowLayout) -> Void)?
-
   public static var headers = Registry()
 
   public var component: Component
@@ -52,6 +47,8 @@ public class GridSpot: NSObject, Gridable {
     super.init()
 
     self.configureLayout()
+    GridSpot.views.defaultItem = Registry.Item.classType(GridSpotCell.self)
+    GridSpot.views.composite =  Registry.Item.classType(GridComposite.self)
   }
 
   public convenience init(title: String = "", kind: String? = nil) {

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -8,11 +8,7 @@ public class ListSpot: NSObject, Listable {
     public static let headerHeight = "headerHeight"
   }
 
-  public static var views: Registry = Registry().then {
-    $0.defaultItem = Registry.Item.classType(ListSpotCell.self)
-    $0.composite =  Registry.Item.classType(ListComposite.self)
-  }
-
+  public static var views: Registry = Registry()
   public static var configure: ((view: UITableView) -> Void)?
   public static var headers = Registry()
 
@@ -43,6 +39,9 @@ public class ListSpot: NSObject, Listable {
 
     registerAndPrepare()
     setupTableView()
+
+    ListSpot.views.defaultItem = Registry.Item.classType(ListSpotCell.self)
+    ListSpot.views.composite =  Registry.Item.classType(ListComposite.self)
   }
 
   public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {

--- a/Sources/iOS/Classes/ListSpotCell.swift
+++ b/Sources/iOS/Classes/ListSpotCell.swift
@@ -16,7 +16,7 @@ public class ListSpotCell: UITableViewCell, SpotConfigurable {
   }
 
   public func configure(inout item: ViewModel) {
-    if let action = item.action where action.isPresent {
+    if let action = item.action where !action.isEmpty {
       accessoryType = .DisclosureIndicator
     } else {
       accessoryType = .None

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -47,7 +47,8 @@ public class SpotsScrollView: UIScrollView {
    Initializes and returns a newly allocated view object with the specified frame rectangle.
    An initialized view object.
 
-   - parameter frame: The frame rectangle for the view, measured in points. The origin of the frame is relative to the superview in which you plan to add it. This method uses the frame rectangle to set the center and bounds properties accordingly.
+   - parameter frame: The frame rectangle for the view, measured in points. The origin of the frame is relative to the superview in which you plan to add it.
+   This method uses the frame rectangle to set the center and bounds properties accordingly.
 
    - returns: An initialized view object
    */

--- a/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
@@ -300,7 +300,7 @@ extension ListAdapter: UITableViewDelegate {
     if let _ = spot.dynamicType.headers.make(spot.component.header) {
       return nil
     }
-    return spot.component.title.isPresent ? spot.component.title : nil
+    return !spot.component.title.isEmpty ? spot.component.title : nil
   }
 
   /**

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -194,6 +194,8 @@
 		BD73974B1D718D38000AF2DE /* CollectionAdapter+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */; };
 		BD76FA471D8066A7001CA31C /* CollectionAdapter+Extensions+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD76FA461D8066A7001CA31C /* CollectionAdapter+Extensions+iOS.swift */; };
 		BD76FA481D8066A7001CA31C /* CollectionAdapter+Extensions+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD76FA461D8066A7001CA31C /* CollectionAdapter+Extensions+iOS.swift */; };
+		BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */; };
+		BDEED2E91D8446400030B475 /* TestSpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */; };
 		D58478141C43FEB9006EBA49 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D58478531C43FFEB006EBA49 /* TestSpotFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestSpotFactory.swift */; };
 		D58478551C43FFEF006EBA49 /* TestSpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478291C43FF34006EBA49 /* TestSpotsController.swift */; };
@@ -327,6 +329,7 @@
 		BD76FA461D8066A7001CA31C /* CollectionAdapter+Extensions+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+Extensions+iOS.swift"; sourceTree = "<group>"; };
 		BDB538321C444D460005E498 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsScrollView.swift; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478131C43FEB9006EBA49 /* Spots-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478241C43FF34006EBA49 /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
@@ -689,6 +692,7 @@
 				D58478281C43FF34006EBA49 /* TestSpotFactory.swift */,
 				D58478291C43FF34006EBA49 /* TestSpotsController.swift */,
 				BD4295571D81D45D00E07E1C /* TestViewSpot.swift */,
+				BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1165,6 +1169,7 @@
 				BD4295561D81D39700E07E1C /* TestCarouselSpot.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */,
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
+				BDEED2E91D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
 				BD73973A1D718CDB000AF2DE /* TestSpotFactory.swift in Sources */,
 				BD73973B1D718CDB000AF2DE /* TestSpotsController.swift in Sources */,
@@ -1244,6 +1249,7 @@
 				BD4295551D81D39700E07E1C /* TestCarouselSpot.swift in Sources */,
 				D58478571C43FFFD006EBA49 /* TestComponent.swift in Sources */,
 				BD42954F1D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
+				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BD4295521D81D32400E07E1C /* TestListSpot.swift in Sources */,
 				D58478531C43FFEB006EBA49 /* TestSpotFactory.swift in Sources */,
 				D58478551C43FFEF006EBA49 /* TestSpotsController.swift in Sources */,

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -58,7 +58,7 @@ class SpotsScrollViewTests: XCTestCase {
       ]
     ]
 
-    let bounds = UIScreen.mainScreen().bounds
+    let bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
     let controller = SpotsController(initialJSON)
     controller.view.autoresizingMask = .None
     controller.view.frame.size = CGSize(width: 375, height: 667)
@@ -66,7 +66,6 @@ class SpotsScrollViewTests: XCTestCase {
     controller.viewWillAppear(true)
 
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews.count, 4)
-    XCTAssertEqual(controller.spotsScrollView.frame.size.height, bounds.height)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 320)
@@ -75,7 +74,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, bounds.height - (320 * 2))
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 27)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
@@ -150,7 +149,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 0)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 293)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, abs(bounds.height - 320 * 3))
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 320)

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -1,0 +1,171 @@
+@testable import Spots
+import Brick
+import Foundation
+import XCTest
+
+extension SpotsController {
+
+  func preloadView() {
+    let _ = view
+  }
+
+  func scrollTo(point: CGPoint) {
+    spotsScrollView.setContentOffset(point, animated: false)
+    spotsScrollView.layoutSubviews()
+  }
+}
+
+class SpotsScrollViewTests: XCTestCase {
+
+  func testSpotsScrollView() {
+    let listItems: [[String : AnyObject]] = [
+      [
+        "title" : "Item",
+        "size" : ["height" : 80]
+      ],
+      [
+        "title" : "Item",
+        "size" : ["height" : 80]
+      ],
+      [
+        "title" : "Item",
+        "size" : ["height" : 80]
+      ],
+      [
+        "title" : "Item",
+        "size" : ["height" : 80]
+      ]
+    ]
+
+    let initialJSON: [String : AnyObject] = [
+      "components" : [
+        [
+          "kind" : "list",
+          "items" : listItems
+        ],
+        [
+          "kind" : "list",
+          "items" : listItems
+        ],
+        [
+          "kind" : "list",
+          "items" : listItems
+        ],
+        [
+          "kind" : "list",
+          "items" : listItems
+        ],
+      ]
+    ]
+
+    let bounds = UIScreen.mainScreen().bounds
+    let controller = SpotsController(initialJSON)
+    controller.preloadView()
+    controller.viewWillAppear(true)
+
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews.count, 4)
+    XCTAssertEqual(controller.spotsScrollView.frame.size.height, bounds.height)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 96)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
+
+    controller.scrollTo(CGPoint(x: 0, y: 160))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 160)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 256)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
+
+    controller.scrollTo(CGPoint(x: 0, y: 320))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 96)
+
+    controller.scrollTo(CGPoint(x: 0, y: 480))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 160)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 256)
+
+    controller.scrollTo(CGPoint(x: 0, y: 544))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 96)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 320)
+
+    controller.scrollTo(CGPoint(x: 0, y: bounds.height))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 224)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 320)
+
+    controller.scrollTo(CGPoint(x: 0, y: controller.spotsScrollView.contentSize.height))
+
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[0].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[1] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[1] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 0)
+    XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
+    XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
+  }
+}

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -17,7 +17,10 @@ extension SpotsController {
 
 class SpotsScrollViewTests: XCTestCase {
 
-  func testSpotsScrollView() {
+  var bounds: CGRect!
+  var controller: SpotsController!
+
+  var initialJSON: [String : AnyObject] {
     let listItems: [[String : AnyObject]] = [
       [
         "title" : "Item",
@@ -37,7 +40,7 @@ class SpotsScrollViewTests: XCTestCase {
       ]
     ]
 
-    let initialJSON: [String : AnyObject] = [
+    return [
       "components" : [
         [
           "kind" : "list",
@@ -57,14 +60,18 @@ class SpotsScrollViewTests: XCTestCase {
         ],
       ]
     ]
+  }
 
-    let bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
-    let controller = SpotsController(initialJSON)
+  override func setUp() {
+    bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
+    controller = SpotsController(initialJSON)
     controller.view.autoresizingMask = .None
     controller.view.frame.size = CGSize(width: 375, height: 667)
     controller.preloadView()
     controller.viewWillAppear(true)
+  }
 
+  func testSpotsScrollView() {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews.count, 4)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[0] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[0] as? UIScrollView)!.contentSize.height, 320)

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -60,6 +60,8 @@ class SpotsScrollViewTests: XCTestCase {
 
     let bounds = UIScreen.mainScreen().bounds
     let controller = SpotsController(initialJSON)
+    controller.view.autoresizingMask = .None
+    controller.view.frame.size = CGSize(width: 375, height: 667)
     controller.preloadView()
     controller.viewWillAppear(true)
 
@@ -73,7 +75,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 96)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, bounds.height - (320 * 2))
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
@@ -88,7 +90,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 256)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 187)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 0)
@@ -106,7 +108,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 96)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 27)
 
     controller.scrollTo(CGPoint(x: 0, y: 480))
 
@@ -121,7 +123,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 256)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 187)
 
     controller.scrollTo(CGPoint(x: 0, y: 544))
 
@@ -136,7 +138,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 320)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 320)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 251)
 
     controller.scrollTo(CGPoint(x: 0, y: bounds.height))
 
@@ -148,7 +150,7 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[1].frame.height, 0)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[2] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[2] as? UIScrollView)!.contentSize.height, 320)
-    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 224)
+    XCTAssertEqual(controller.spotsScrollView.contentView.subviews[2].frame.height, 293)
     XCTAssertTrue(controller.spotsScrollView.contentView.subviews[3] is UITableView)
     XCTAssertEqual((controller.spotsScrollView.contentView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.spotsScrollView.contentView.subviews[3].frame.height, 320)


### PR DESCRIPTION
This PR adds test for the `SpotsScrollView` layout. The test is quiet big but if you analyze the test you get a deeper understand about how the internal scrolling in Spots really works.

It also removes some usage of `then` in the Spots. We aim to remove all dependencies on Sugar so it felt like a good idea to do.
But the reason I ended up removing it was that, `then` is only invoked if the lazy method is invoked. This was causing a crash because of that as the cell default cell was not registered on the UI component.

Something to think about when adding `lazy` methods with extended `then`-like loading mechanisms.

Oh, and for removing `Sugar`, this also removes the use of `isPresent`, the have been replaced by `!.isEmpty`.