### PR TITLE
Add animations to reloadIfNeeded with Components

### DIFF
--- a/Sources/Mac/Extensions/CollectionAdapter+SpotAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/CollectionAdapter+SpotAdapter+Mac.swift
@@ -125,7 +125,7 @@ extension CollectionAdapter {
     }
   }
 
-  public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
+  public func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation, updateDataSource: () -> Void, completion: Completion) {
     guard !changes.updates.isEmpty else {
       spot.collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource, completion: completion)
       return

--- a/Sources/Mac/Extensions/ListAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/ListAdapter+Mac.swift
@@ -128,7 +128,7 @@ extension ListAdapter {
     }
   }
 
-  public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
+  public func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation, updateDataSource: () -> Void, completion: Completion) {
     guard !changes.updates.isEmpty else {
       spot.tableView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource, completion: completion)
       return

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -57,8 +57,8 @@ public extension Spotable {
   }
 
   /// Reload view models with change set
-  func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
-    adapter?.reloadIfNeeded(changes, updateDataSource: updateDataSource, completion: completion)
+  func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation = .Automatic, updateDataSource: () -> Void, completion: Completion) {
+    adapter?.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: updateDataSource, completion: completion)
   }
 
   /// A collection of view models

--- a/Sources/Shared/Protocols/SpotAdapter.swift
+++ b/Sources/Shared/Protocols/SpotAdapter.swift
@@ -23,5 +23,5 @@ public protocol SpotAdapter: class {
   /// Reload view model indexes with animation in a Spotable object
   func reload(indexes: [Int]?, withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view model with a change set
-  func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion)
+  func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation, updateDataSource: () -> Void, completion: Completion)
 }

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -69,7 +69,7 @@ public protocol Spotable: class {
 
   func reloadIfNeeded(items: [ViewModel], withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view models if needed using change set
-  func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion)
+  func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation, updateDataSource: () -> Void, completion: Completion)
 
   /// Return a Spotable object as a UIScrollView
   func render() -> ScrollView

--- a/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
@@ -242,7 +242,7 @@ public extension CollectionAdapter {
    - parameter updates:    A collection of updates
    - parameter completion: A completion closure that is run when the updates are finished
    */
-  public func process(updates: [Int], completion: Completion) {
+  public func process(updates: [Int], withAnimation animiation: SpotsAnimation, completion: Completion) {
     guard !updates.isEmpty else {
       completion?()
       return
@@ -266,16 +266,16 @@ public extension CollectionAdapter {
    - parameter updateDataSource: A closure to update your data source
    - parameter completion:       A completion closure that runs when your updates are done
    */
-  public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
+  public func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation = .Automatic, updateDataSource: () -> Void, completion: Completion) {
     spot.collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        self.process(changes.updatedChildren) {
+        self.process(changes.updatedChildren, withAnimation: animation) {
           completion?()
           self.spot.layout(self.spot.collectionView.bounds.size)
         }
       } else {
-        self.process(changes.updates) {
-          self.process(changes.updatedChildren) {
+        self.process(changes.updates, withAnimation: animation) {
+          self.process(changes.updatedChildren, withAnimation: animation) {
             completion?()
             self.spot.layout(self.spot.collectionView.bounds.size)
           }

--- a/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
@@ -238,13 +238,13 @@ extension ListAdapter {
    - parameter updates:    A collection of updates
    - parameter completion: A completion closure that is run when the updates are finished
    */
-  public func process(updates: [Int], completion: Completion) {
+  public func process(updates: [Int], withAnimation animation: SpotsAnimation = .Automatic, completion: Completion) {
     guard !updates.isEmpty else { completion?(); return }
 
     let lastUpdate = updates.last
     for index in updates {
       guard let item = self.spot.item(index) else { completion?(); continue }
-      self.update(item, index: index, withAnimation: .Automatic) {
+      self.update(item, index: index, withAnimation: animation) {
         if index == lastUpdate {
           completion?()
         }
@@ -259,13 +259,13 @@ extension ListAdapter {
    - parameter updateDataSource: A closure to update your data source
    - parameter completion:       A completion closure that runs when your updates are done
    */
-  public func reloadIfNeeded(changes: ViewModelChanges, updateDataSource: () -> Void, completion: Completion) {
-    spot.tableView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), updateDataSource: updateDataSource) {
+  public func reloadIfNeeded(changes: ViewModelChanges, withAnimation animation: SpotsAnimation = .Automatic, updateDataSource: () -> Void, completion: Completion) {
+    spot.tableView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions), withAnimation: animation.tableViewAnimation, updateDataSource: updateDataSource) {
       if changes.updates.isEmpty {
-        self.process(changes.updatedChildren, completion: completion)
+        self.process(changes.updatedChildren, withAnimation: animation, completion: completion)
       } else {
         self.process(changes.updates) {
-          self.process(changes.updatedChildren, completion: completion)
+          self.process(changes.updatedChildren, withAnimation: animation, completion: completion)
         }
       }
     }


### PR DESCRIPTION
This PR adds more fine grained control when using `reloadIfNeeded` with `[Component]`. You can no specify which animation to perform when doing the updates.