### PR TITLE
Fix items

### DIFF
--- a/Sources/Shared/Classes/Registry.swift
+++ b/Sources/Shared/Classes/Registry.swift
@@ -102,7 +102,7 @@ public class Registry {
     }
 
     if let view = view {
-      cache.setObject(view, forKey: identifier)
+      cache.setObject(view, forKey: registryType!.rawValue + identifier)
     }
 
     return (type: registryType, view: view)

--- a/Sources/Shared/Classes/Registry.swift
+++ b/Sources/Shared/Classes/Registry.swift
@@ -74,13 +74,13 @@ public class Registry {
   func make(identifier: String) -> (type: RegistryType?, view: View?)? {
     guard let item = storage[identifier] else { return nil }
 
-    let registryType: RegistryType?
+    let registryType: RegistryType
     var view: View? = nil
 
     switch item {
     case .classType(let classType):
       registryType = .Regular
-      if let view = cache.objectForKey(registryType!.rawValue + identifier) as? View {
+      if let view = cache.objectForKey(registryType.rawValue + identifier) as? View {
         return (type: registryType, view: view)
       }
 
@@ -88,7 +88,7 @@ public class Registry {
 
     case .nib(let nib):
       registryType = .Nib
-      if let view = cache.objectForKey(registryType!.rawValue + identifier) as? View {
+      if let view = cache.objectForKey(registryType.rawValue + identifier) as? View {
         return (type: registryType, view: view)
       }
       #if os(OSX)
@@ -102,7 +102,7 @@ public class Registry {
     }
 
     if let view = view {
-      cache.setObject(view, forKey: registryType!.rawValue + identifier)
+      cache.setObject(view, forKey: registryType.rawValue + identifier)
     }
 
     return (type: registryType, view: view)

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -221,9 +221,12 @@ public extension Spotable {
    Refreshes the indexes of all items within the component
    */
   public func refreshIndexes() {
-    items.enumerate().forEach {
-      items[$0.index].index = $0.index
+    var updatedItems  = items
+    updatedItems.enumerate().forEach {
+      updatedItems[$0.index].index = $0.index
     }
+
+    items = updatedItems
   }
 
   /**


### PR DESCRIPTION
- Correct use of key in NSCache
- Update items on temp array before assigning back to items. The problem is if we change a property for 1 item in the `items` array, `didSet` will trigger a lot of other actions, which is not what we want. This is a small snippets https://github.com/onmyway133/notes/issues/225

This ensure we only update `items` once. But the root of the problem is that we should trigger `didSet` when truly needed