### PR TITLE
Fix/reloadifneeded with components

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -150,7 +150,11 @@ public extension Spotable {
 
   /// A collection of view models
   var items: [Item] {
-    set(items) { component.items = items }
+    set(items) {
+      component.items = items
+      registerAndPrepare()
+      updateHeight()
+    }
     get { return component.items }
   }
 

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -67,7 +67,6 @@ public protocol Spotable: class {
   func delete(indexes: [Int], withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view model indexes with animation in a Spotable object
   func reload(indexes: [Int]?, withAnimation animation: SpotsAnimation, completion: Completion)
-
   func reloadIfNeeded(items: [Item], withAnimation animation: SpotsAnimation, completion: Completion)
   /// Reload view models if needed using change set
   func reloadIfNeeded(changes: ItemChanges, withAnimation animation: SpotsAnimation, updateDataSource: () -> Void, completion: Completion)


### PR DESCRIPTION
We had some issues where the list did not update properly until you started to scroll (the scrolling caused an update to correct the views `contentSize` and `frame`).

This PR aims to correct the problem by updating the size when ever you perform an mutation to the collection of items on `SpotsController`. 