### PR TITLE
Seed the initial size for dummy views

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "krzyzanowskim/CryptoSwift" "0.5.2"
 github "zenangst/Tailor" "1.3.0"
-github "hyperoslo/Brick" "0.9.6"
-github "hyperoslo/Cache" "cff7ea060664c856ec76f3345cf1e541b5dc0e18"
+github "hyperoslo/Brick" "1.0.0"
+github "hyperoslo/Cache" "1.5.1"

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -341,13 +341,17 @@ public extension Spotable {
       (view as? SpotConfigurable)?.configure(&viewModel)
     #endif
 
-    if usesViewSize {
+    if let itemView = view as? SpotConfigurable where usesViewSize {
       if viewModel.size.height == 0 {
-        viewModel.size.height = (view as? SpotConfigurable)?.preferredViewSize.height ?? 0.0
+        viewModel.size.height = itemView.preferredViewSize.height ?? 0.0
       }
 
       if viewModel.size.width == 0 {
-        viewModel.size.width = (view as? SpotConfigurable)?.preferredViewSize.width ?? 0.0
+        viewModel.size.width = itemView.preferredViewSize.width ?? 0.0
+      }
+
+      if viewModel.size.width == 0 {
+        viewModel.size.width = view.bounds.width
       }
     }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -312,6 +312,17 @@ public extension Spotable {
     guard let (_, resolvedView) = Self.views.make(kind),
       view = resolvedView else { return }
 
+    // Set initial size for view
+    view.frame.size = render().frame.size
+
+    if let view = view as? UITableViewCell {
+      view.contentView.frame = view.bounds
+    }
+
+    if let view = view as? UICollectionViewCell {
+      view.contentView.frame = view.bounds
+    }
+
     #if !os(OSX)
       if let composite = view as? SpotComposable {
         let spots = composite.parse(viewModel)

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -313,19 +313,6 @@ public extension Spotable {
       view = resolvedView else { return }
 
     #if !os(OSX)
-      // Set initial size for view
-      view.frame.size = render().frame.size
-
-      if let view = view as? UITableViewCell {
-        view.contentView.frame = view.bounds
-      }
-
-      if let view = view as? UICollectionViewCell {
-        view.contentView.frame = view.bounds
-      }
-    #endif
-
-    #if !os(OSX)
       if let composite = view as? SpotComposable {
         let spots = composite.parse(viewModel)
 
@@ -337,6 +324,17 @@ public extension Spotable {
           spotsCompositeDelegate?.compositeSpots[component.index]?[index] = spots
         }
       } else {
+        // Set initial size for view
+        view.frame.size = render().frame.size
+
+        if let view = view as? UITableViewCell {
+          view.contentView.frame = view.bounds
+        }
+
+        if let view = view as? UICollectionViewCell {
+          view.contentView.frame = view.bounds
+        }
+        
         (view as? SpotConfigurable)?.configure(&viewModel)
       }
     #else

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -312,16 +312,18 @@ public extension Spotable {
     guard let (_, resolvedView) = Self.views.make(kind),
       view = resolvedView else { return }
 
-    // Set initial size for view
-    view.frame.size = render().frame.size
+    #if !os(OSX)
+      // Set initial size for view
+      view.frame.size = render().frame.size
 
-    if let view = view as? UITableViewCell {
-      view.contentView.frame = view.bounds
-    }
+      if let view = view as? UITableViewCell {
+        view.contentView.frame = view.bounds
+      }
 
-    if let view = view as? UICollectionViewCell {
-      view.contentView.frame = view.bounds
-    }
+      if let view = view as? UICollectionViewCell {
+        view.contentView.frame = view.bounds
+      }
+    #endif
 
     #if !os(OSX)
       if let composite = view as? SpotComposable {

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -290,6 +290,8 @@ public class SpotsController: UIViewController, SpotsProtocol, SpotsCompositeDel
   }
 
   public func setupSpot(index: Int, spot: Spotable) {
+    spot.render().bounds.size.width = view.bounds.width
+    spot.render().frame.origin.x = 0.0
     spot.spotsCompositeDelegate = self
     spots[index].component.index = index
     spot.registerAndPrepare()


### PR DESCRIPTION
As of https://github.com/hyperoslo/Spots/issues/320

So this use `render()` size to seed the size for the dummy views from Registry. So the `configure` in cells can be based on `contentView`. 