### PR TITLE
Add return if new items is empty

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -144,6 +144,13 @@ extension SpotsProtocol {
         CATransaction.begin()
         spot.items = newItems
       }) {
+        guard !newItems.isEmpty else {
+          closure?()
+          self.spotsScrollView.forceUpdate = true
+          CATransaction.commit()
+          return
+        }
+
         let executeClosure = newItems.count - 1
         for (index, item) in newItems.enumerate() {
           let components = Parser.parse(item.children).map { $0.component }


### PR DESCRIPTION
We had a bug where if the `newItems` collection was empty, the completion was never called. This PR fixes that issue by adding a `guard` that calls the appropriate methods before running the completion closure.