### PR TITLE
Improve SpotsScrollView layout operations

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -118,6 +118,7 @@ public class SpotsScrollView: UIScrollView {
     }
 
     setNeedsLayout()
+    layoutSubviews()
   }
 
   /**

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -96,6 +96,7 @@ public class SpotsScrollView: UIScrollView {
     scrollView.addObserver(self, forKeyPath: ObservedKeypath.contentOffset.rawValue, options: .Old, context: subviewContext)
 
     setNeedsLayout()
+    layoutSubviews()
   }
 
   /**
@@ -216,7 +217,7 @@ public class SpotsScrollView: UIScrollView {
       self.frame.size.height = superview.frame.size.height
     }
 
-    guard initialContentOffset != contentOffset else { return }
+    guard !CGPointEqualToPoint(initialContentOffset, contentOffset) else { return }
     setNeedsLayout()
     layoutIfNeeded()
   }


### PR DESCRIPTION
To ensure that the layout is correct even before the ui scrolls, we now call `layoutSubviews()` whenever a view is add or removed from the content view.

This also fixes the tests that I seemed to have broken in the last PR. Sorry about that… fixed now.

P.S
Keep      Summer      safe.