### PR TITLE
Improve macOS scrolling in CarouselSpot

### DIFF
--- a/Examples/SpotifyMac/Podfile
+++ b/Examples/SpotifyMac/Podfile
@@ -7,12 +7,12 @@ inhibit_all_warnings!
 target "Spotify Mac" do
   core_pods
   pod 'Alamofire', '4.0.1'
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar.git', branch: 'swift-3'
+  pod 'Sugar'
   pod 'JWTDecode', '2.0.0'
   pod 'Fashion', '2.0.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary.git', branch: 'swift-3'
-  pod 'Hue', git: 'https://github.com/hyperoslo/Hue.git', branch: 'swift-3'
-  pod 'Compass', git: 'https://github.com/hyperoslo/Compass', branch: 'swift-3'
+  pod 'Hue'
+  pod 'Compass'
   pod 'Malibu', '2.0.0'
   pod 'OhMyAuth', git: 'https://github.com/hyperoslo/OhMyAuth.git', branch: 'swift-3'
   pod 'Keychain', git: 'https://github.com/hyperoslo/Keychain.git', branch: 'swift-3'

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Alamofire (4.0.1)
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.0):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
-  - Compass (3.0.0)
+  - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fashion (2.0.0)
   - Hue (2.0.0)
@@ -19,45 +19,33 @@ PODS:
     - JWTDecode
     - Keychain
     - Sugar
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.1):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
   - When (2.0.0)
 
 DEPENDENCIES:
   - Alamofire (= 4.0.1)
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
-  - Compass (from `https://github.com/hyperoslo/Compass`, branch `swift-3`)
+  - Brick
+  - Cache
+  - Compass
   - CryptoSwift (= 0.6.0)
   - Fashion (= 2.0.0)
