### PR TITLE
Don't register default items if they are already set in init

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -283,6 +283,7 @@ public extension Spotable {
   }
 
   public static func register(defaultView view: View.Type) {
+    self.views.defaultItem = Registry.Item.classType(view)
     self.views.storage[self.views.defaultIdentifier] = Registry.Item.classType(view)
   }
 }

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -129,8 +129,14 @@ public class CarouselSpot: NSObject, Gridable {
     self.component = component
     super.init()
     configureLayout()
-    CarouselSpot.views.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
-    CarouselSpot.views.composite =  Registry.Item.classType(CarouselComposite.self)
+
+    if CarouselSpot.views.defaultItem == nil {
+      CarouselSpot.views.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
+    }
+
+    if CarouselSpot.views.composite == nil {
+      CarouselSpot.views.composite =  Registry.Item.classType(CarouselComposite.self)
+    }
   }
 
   /**

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -47,8 +47,14 @@ public class GridSpot: NSObject, Gridable {
     super.init()
 
     self.configureLayout()
-    GridSpot.views.defaultItem = Registry.Item.classType(GridSpotCell.self)
-    GridSpot.views.composite =  Registry.Item.classType(GridComposite.self)
+
+    if GridSpot.views.defaultItem == nil {
+      GridSpot.views.defaultItem = Registry.Item.classType(GridSpotCell.self)
+    }
+
+    if GridSpot.views.composite == nil {
+      GridSpot.views.composite =  Registry.Item.classType(GridComposite.self)
+    }
   }
 
   public convenience init(title: String = "", kind: String? = nil) {

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -40,8 +40,13 @@ public class ListSpot: NSObject, Listable {
     registerAndPrepare()
     setupTableView()
 
-    ListSpot.views.defaultItem = Registry.Item.classType(ListSpotCell.self)
-    ListSpot.views.composite =  Registry.Item.classType(ListComposite.self)
+    if ListSpot.views.defaultItem == nil {
+      ListSpot.views.defaultItem = Registry.Item.classType(ListSpotCell.self)
+    }
+
+    if ListSpot.views.composite == nil {
+      ListSpot.views.composite =  Registry.Item.classType(ListComposite.self)
+    }
   }
 
   public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {


### PR DESCRIPTION
We were registering the default item in each init, which is wrong. Now we register it if it is `nil`.