### PR TITLE
Check for dragging and tracking in SpotsScrollView

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -141,7 +141,9 @@ public class SpotsScrollView: UIScrollView {
             setNeedsLayout()
             layoutIfNeeded()
           }
-        } else if keyPath == ObservedKeypath.contentOffset.rawValue {
+        } else if keyPath == ObservedKeypath.contentOffset.rawValue
+          && (dragging == false && tracking == false)
+        {
           let oldOffset = change.CGPointValue()
           let newOffset = scrollView.contentOffset
           if !CGPointEqualToPoint(newOffset, oldOffset) {

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -142,8 +142,7 @@ public class SpotsScrollView: UIScrollView {
             layoutIfNeeded()
           }
         } else if keyPath == ObservedKeypath.contentOffset.rawValue
-          && (dragging == false && tracking == false)
-        {
+          && (dragging == false && tracking == false) {
           let oldOffset = change.CGPointValue()
           let newOffset = scrollView.contentOffset
           if !CGPointEqualToPoint(newOffset, oldOffset) {


### PR DESCRIPTION
When we removed the `forceUpdate` property, we introduce another KVO to observe `contentOffset`. This has some negative side-effects that it gets called when a user scrolls which is not really what we want as it is doing more calculations that is actually has to.

This PR improve performance when scrolling by including some extra criteria for when the operation should be invoked.

Now it checks if both `dragging` and `tracking` is set to `false` before calling `layoutIfNeeded`. This way it won’t have the same negative side-effects. It would still run when performing mutation like want it to.