-  - Hue (from `https://github.com/hyperoslo/Hue.git`, branch `swift-3`)
+  - Hue
   - Imaginary (from `https://github.com/hyperoslo/Imaginary.git`, branch `swift-3`)
   - JWTDecode (= 2.0.0)
   - Keychain (from `https://github.com/hyperoslo/Keychain.git`, branch `swift-3`)
   - Malibu (= 2.0.0)
   - OhMyAuth (from `https://github.com/hyperoslo/OhMyAuth.git`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar.git`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Hue.git
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary.git
@@ -69,23 +57,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/hyperoslo/OhMyAuth.git
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar.git
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :commit: 89f4e49c67483d4b7951279d1829ba47876d5ddb
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :commit: d03fe87b19caf00e108d82f7e5c8da578699e3b4
-    :git: https://github.com/hyperoslo/Hue.git
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary.git
@@ -93,17 +66,14 @@ CHECKOUT OPTIONS:
     :commit: aba620997062a2082a9d1a57fb5c81e4e0fe79df
     :git: https://github.com/hyperoslo/Keychain.git
   OhMyAuth:
-    :commit: 121dd6ffe1db71792bd2dc935a0164758033efba
+    :commit: 94360e0e71e7af5ed97d9ac98697889c66b601c4
     :git: https://github.com/hyperoslo/OhMyAuth.git
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar.git
 
 SPEC CHECKSUMS:
   Alamofire: 7682d43245de14874acd142ec137b144aa1dd335
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
-  Compass: 107bfda77a4296f1ec213956e50fdacde545e1b5
+  Brick: a4900b83cef55f0a79ff78b453eff9e95e65df1f
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fashion: f5cd202dcd048edd35217349527ac446d0853cd7
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
@@ -112,11 +82,11 @@ SPEC CHECKSUMS:
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
   Malibu: d697d750eba061696ddafa097b6cb325ba6037f7
   OhMyAuth: 6635daf8b6378ac68db57f313cd2ac06033d975b
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: 4f51eac13c78f3f872aa0ceed26911efb5054e7c
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   When: 3df626af4891607ea7dd3f46a451176c5642c528
 
-PODFILE CHECKSUM: af2badb37e2a7cbdeee26bcc54225e4f3921b149
+PODFILE CHECKSUM: 39f2a9e027a6ee4ad115021b6dd32f51c3550795
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/SpotifyMac/Spotify Mac/Views/FeaturedGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/FeaturedGridItem.swift
@@ -54,9 +54,6 @@ open class FeaturedGridItem: NSCollectionViewItem, SpotConfigurable {
 
     addObserver(self, forKeyPath: #keyPath(customImageView.image), options: .new, context: nil)
 
-    let area = NSTrackingArea(rect: customView.bounds, options: [.inVisibleRect, .mouseEnteredAndExited, .activeInKeyWindow], owner: self, userInfo: nil)
-    customView.addTrackingArea(area)
-
     setupConstraints()
   }
 
@@ -120,59 +117,6 @@ open class FeaturedGridItem: NSCollectionViewItem, SpotConfigurable {
         }
       }
     }
-  }
-
-  open override func mouseEntered(with theEvent: NSEvent) {
-    super.mouseEntered(with: theEvent)
-
-    guard customView.layer?.animation(forKey: "animationGroup") == nil else { return }
-
-    let animationGroup = CAAnimationGroup()
-    animationGroup.duration = 0.10
-    animationGroup.isRemovedOnCompletion = false
-    animationGroup.fillMode = kCAFillModeForwards
-
-    let zoomInAnimation = CABasicAnimation(keyPath: "transform.scale")
-    zoomInAnimation.fromValue = 1.0
-    zoomInAnimation.toValue = 1.1
-
-    let positionAnimation = CABasicAnimation(keyPath: "position")
-    let newValue = NSValue(point: CGPoint(
-      x: customView.frame.origin.x + customView.frame.size.width / 2,
-      y: customView.frame.origin.y + customView.frame.size.height / 2))
-    positionAnimation.fromValue = newValue
-    positionAnimation.toValue = newValue
-
-    animationGroup.animations = [zoomInAnimation, positionAnimation]
-
-    customView.layer?.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-    customView.layer?.add(animationGroup, forKey: "animationGroup")
-  }
-
-  open override func mouseExited(with theEvent: NSEvent) {
-    super.mouseExited(with: theEvent)
-
-    guard customView.layer?.animationKeys() != nil else { return }
-
-    let animationGroup = CAAnimationGroup()
-    animationGroup.duration = 0.10
-    animationGroup.isRemovedOnCompletion = false
-    animationGroup.fillMode = kCAFillModeForwards
-
-    let zoomInAnimation = CABasicAnimation(keyPath: "transform.scale")
-    zoomInAnimation.fromValue = 1.1
-    zoomInAnimation.toValue = 1.0
-
-    let positionAnimation = CABasicAnimation(keyPath: "position")
-    let newValue = NSValue(point: CGPoint(
-      x: customView.frame.origin.x + customView.frame.size.width / 2,
-      y: customView.frame.origin.y + customView.frame.size.height / 2))
-    positionAnimation.fromValue = newValue
-    positionAnimation.toValue = newValue
-
-    animationGroup.animations = [zoomInAnimation, positionAnimation]
-    customView.layer?.removeAnimation(forKey: "animationGroup")
-    customView.layer?.add(animationGroup, forKey: "reverseAnimation")
   }
 
   open func configure(_ item: inout Item) {

--- a/Sources/Mac/Classes/NoScrollView.swift
+++ b/Sources/Mac/Classes/NoScrollView.swift
@@ -23,7 +23,9 @@ open class NoScrollView: NSScrollView {
     if theEvent.scrollingDeltaX != 0.0 && horizontalScroller != nil && scrollingEnabled {
       super.scrollWheel(with: theEvent)
     } else {
-      nextResponder?.scrollWheel(with: theEvent)
+      if theEvent.scrollingDeltaY != 0.0 {
+        nextResponder?.scrollWheel(with: theEvent)
+      }
     }
   }
 

--- a/Sources/Mac/Classes/NoScrollView.swift
+++ b/Sources/Mac/Classes/NoScrollView.swift
@@ -22,10 +22,8 @@ open class NoScrollView: NSScrollView {
   override open func scrollWheel(with theEvent: NSEvent) {
     if theEvent.scrollingDeltaX != 0.0 && horizontalScroller != nil && scrollingEnabled {
       super.scrollWheel(with: theEvent)
-    } else {
-      if theEvent.scrollingDeltaY != 0.0 {
-        nextResponder?.scrollWheel(with: theEvent)
-      }
+    } else if theEvent.scrollingDeltaY != 0.0 {
+      nextResponder?.scrollWheel(with: theEvent)
     }
   }
 

--- a/core-pods.rb
+++ b/core-pods.rb
@@ -1,9 +1,9 @@
 def core_pods
   pod 'Spots', path: '../../'
-  pod 'Brick', :git => 'https://github.com/hyperoslo/Brick', :branch => 'swift-3'
-  pod 'Tailor', '2.0.1'
+  pod 'Brick'
+  pod 'Tailor'
   pod 'CryptoSwift', '0.6.0'
-  pod 'Cache', :git => 'https://github.com/hyperoslo/Cache', :branch => 'swift-3'
+  pod 'Cache'
 
   post_install do |installer|
     puts("Enabling dev mode for Spots")


### PR DESCRIPTION
After the Sierra update, the scrolling inside of `CarouselSpot` got a small regression where it screwed up the scrolling experience. In a nutshell, the carousel would lose the first responder when the scrolling event phase changed to `.ended`.

This PR aims to address that issue by adding an extra condition for when it should switch first responder. Now scrolling should work like intended.

This also updates the pods inside the macOS demo for Spots.

+ removes the tracking area in the macOS demo because it was acting a bit odd.