### PR TITLE
Add UI quering methods

### DIFF
--- a/Sources/Mac/Extensions/CollectionAdapter+SpotAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/CollectionAdapter+SpotAdapter+Mac.swift
@@ -4,6 +4,10 @@ import Sugar
 
 extension CollectionAdapter {
 
+  public func ui<T>(atIndex index: Int) -> T? {
+    return spot.collectionView.itemAtIndexPath(NSIndexPath(forItem: index, inSection: 0)) as? T
+  }
+
   public func append(item: ViewModel, withAnimation animation: SpotsAnimation, completion: Completion) {
     let count = spot.component.items.count
     spot.component.items.append(item)

--- a/Sources/Mac/Extensions/ListAdapter+Mac.swift
+++ b/Sources/Mac/Extensions/ListAdapter+Mac.swift
@@ -4,6 +4,10 @@ import Brick
 
 extension ListAdapter {
 
+  public func ui<T>(atIndex index: Int) -> T? {
+    return spot.tableView.rowViewAtRow(index, makeIfNecessary: false) as? T
+  }
+
   public func append(item: ViewModel, withAnimation animation: SpotsAnimation, completion: Completion) {
     let count = spot.component.items.count
     spot.component.items.append(item)

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -9,8 +9,14 @@ import Sugar
 
 public extension Spotable {
 
+  /// A computed value for the current index
   public var index: Int {
     return component.index
+  }
+
+  /// Resolve UI component at index (UITableViewCell or UICollectionViewItem)
+  public func ui<T>(atIndex index: Int) -> T? {
+    return adapter?.ui(atIndex: index)
   }
 
   /// Append view model to a Spotable object

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -302,6 +302,5 @@ public extension Spotable {
 
   public static func register(defaultView view: View.Type) {
     self.views.defaultItem = Registry.Item.classType(view)
-    self.views.storage[self.views.defaultIdentifier] = Registry.Item.classType(view)
   }
 }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -280,6 +280,18 @@ public extension Spotable {
     prepareItems()
   }
 
+  func registerDefault(view view: UIView.Type) {
+    if self.dynamicType.views.storage[self.dynamicType.views.defaultIdentifier] == nil {
+      self.dynamicType.views.defaultItem = Registry.Item.classType(view)
+    }
+  }
+
+  func registerComposite(view view: UIView.Type) {
+    if self.dynamicType.views.composite == nil {
+      self.dynamicType.views.composite = Registry.Item.classType(view)
+    }
+  }
+
   public static func register(nib nib: Nib, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.nib(nib)
   }

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -40,6 +40,26 @@ public extension SpotsProtocol {
     return ["components" : result ]
   }
 
+  public func ui<T>(@noescape includeElement: (ViewModel) -> Bool) -> T? {
+    for spot in spots {
+      if let first = spot.items.filter(includeElement).first {
+        return spot.ui(atIndex: first.index)
+      }
+    }
+
+    for (_, cSpots) in compositeSpots {
+      for (_, spots) in cSpots.enumerate() {
+        for spot in spots.1 {
+          if let first = spot.items.filter(includeElement).first {
+            return spot.ui(atIndex: first.index)
+          }
+        }
+      }
+    }
+
+    return nil
+  }
+
   /**
    - Parameter includeElement: A filter predicate to find a spot
    */

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -207,8 +207,8 @@ extension SpotsProtocol {
         case .Removed:
           self.removeSpot(index)
         case .Items:
-          runClosure = self.setupItemsForSpot(index, 
-            newComponents: newComponents, 
+          runClosure = self.setupItemsForSpot(index,
+            newComponents: newComponents,
             withAnimation: animation,
             closure: closure)
         case .None: break

--- a/Sources/Shared/Protocols/SpotAdapter.swift
+++ b/Sources/Shared/Protocols/SpotAdapter.swift
@@ -3,6 +3,9 @@ import Brick
 
 public protocol SpotAdapter: class {
 
+  /// Resolve a UI component at index
+  func ui<T>(atIndex index: Int) -> T?
+  /// Append a view model to a Spotable object
   func append(item: ViewModel, withAnimation animation: SpotsAnimation, completion: Completion)
   /// Append a collection of view models to Spotable object
   func append(items: [ViewModel], withAnimation animation: SpotsAnimation, completion: Completion)

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -129,14 +129,8 @@ public class CarouselSpot: NSObject, Gridable {
     self.component = component
     super.init()
     configureLayout()
-
-    if CarouselSpot.views.defaultItem == nil {
-      CarouselSpot.views.defaultItem = Registry.Item.classType(CarouselSpotCell.self)
-    }
-
-    if CarouselSpot.views.composite == nil {
-      CarouselSpot.views.composite =  Registry.Item.classType(CarouselComposite.self)
-    }
+    registerDefault(view: CarouselSpotCell.self)
+    registerComposite(view: CarouselComposite.self)
   }
 
   /**

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -48,9 +48,8 @@ public class GridSpot: NSObject, Gridable {
 
     self.configureLayout()
 
-    if GridSpot.views.defaultItem == nil {
-      GridSpot.views.defaultItem = Registry.Item.classType(GridSpotCell.self)
-    }
+    registerDefault(view: GridSpotCell.self)
+    registerComposite(view: GridComposite.self)
 
     if GridSpot.views.composite == nil {
       GridSpot.views.composite =  Registry.Item.classType(GridComposite.self)

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -37,16 +37,10 @@ public class ListSpot: NSObject, Listable {
       self.component.kind = "list"
     }
 
+    registerDefault(view: ListSpotCell.self)
+    registerComposite(view: ListComposite.self)
     registerAndPrepare()
     setupTableView()
-
-    if ListSpot.views.defaultItem == nil {
-      ListSpot.views.defaultItem = Registry.Item.classType(ListSpotCell.self)
-    }
-
-    if ListSpot.views.composite == nil {
-      ListSpot.views.composite =  Registry.Item.classType(ListComposite.self)
-    }
   }
 
   public convenience init(tableView: UITableView? = nil, title: String = "", kind: String? = nil) {

--- a/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+Extensions+iOS.swift
@@ -4,6 +4,10 @@ import Brick
 
 public extension CollectionAdapter {
 
+  public func ui<T>(atIndex index: Int) -> T? {
+    return spot.collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0)) as? T
+  }
+
   /**
    - Parameter item: The view model that you want to append
    - Parameter withAnimation: The animation that should be used (currently not in use)

--- a/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/ListAdapter+Extensions+iOS.swift
@@ -3,6 +3,11 @@ import UIKit
 import Sugar
 
 extension ListAdapter {
+
+  public func ui<T>(atIndex index: Int) -> T? {
+    return spot.tableView.cellForRowAtIndexPath(NSIndexPath(forRow: index, inSection: 0)) as? T
+  }
+
   /**
    - Parameter item: The view model that you want to append
    - Parameter animation: The animation that should be used

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -63,12 +63,20 @@ class SpotsScrollViewTests: XCTestCase {
   }
 
   override func setUp() {
+    super.setUp()
+
     bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
     controller = SpotsController(initialJSON)
     controller.view.autoresizingMask = .None
     controller.view.frame.size = CGSize(width: 375, height: 667)
     controller.preloadView()
     controller.viewWillAppear(true)
+  }
+
+  override func tearDown() {
+    super.tearDown()
+
+    controller = nil
   }
 
   func testSpotsScrollView() {


### PR DESCRIPTION
This PR adds some convenience methods for looking up UI elements within `Spots`.

All adapters now support a `ui(atIndex:)` and you get a brand new `ui` query method on `SpotProtocol`.

```swift
func ui<T>(@noescape includeElement: (ViewModel) -> Bool) -> T?
```

it is used like this;

```swift
let cell: MyCell = controller?.ui({ $0.identifier == “my identifier”.hashValue})
```