### PR TITLE
Refactor/spot configurable

### DIFF
--- a/Playgrounds/Playground-iOS.playground/Contents.swift
+++ b/Playgrounds/Playground-iOS.playground/Contents.swift
@@ -15,7 +15,7 @@ enum Cell: String, StringConvertible {
 
 public class ListCell: UITableViewCell, SpotConfigurable {
 
-  public var size = CGSize(width: 0, height: 60)
+  public var preferredViewSize: CGSize(width: 0, height: 60)
   public var item: Item?
 
   lazy var selectedView: UIView = {
@@ -99,7 +99,7 @@ public class ListHeaderView: UIView, Componentable {
 
 class GridTopicCell: UICollectionViewCell, SpotConfigurable {
 
-  var size = CGSize(width: 125, height: 160)
+  var preferredViewSize: CGSize(width: 125, height: 160)
 
   lazy var label: UILabel = {
     let label = UILabel()

--- a/Playgrounds/Playground-iOS.playground/timeline.xctimeline
+++ b/Playgrounds/Playground-iOS.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7196&amp;EndingColumnNumber=16&amp;EndingLineNumber=229&amp;StartingColumnNumber=1&amp;StartingLineNumber=229&amp;Timestamp=496573830.744972"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7220&amp;EndingColumnNumber=16&amp;EndingLineNumber=229&amp;StartingColumnNumber=1&amp;StartingLineNumber=229&amp;Timestamp=496838613.929928"
          lockedSize = "{357, 436}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">

--- a/Sources/Mac/Classes/GridSpotItem.swift
+++ b/Sources/Mac/Classes/GridSpotItem.swift
@@ -27,7 +27,7 @@ public class GridSpotItem: NSCollectionViewItem, SpotConfigurable {
     }
   }
 
-  public var preferredViewSize: CGSize(width: 0, height: 88)
+  public var preferredViewSize = CGSize(width: 0, height: 88)
   public var customView = FlippedView()
 
   public lazy var customImageView: NSImageView = {

--- a/Sources/Mac/Classes/GridSpotItem.swift
+++ b/Sources/Mac/Classes/GridSpotItem.swift
@@ -27,7 +27,7 @@ public class GridSpotItem: NSCollectionViewItem, SpotConfigurable {
     }
   }
 
-  public var size = CGSize(width: 0, height: 88)
+  public var preferredViewSize: CGSize(width: 0, height: 88)
   public var customView = FlippedView()
 
   public lazy var customImageView: NSImageView = {

--- a/Sources/Mac/Classes/ListSpotItem.swift
+++ b/Sources/Mac/Classes/ListSpotItem.swift
@@ -19,7 +19,7 @@ public class ListSpotItem: NSTableRowView, SpotConfigurable {
     }
   }
 
-  public var size = CGSize(width: 0, height: 88)
+  public var preferredViewSize: CGSize(width: 0, height: 88)
 
   lazy var titleLabel: NSTextField = {
     let titleLabel = NSTextField()

--- a/Sources/Mac/Classes/ListSpotItem.swift
+++ b/Sources/Mac/Classes/ListSpotItem.swift
@@ -19,7 +19,7 @@ public class ListSpotItem: NSTableRowView, SpotConfigurable {
     }
   }
 
-  public var preferredViewSize: CGSize(width: 0, height: 88)
+  public var preferredViewSize = CGSize(width: 0, height: 88)
 
   lazy var titleLabel: NSTextField = {
     let titleLabel = NSTextField()

--- a/Sources/Mac/Extensions/Gridable+Mac.swift
+++ b/Sources/Mac/Extensions/Gridable+Mac.swift
@@ -104,11 +104,11 @@ extension Gridable {
 
     if usesViewSize {
       if viewModel.size.height == 0 {
-        viewModel.size.height = view.size.height
+        viewModel.size.height = view.preferredViewSize.height
       }
 
       if viewModel.size.width == 0 {
-        viewModel.size.width = view.size.width
+        viewModel.size.width = view.preferredViewSize.width
       }
     }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -329,11 +329,11 @@ public extension Spotable {
 
     if usesViewSize {
       if viewModel.size.height == 0 {
-        viewModel.size.height = (view as? SpotConfigurable)?.size.height ?? 0.0
+        viewModel.size.height = (view as? SpotConfigurable)?.preferredViewSize.height ?? 0.0
       }
 
       if viewModel.size.width == 0 {
-        viewModel.size.width = (view as? SpotConfigurable)?.size.width ?? 0.0
+        viewModel.size.width = (view as? SpotConfigurable)?.preferredViewSize.width ?? 0.0
       }
     }
 

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -43,7 +43,7 @@ public extension Spotable where Self : Viewable {
 
         if let spotConfigurable = view as? SpotConfigurable {
           spotConfigurable.configure(&component.items[index])
-          view.frame.size = spotConfigurable.size
+          view.frame.size = spotConfigurable.preferredViewSize
         }
 
         scrollView.addSubview(view)
@@ -78,7 +78,7 @@ public extension Spotable where Self : Viewable {
 
     let view = classType.init()
     (view as? SpotConfigurable)?.configure(&component.items[index])
-    if let size = (view as? SpotConfigurable)?.size {
+    if let size = (view as? SpotConfigurable)?.preferredViewSize {
       view.frame.size = size
     }
 
@@ -101,7 +101,7 @@ public extension Spotable where Self : Viewable {
 
       let view = classType.init()
       (view as? SpotConfigurable)?.configure(&component.items[index])
-      if let size = (view as? SpotConfigurable)?.size {
+      if let size = (view as? SpotConfigurable)?.preferredViewSize {
         view.frame.size = size
       }
 
@@ -124,7 +124,7 @@ public extension Spotable where Self : Viewable {
 
     let view = classType.init()
     (view as? SpotConfigurable)?.configure(&component.items[index])
-    if let size = (view as? SpotConfigurable)?.size {
+    if let size = (view as? SpotConfigurable)?.preferredViewSize {
       view.frame.size = size
     }
     #if os(iOS)
@@ -149,7 +149,7 @@ public extension Spotable where Self : Viewable {
 
       let view = classType.init()
       (view as? SpotConfigurable)?.configure(&component.items[index])
-      if let size = (view as? SpotConfigurable)?.size {
+      if let size = (view as? SpotConfigurable)?.preferredViewSize {
         view.frame.size = size
       }
       #if os(iOS)

--- a/Sources/Shared/Protocols/SpotConfigurable.swift
+++ b/Sources/Shared/Protocols/SpotConfigurable.swift
@@ -8,5 +8,5 @@ import Brick
 
 public protocol SpotConfigurable: ItemConfigurable {
 
-  var size: CGSize { get set }
+  var preferredViewSize: CGSize { get set }
 }

--- a/Sources/Shared/Protocols/SpotConfigurable.swift
+++ b/Sources/Shared/Protocols/SpotConfigurable.swift
@@ -8,5 +8,5 @@ import Brick
 
 public protocol SpotConfigurable: ItemConfigurable {
 
-  var preferredViewSize: CGSize { get set }
+  var preferredViewSize: CGSize { get }
 }

--- a/Sources/iOS/Classes/CarouselSpotCell.swift
+++ b/Sources/iOS/Classes/CarouselSpotCell.swift
@@ -4,7 +4,7 @@ import Brick
 /// A default cell for the CarouselSpot
 class CarouselSpotCell: UICollectionViewCell, SpotConfigurable {
 
-  var size = CGSize(width: 88, height: 88)
+  var preferredViewSize: CGSize = CGSize(width: 88, height: 88)
   var item: Item?
 
   var label: UILabel = {

--- a/Sources/iOS/Classes/GridSpotCell.swift
+++ b/Sources/iOS/Classes/GridSpotCell.swift
@@ -3,7 +3,7 @@ import Brick
 
 class GridSpotCell: UICollectionViewCell, SpotConfigurable {
 
-  var size = CGSize(width: 88, height: 88)
+  var preferredViewSize = CGSize(width: 88, height: 88)
   var item: Item?
 
   var label: UILabel = {

--- a/Sources/iOS/Classes/ListSpotCell.swift
+++ b/Sources/iOS/Classes/ListSpotCell.swift
@@ -3,7 +3,7 @@ import Brick
 
 public class ListSpotCell: UITableViewCell, SpotConfigurable {
 
-  public var size = CGSize(width: 0, height: 44)
+  public var preferredViewSize = CGSize(width: 0, height: 44)
   public var item: Item?
 
   public override init(style: UITableViewCellStyle, reuseIdentifier: String!) {
@@ -25,6 +25,6 @@ public class ListSpotCell: UITableViewCell, SpotConfigurable {
     textLabel?.text = item.title
     imageView?.image = UIImage(named: item.image)
 
-    item.size.height = item.size.height > 0.0 ? item.size.height : size.height
+    item.size.height = item.size.height > 0.0 ? item.size.height : preferredViewSize.height
   }
 }

--- a/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
+++ b/Sources/iOS/Extensions/CollectionAdapter+UICollectionViewDataSource.swift
@@ -52,7 +52,7 @@ extension CollectionAdapter : UICollectionViewDataSource {
     } else if let cell = cell as? SpotConfigurable {
       cell.configure(&spot.component.items[indexPath.item])
       if spot.component.items[indexPath.item].size.height == 0.0 {
-        spot.component.items[indexPath.item].size = cell.size
+        spot.component.items[indexPath.item].size = cell.preferredViewSize
       }
       spot.configure?(cell)
     }

--- a/Sources/iOS/Extensions/ListAdapter+UITableViewDataSource.swift
+++ b/Sources/iOS/Extensions/ListAdapter+UITableViewDataSource.swift
@@ -41,7 +41,7 @@ extension ListAdapter: UITableViewDataSource {
       cell.configure(&spot.component.items[indexPath.item])
 
       if spot.component.items[indexPath.item].size.height == 0.0 {
-        spot.component.items[indexPath.item].size = cell.size
+        spot.component.items[indexPath.item].size = cell.preferredViewSize
       }
 
       spot.configure?(cell)

--- a/Spots.podspec
+++ b/Spots.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Spots"
   s.summary          = "Spots is a view controller framework that makes your setup and future development blazingly fast."
-  s.version          = "3.0.5"
+  s.version          = "4.0.0"
   s.homepage         = "https://github.com/hyperoslo/Spots"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 		BD129F2B1D7B2F91009AC164 /* SpotsAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsAnimation.swift; sourceTree = "<group>"; };
 		BD129F2D1D7B2F91009AC164 /* Component+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+Extension.swift"; sourceTree = "<group>"; };
 		BD129F2E1D7B2F91009AC164 /* Gridable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Gridable+Extensions.swift"; sourceTree = "<group>"; };
-		BD129F2F1D7B2F91009AC164 /* Spotable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Spotable+Extensions.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		BD129F2F1D7B2F91009AC164 /* Spotable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Spotable+Extensions.swift"; sourceTree = "<group>"; };
 		BD129F301D7B2F91009AC164 /* SpotsProtocol+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Extensions.swift"; sourceTree = "<group>"; };
 		BD129F311D7B2F91009AC164 /* SpotsProtocol+LiveEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+LiveEditing.swift"; sourceTree = "<group>"; };
 		BD129F321D7B2F91009AC164 /* SpotsProtocol+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Mutation.swift"; sourceTree = "<group>"; };


### PR DESCRIPTION
⚠️ **Breaking change** ⚠️ 

This PR aims to improve the naming of properties in `SpotConfiguable`. `size` was a bit unclear of what it actually did so this PR renames that property to `preferredViewSize`.

The previous naming was misleading because it didn’t imply that it was optional. Doing a view with dynamic height does not rely on this property, or… it could but it’s doesn’t have to.

Hence this naming being more clear.

This is fairly easy to migrate as it is pretty much a search & replace operation. And seeing that we already broke the API in a previous commit, I also updated the version in the podspec.