### PR TITLE
Remove force update method on SpotsScrollView

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -49,7 +49,6 @@ import Cache
                 (gridable.layout as? GridableLayout)?.yOffset = gridable.render().frame.origin.y
               }
               #endif
-              self.spotsScrollView.forceUpdate = true
             }
             print("Spots reloaded: \(self.spots.count)")
             self.liveEditing(self.stateCache)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -27,7 +27,6 @@ extension SpotsProtocol {
 
           if spotsLeft == 0 {
             completion?()
-            self?.spotsScrollView.forceUpdate = true
           }
         }
       }
@@ -74,7 +73,6 @@ extension SpotsProtocol {
 
       self.process(changes: changes, components: newComponents, withAnimation: animation) {
         closure?()
-        self.spotsScrollView.forceUpdate = true
       }
     }
   }
@@ -103,10 +101,10 @@ extension SpotsProtocol {
 
   private func newSpot(index: Int, newComponents: [Component], inout yOffset: CGFloat) {
     let spot = SpotFactory.resolve(newComponents[index])
-    self.spots.append(spot)
-    self.setupSpot(index, spot: spot)
+    spots.append(spot)
+    setupSpot(index, spot: spot)
     (spot as? Gridable)?.layout.yOffset = yOffset
-    self.spotsScrollView.contentView.addSubview(spot.render())
+    spotsScrollView.contentView.addSubview(spot.render())
     yOffset += spot.render().frame.size.height
   }
 
@@ -159,7 +157,6 @@ extension SpotsProtocol {
           }
         }
 
-        self.spotsScrollView.forceUpdate = true
         closure?()
         CATransaction.commit()
       }
