### PR TITLE
Fix CollectionAdapter update completion closure not being invoked

### DIFF
--- a/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
@@ -214,9 +214,8 @@ public extension CollectionAdapter {
       if let spots = spot.spotsCompositeDelegate?.resolve(spotIndex: spot.index, itemIndex: indexPath.item) {
         spot.collectionView.performBatchUpdates({
           composite.configure(&self.spot.component.items[indexPath.item], spots: spots)
-          }, completion: { (_) in
-            completion?()
-        })
+          }, completion: nil)
+          completion?()
         return
       }
     }


### PR DESCRIPTION
We still had one scenario where the `completion` was not called, this PR should adress that issue.