### PR TITLE
Fix frame integral

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -19,8 +19,13 @@ public extension Spotable {
     guard usesDynamicHeight else {
       return self.render().frame.height
     }
-
-    return component.items.reduce(0, { $0 + $1.size.height })
+    
+    var height: CGFloat = 0
+    component.items.forEach {
+      height += $0.size.height
+    }
+    
+    return height
   }
 
   /// Resolve a UI component at index with inferred type

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -177,8 +177,8 @@ open class SpotsScrollView: UIScrollView {
         frame.size.width = ceil(contentView.frame.size.width) - scrollView.contentInset.left - scrollView.contentInset.right
         frame.origin.x = scrollView.contentInset.left
 
-        scrollView.frame = frame
-        scrollView.contentOffset = contentOffset
+        scrollView.frame = frame.integral
+        scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
 
         yOffsetOfCurrentSubview += scrollView.contentSize.height + scrollView.contentInset.top + scrollView.contentInset.bottom
       } else if let subview = subview {


### PR DESCRIPTION
As of https://github.com/hyperoslo/Spots/pull/339. This tries to apply the same fixes for swift 3

- The idea is trying to reduce the cases of float values
- There are some more places we use `reduce`, but I don't see if they cause problems