@@ -170,7 +167,6 @@ extension SpotsProtocol {
       }) {
         guard !newItems.isEmpty else {
           closure?()
-          self.spotsScrollView.forceUpdate = true
           CATransaction.commit()
           return
         }
@@ -192,7 +188,6 @@ extension SpotsProtocol {
           spot.update(item, index: index, withAnimation: animation) {
             guard index == executeClosure else { return }
             closure?()
-            self.spotsScrollView.forceUpdate = true
             CATransaction.commit()
           }
         }
@@ -205,7 +200,6 @@ extension SpotsProtocol {
         spot.adapter?.reload(nil, withAnimation: animation) {
           closure?()
           Dispatch.delay(for: 0.1) {
-            self.spotsScrollView.forceUpdate = true
             CATransaction.commit()
           }
         }
@@ -302,7 +296,6 @@ extension SpotsProtocol {
       }
 
       completion?()
-      weakSelf.spotsScrollView.forceUpdate = true
 
       offsets.enumerate().forEach {
         newSpots[$0.index].render().contentOffset = $0.element
@@ -330,7 +323,6 @@ extension SpotsProtocol {
       weakSelf.setupSpots(animated)
 
       completion?()
-      weakSelf.spotsScrollView.forceUpdate = true
     }
   }
 
@@ -343,7 +335,6 @@ extension SpotsProtocol {
   public func update(spotAtIndex index: Int = 0, withAnimation animation: SpotsAnimation = .Automatic, withCompletion completion: Completion = nil, @noescape _ closure: (spot: Spotable) -> Void) {
     guard let spot = spot(index, Spotable.self) else {
       completion?()
-      self.spotsScrollView.forceUpdate = true
       return }
     closure(spot: spot)
     spot.refreshIndexes()
@@ -359,7 +350,6 @@ extension SpotsProtocol {
 
       weakSelf.spot(index, Spotable.self)?.reload(nil, withAnimation: animation) {
         completion?()
-        weakSelf.spotsScrollView.forceUpdate = true
       }
     }
   }
@@ -375,13 +365,11 @@ extension SpotsProtocol {
   public func updateIfNeeded(spotAtIndex index: Int = 0, items: [Item], withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     guard let spot = spot(index, Spotable.self) where !(spot.items == items) else {
       completion?()
-      self.spotsScrollView.forceUpdate = true
       return
     }
 
     update(spotAtIndex: index, withAnimation: animation, withCompletion: completion, {
       $0.items = items
-      self.spotsScrollView.forceUpdate = true
     })
   }
 
@@ -394,7 +382,6 @@ extension SpotsProtocol {
   public func append(item: Item, spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(item, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -408,7 +395,6 @@ extension SpotsProtocol {
   public func append(items: [Item], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.append(items, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -422,7 +408,6 @@ extension SpotsProtocol {
   public func prepend(items: [Item], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.prepend(items, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -437,7 +422,6 @@ extension SpotsProtocol {
   public func insert(item: Item, index: Int = 0, spotIndex: Int, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.insert(item, index: index, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -454,13 +438,11 @@ extension SpotsProtocol {
       else {
         spot(spotIndex, Spotable.self)?.refreshIndexes()
         completion?()
-        self.spotsScrollView.forceUpdate = true
         return
     }
 
     spot(spotIndex, Spotable.self)?.update(item, index: index, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -474,7 +456,6 @@ extension SpotsProtocol {
   public func update(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .Automatic, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.reload(indexes, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -488,7 +469,6 @@ extension SpotsProtocol {
   public func delete(index: Int, spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.delete(index, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }
@@ -502,7 +482,6 @@ extension SpotsProtocol {
   public func delete(indexes indexes: [Int], spotIndex: Int = 0, withAnimation animation: SpotsAnimation = .None, completion: Completion = nil) {
     spot(spotIndex, Spotable.self)?.delete(indexes, withAnimation: animation) {
       completion?()
-      self.spotsScrollView.forceUpdate = true
     }
     spot(spotIndex, Spotable.self)?.refreshIndexes()
   }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -223,8 +223,6 @@ public class SpotsController: UIViewController, SpotsProtocol, SpotsCompositeDel
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
 
-    defer { spotsScrollView.forceUpdate = true }
-
     if let tabBarController = self.tabBarController
       where tabBarController.tabBar.translucent {
         spotsScrollView.contentInset.bottom = tabBarController.tabBar.frame.size.height
@@ -236,16 +234,6 @@ public class SpotsController: UIViewController, SpotsProtocol, SpotsCompositeDel
 
     spotsScrollView.insertSubview(refreshControl, atIndex: 0)
 #endif
-  }
-
-  /**
-   Notifies the view controller that its view was added to a view hierarchy.
-
-   - parameter animated: If true, the view was added to the window using an animation.
-   */
-  override public func viewDidAppear(animated: Bool) {
-    spotsScrollView.forceUpdate = true
-    super.viewDidAppear(animated)
   }
 
   func configureView(withSize size: CGSize) {

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -4,10 +4,10 @@ import QuartzCore
 public class SpotsScrollView: UIScrollView {
 
   enum ObservedKeypath: String {
-    case ContentOffset = "contentOffset"
-    case ContentSize   = "contentSize"
-    case Frame         = "frame"
-    case Bounds        = "bounds"
+    case contentOffset = "contentOffset"
+    case contentSize   = "contentSize"
+    case frame         = "frame"
+    case bounds        = "bounds"
   }
 
   /// A KVO context used to monitor changes in contentSize, frames and bounds
@@ -72,8 +72,8 @@ public class SpotsScrollView: UIScrollView {
     subviewsInLayoutOrder.insert(subview, atIndex: index)
 
     if subview.superview == contentView && !(subview is UIScrollView) {
-      subview.addObserver(self, forKeyPath: ObservedKeypath.Frame.rawValue, options: .Old, context: subviewContext)
-      subview.addObserver(self, forKeyPath: ObservedKeypath.Bounds.rawValue, options: .Old, context: subviewContext)
+      subview.addObserver(self, forKeyPath: ObservedKeypath.frame.rawValue, options: .Old, context: subviewContext)
+      subview.addObserver(self, forKeyPath: ObservedKeypath.bounds.rawValue, options: .Old, context: subviewContext)
     }
 
     guard let scrollView = subview as? UIScrollView else {
@@ -92,8 +92,8 @@ public class SpotsScrollView: UIScrollView {
       scrollView.scrollEnabled = true
     }
 
-    scrollView.addObserver(self, forKeyPath: ObservedKeypath.ContentSize.rawValue, options: .Old, context: subviewContext)
-    scrollView.addObserver(self, forKeyPath: ObservedKeypath.ContentOffset.rawValue, options: .Old, context: subviewContext)
+    scrollView.addObserver(self, forKeyPath: ObservedKeypath.contentSize.rawValue, options: .Old, context: subviewContext)
+    scrollView.addObserver(self, forKeyPath: ObservedKeypath.contentOffset.rawValue, options: .Old, context: subviewContext)
 
     setNeedsLayout()
   }
@@ -105,11 +105,11 @@ public class SpotsScrollView: UIScrollView {
    */
   public override func willRemoveSubview(subview: UIView) {
     if subview is UIScrollView && subview.superview == contentView {
-      subview.removeObserver(self, forKeyPath: ObservedKeypath.ContentSize.rawValue, context: subviewContext)
-      subview.removeObserver(self, forKeyPath: ObservedKeypath.ContentOffset.rawValue, context: subviewContext)
+      subview.removeObserver(self, forKeyPath: ObservedKeypath.contentSize.rawValue, context: subviewContext)
+      subview.removeObserver(self, forKeyPath: ObservedKeypath.contentOffset.rawValue, context: subviewContext)
     } else if subview.superview == contentView {
-      subview.removeObserver(self, forKeyPath: ObservedKeypath.Frame.rawValue, context: subviewContext)
-      subview.removeObserver(self, forKeyPath: ObservedKeypath.Bounds.rawValue, context: subviewContext)
+      subview.removeObserver(self, forKeyPath: ObservedKeypath.frame.rawValue, context: subviewContext)
+      subview.removeObserver(self, forKeyPath: ObservedKeypath.bounds.rawValue, context: subviewContext)
     }
 
     if let index = subviewsInLayoutOrder.indexOf({ $0 == subview }) {
@@ -131,14 +131,14 @@ public class SpotsScrollView: UIScrollView {
     if let change = change where context == subviewContext {
       if let scrollView = object as? UIScrollView {
         guard let change = change[NSKeyValueChangeOldKey] else { return }
-        if keyPath == ObservedKeypath.ContentSize.rawValue {
+        if keyPath == ObservedKeypath.contentSize.rawValue {
           let oldContentSize = change.CGSizeValue()
           let newContentSize = scrollView.contentSize
           if !CGSizeEqualToSize(newContentSize, oldContentSize) {
             setNeedsLayout()
             layoutIfNeeded()
           }
-        } else if keyPath == ObservedKeypath.ContentOffset.rawValue {
+        } else if keyPath == ObservedKeypath.contentOffset.rawValue {
           let oldOffset = change.CGPointValue()
           let newOffset = scrollView.contentOffset
           if !CGPointEqualToPoint(newOffset, oldOffset) {


### PR DESCRIPTION
I never liked the `forceUpdate` hack that we had to force and update to the view. This PR removes that property on `SpotsScrollView` because it should no longer be needed.

Now, `SpotsScrollView` will observe the `contentOffset` of it’s children, which means that if that changes in some way, it should align the views like you would expect them to be laid out on screen.

So, no more need to call this method in your completion closures.

Because the property is removed, you could consider this as a breaking change. The only migration that you need in your implementation is to remove setting the property to `true`.