### PR TITLE
Add guard if reloading without components

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -36,6 +36,15 @@ extension SpotsProtocol {
 
   #if !os(OSX)
   public func reloadIfNeeded(components: [Component], withAnimation animation: SpotsAnimation = .Automatic, closure: Completion = nil) {
+    guard !components.isEmpty else {
+      Dispatch.mainQueue {
+        self.spots.forEach { $0.render().removeFromSuperview() }
+        self.spots = []
+        closure?()
+      }
+      return
+    }
+
     Dispatch.inQueue(queue: .Interactive) {
       let newComponents = components
       let oldComponents = self.spots.map { $0.component }


### PR DESCRIPTION
We had a small issue that if you tried to use `reloadIfNeeded` without components, it wouldn’t update properly. To solve this, we now have a `guard` at the top of the method to check if there are any new components coming in.

I went with `guard` because if the collection is empty, there is also no point in comparing the existing components with an empty collection.