### PR TITLE
Add computed property to check if cache exists

### DIFF
--- a/Sources/Shared/Structs/SpotCache.swift
+++ b/Sources/Shared/Structs/SpotCache.swift
@@ -15,7 +15,7 @@ public struct SpotCache {
     return cache.path + "/" + fileName()
   }
 
-  /// Check if file exists for cache
+  /// Checks if file exists for cache
   public var cacheExists: Bool {
     return NSFileManager.defaultManager().fileExistsAtPath(path)
   }

--- a/Sources/Shared/Structs/SpotCache.swift
+++ b/Sources/Shared/Structs/SpotCache.swift
@@ -10,10 +10,12 @@ public struct SpotCache {
   static let cacheName = "SpotCache"
   let cache = Cache<JSON>(name: "\(SpotCache.cacheName)/\(NSBundle.mainBundle().bundleIdentifier!)")
 
+  /// The path of the cache
   var path: String {
     return cache.path + "/" + fileName()
   }
 
+  /// Check if file exists for cache
   public var cacheExists: Bool {
     return NSFileManager.defaultManager().fileExistsAtPath(path)
   }

--- a/Sources/Shared/Structs/SpotCache.swift
+++ b/Sources/Shared/Structs/SpotCache.swift
@@ -14,6 +14,10 @@ public struct SpotCache {
     return cache.path + "/" + fileName()
   }
 
+  public var cacheExists: Bool {
+    return NSFileManager.defaultManager().fileExistsAtPath(path)
+  }
+
   // MARK: - Initialization
 
   public init(key: String) {


### PR DESCRIPTION
This PR adds a small property on `SpotCache` to check if a cache exists. It will just check if the file exists, not if there is a cache.

```swift
  public var cacheExists: Bool {
    return NSFileManager.defaultManager().fileExistsAtPath(path)
  }
```