### PR TITLE
Fix comparison

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -145,7 +145,7 @@ public class SpotsScrollView: UIScrollView {
           && (dragging == false && tracking == false) {
           let oldOffset = change.CGPointValue()
           let newOffset = scrollView.contentOffset
-          if !CGPointEqualToPoint(newOffset, oldOffset) {
+          if !compare(newOffset, oldOffset) {
             setNeedsLayout()
             layoutIfNeeded()
           }
@@ -220,8 +220,14 @@ public class SpotsScrollView: UIScrollView {
       self.frame.size.height = superview.frame.size.height
     }
 
-    guard !CGPointEqualToPoint(initialContentOffset, contentOffset) else { return }
+    guard !compare(initialContentOffset, contentOffset) else { return }
     setNeedsLayout()
     layoutIfNeeded()
   }
+}
+
+// MARK: - Helper
+
+func compare(p1: CGPoint, _ p2: CGPoint) -> Bool {
+  return Int(p1.x) == Int(p2.x) && Int(p1.y) == Int(p2.y)
 }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -154,7 +154,7 @@ public class SpotsScrollView: UIScrollView {
         oldFrame = change[NSKeyValueChangeOldKey]?.CGRectValue() {
         let newFrame = view.frame
 
-        if (!CGRectEqualToRect(newFrame, oldFrame)) {
+        if (!compare(newFrame, oldFrame)) {
           self.setNeedsLayout()
           self.layoutIfNeeded()
         }
@@ -230,4 +230,8 @@ public class SpotsScrollView: UIScrollView {
 
 func compare(p1: CGPoint, _ p2: CGPoint) -> Bool {
   return Int(p1.x) == Int(p2.x) && Int(p1.y) == Int(p2.y)
+}
+
+func compare(r1: CGRect, _ r2: CGRect) -> Bool {
+  return CGRectEqualToRect(CGRectIntegral(r1), CGRectIntegral(r2))
 }


### PR DESCRIPTION
I have run into a case where I have`oldOffset.y = 0.666` and `newOffset.y = 0`, or `oldOffset.y = 356.33333` and `newOffset.y = 356`

Since comparison between `oldOffset` and `newOffset` is too strict, so the check won't pass. Don't know the exact cause but this should work round the issue 😄 

In the same vein, I make in the same for CGRect comparison too
This will merge into `fix/legacy`, which is pointing to 4.0.2