### PR TITLE
Fix dependence of UIScreen

### DIFF
--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -47,11 +47,11 @@ public extension Spotable where Self : Gridable {
       configureItem(index, usesViewSize: true)
       if component.span > 0 {
         #if os(OSX)
-          if let layout = layout as? NSCollectionViewFlowLayout where component.span > 0 {
+          if let layout = layout as? NSCollectionViewFlowLayout {
             component.items[index].size.width = collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
           }
         #else
-          component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
+          component.items[index].size.width = collectionView.bounds.size.width / CGFloat(component.span)
         #endif
       }
     }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -70,9 +70,9 @@ public class GridableLayout: UICollectionViewFlowLayout {
     var rect = CGRect(origin: CGPoint.zero, size: contentSize)
 
     if headerReferenceSize.height > 0.0 {
-      rect.origin = CGPoint(x: -UIScreen.mainScreen().bounds.width, y: 0)
+      rect.origin = CGPoint(x: -collectionView.bounds.width, y: 0)
       rect.size.height = contentSize.height
-      rect.size.width = UIScreen.mainScreen().bounds.width * 3
+      rect.size.width = collectionView.bounds.width * 3
     }
 
     if let newAttributes = super.layoutAttributesForElementsInRect(rect) {

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -44,18 +44,6 @@ extension Gridable {
   }
 
   /**
-   Prepares all items in the Gridable object component
-   */
-  public func prepareItems() {
-    component.items.enumerate().forEach { (index: Int, _) in
-      configureItem(index, usesViewSize: true)
-      if component.span > 0 {
-        component.items[index].size.width = UIScreen.mainScreen().bounds.size.width / CGFloat(component.span)
-      }
-    }
-  }
-
-  /**
    - parameter size: A CGSize to set the width and height of the collection view
    */
   public func layout(size: CGSize) {

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -16,11 +16,11 @@ extension SpotsController {
     let multiplier: CGFloat = !refreshPositions.isEmpty
       ? CGFloat(1 + refreshPositions.count)
       : 1
-    let itemOffset = (size.height - UIScreen.mainScreen().bounds.size.height * 2) > 0
-      ? UIScreen.mainScreen().bounds.size.height * 2
+    let itemOffset = (size.height - scrollView.bounds.size.height * 2) > 0
+      ? scrollView.bounds.size.height * 2
       : (spots.last?.component.items.last?.size.height ?? 0) * 6
     let shouldFetch = !refreshing &&
-      size.height > UIScreen.mainScreen().bounds.height &&
+      size.height > scrollView.bounds.height &&
       offset.y > size.height - scrollView.bounds.height * multiplier &&
       !refreshPositions.contains(size.height - itemOffset)
 

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -157,7 +157,7 @@ class CarouselSpotTests: XCTestCase {
     // Check `paginate` mapping
     XCTAssertTrue(spot.paginate)
 
-    let width = UIScreen.mainScreen().bounds.width / 4
+    let width = spot.render().bounds.width / 4
 
     // Test that spot height is equal to first item in the list
     XCTAssertEqual(spot.items.count, 4)


### PR DESCRIPTION
This PR aims to fix #320, it shouldn't rely on `UIScreen` when doing size calculations.

To fix this, we now rely on the closest parent to where the calculation is done.