### PR TITLE
Fix animations for ListAdapter.update

### DIFF
--- a/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
@@ -220,7 +220,7 @@ extension ListAdapter {
     }
 
     if let indexes = indexes {
-      spot.tableView.reload(indexes)
+      spot.tableView.reload(indexes, animation: animation.tableViewAnimation)
     } else {
       animation != .None
         ? spot.tableView.reloadSection(0, animation: animation.tableViewAnimation)


### PR DESCRIPTION
Before, we didn't pass the `animation` to the adapter. This PR fixes that issue.