### PR TITLE
Refactor Gridable layout

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "krzyzanowskim/CryptoSwift" "0.6.1"
 github "zenangst/Tailor" "2.0.1"
-github "hyperoslo/Brick" "2.0.0"
+github "hyperoslo/Brick" "2.0.1"
 github "hyperoslo/Cache" "2.0.0"

--- a/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ExploreController.swift
@@ -42,15 +42,14 @@ class ExploreController: Controller {
     suggestedSpot.paginateByItem = false
 
     let spots: [Spotable] = [
-      ListSpot(component: Component(title : "Suggested Channels", meta: ["headerHeight" : 33])),
       suggestedSpot,
-      ListSpot(component: Component(title : "Suggested Topics", meta: ["headerHeight" : 33])),
       CarouselSpot(suggestedTopics),
       ListSpot(component: browse)
     ]
 
     self.init(spots: spots)
     self.title = title
+    scrollView.contentInset.top = 10
   }
 
   static func suggestedImage(_ id: Int) -> String {

--- a/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/FavoritesController.swift
@@ -58,17 +58,17 @@ class FavoritesController: Controller {
     reload([
       "components" : [
         [
-        "kind" : newType,
-        "span" : 3
+          "kind" : newType,
+          "span" : 3
         ]
       ]
-    ], animated: { view in
-      view.alpha = 0.0
-      view.transform = CGAffineTransform(scaleX: 1.0, y: 0.0)
-      UIView.animate(withDuration: 0.3) {
-        view.alpha = 1.0
-        view.transform = CGAffineTransform.identity
-      }
+      ], animated: { view in
+        view.alpha = 0.0
+        view.transform = CGAffineTransform(scaleX: 1.0, y: 0.0)
+        UIView.animate(withDuration: 0.3) {
+          view.alpha = 1.0
+          view.transform = CGAffineTransform.identity
+        }
     }) {
       dispatch(queue: .interactive) { [weak self] in
         let items = FavoritesController.generateItems(0, to: 11, kind: newType == "grid" ? Cell.Topic : Cell.Feed)

--- a/Examples/Apple News/Podfile
+++ b/Examples/Apple News/Podfile
@@ -6,9 +6,9 @@ inhibit_all_warnings!
 
 target "AppleNews" do
   core_pods
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar', :branch => 'swift-3'
-  pod 'Hue', git: 'https://github.com/hyperoslo/Hue', :branch => 'swift-3'
-  pod 'Compass', git: 'https://github.com/hyperoslo/Compass', :branch => 'swift-3'
+  pod 'Sugar', '~> 2.0'
+  pod 'Hue', '~> 2.0'
+  pod 'Compass', '~> 4.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', :branch => 'swift-3'
   pod 'Fakery', '2.0.0'
   pod 'Transition', git: 'https://github.com/hyperoslo/Transition', :branch => 'swift-3'

--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -1,97 +1,67 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
-  - Compass (3.0.0)
+  - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fakery (2.0.0)
   - Hue (2.0.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
   - Transition (0.1.0)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
-  - Compass (from `https://github.com/hyperoslo/Compass`, branch `swift-3`)
+  - Brick
+  - Cache
+  - Compass (~> 4.0)
   - CryptoSwift (= 0.6.0)
   - Fakery (= 2.0.0)
-  - Hue (from `https://github.com/hyperoslo/Hue`, branch `swift-3`)
+  - Hue (~> 2.0)
   - Imaginary (from `https://github.com/hyperoslo/Imaginary`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar (~> 2.0)
+  - Tailor
   - Transition (from `https://github.com/hyperoslo/Transition`, branch `swift-3`)
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar
   Transition:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Transition
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :commit: 89f4e49c67483d4b7951279d1829ba47876d5ddb
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :commit: d03fe87b19caf00e108d82f7e5c8da578699e3b4
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar
   Transition:
     :commit: 57174fa92a12e9ef5c5f88a88ef1889bb83e46f7
     :git: https://github.com/hyperoslo/Transition
 
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
-  Compass: 107bfda77a4296f1ec213956e50fdacde545e1b5
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   Transition: 66d86e3ae1b8f0b3d9ba2000c7a45fbc17b066f2
 
-PODFILE CHECKSUM: 267d53aa17cf1d77fdc7b5f9ec07b55d5099e97c
+PODFILE CHECKSUM: f42fd0dd8c308aa35c34edf43eb4129a0b53e674
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Brick (2.0.0):
+  - Brick (2.0.1):
     - Tailor (~> 2.0)
   - Cache (2.0.0):
     - CryptoSwift
@@ -9,7 +9,7 @@ PODS:
   - Imaginary (0.1.0):
     - Cache
   - Keychain (1.0.0)
-  - Spots (5.0.3):
+  - Spots (5.0.4):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -50,14 +50,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Keychain
 
 SPEC CHECKSUMS:
-  Brick: a4900b83cef55f0a79ff78b453eff9e95e65df1f
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
   Cache: 86c7a082ce5a734df15a103581d81d29002a171e
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
-  Spots: 14c0d559049796dc53842e4ac861ba83257f1829
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
   Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   Whisper: '08be92623311f8e53201e62e17f6d7b9599a4714'

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (4.0.1)
-  - Brick (2.0.0):
+  - Brick (2.0.1):
     - Tailor (~> 2.0)
   - Cache (2.0.0):
     - CryptoSwift
@@ -19,7 +19,7 @@ PODS:
     - JWTDecode
     - Keychain
     - Sugar
-  - Spots (5.0.1):
+  - Spots (5.0.4):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -66,12 +66,12 @@ CHECKOUT OPTIONS:
     :commit: aba620997062a2082a9d1a57fb5c81e4e0fe79df
     :git: https://github.com/hyperoslo/Keychain.git
   OhMyAuth:
-    :commit: 94360e0e71e7af5ed97d9ac98697889c66b601c4
+    :commit: 11bfb1d489b685c77c8a68eb836e253b8d51383a
     :git: https://github.com/hyperoslo/OhMyAuth.git
 
 SPEC CHECKSUMS:
   Alamofire: 7682d43245de14874acd142ec137b144aa1dd335
-  Brick: a4900b83cef55f0a79ff78b453eff9e95e65df1f
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
   Cache: 86c7a082ce5a734df15a103581d81d29002a171e
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
@@ -81,8 +81,8 @@ SPEC CHECKSUMS:
   JWTDecode: 178e47e5d28d3abcff778bacced8342858cd6cb5
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
   Malibu: d697d750eba061696ddafa097b6cb325ba6037f7
-  OhMyAuth: 6635daf8b6378ac68db57f313cd2ac06033d975b
-  Spots: 4f51eac13c78f3f872aa0ceed26911efb5054e7c
+  OhMyAuth: e10e5ab7a2a3d77c8e056b0d2aa495b9cefec19c
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
   Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   When: 3df626af4891607ea7dd3f46a451176c5642c528

--- a/Examples/SpotsCards/Podfile
+++ b/Examples/SpotsCards/Podfile
@@ -6,8 +6,8 @@ inhibit_all_warnings!
 
 target "SpotsCards" do
   core_pods
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar', :branch => 'swift-3'
-  pod 'Hue', git: 'https://github.com/hyperoslo/Hue', :branch => 'swift-3'
-  pod 'Compass', git: 'https://github.com/hyperoslo/Compass', :branch => 'swift-3'
+  pod 'Sugar', '~> 2.0'
+  pod 'Hue', '~> 2.0'
+  pod 'Compass', '~> 4.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', :branch => 'swift-3'
 end

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -1,85 +1,55 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
-  - Compass (3.0.0)
+  - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Hue (2.0.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
-  - Compass (from `https://github.com/hyperoslo/Compass`, branch `swift-3`)
+  - Brick
+  - Cache
+  - Compass (~> 4.0)
   - CryptoSwift (= 0.6.0)
-  - Hue (from `https://github.com/hyperoslo/Hue`, branch `swift-3`)
+  - Hue (~> 2.0)
   - Imaginary (from `https://github.com/hyperoslo/Imaginary`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar (~> 2.0)
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :commit: 89f4e49c67483d4b7951279d1829ba47876d5ddb
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :commit: d03fe87b19caf00e108d82f7e5c8da578699e3b4
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
-  Compass: 107bfda77a4296f1ec213956e50fdacde545e1b5
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
-PODFILE CHECKSUM: 1b615154eb911dbefbdc5a6b2aab1b152ba1470d
+PODFILE CHECKSUM: c602180fa490a7e94d53019f0120c8a5d4a96f90
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/SpotsDemo/Podfile
+++ b/Examples/SpotsDemo/Podfile
@@ -6,9 +6,9 @@ inhibit_all_warnings!
 
 target "SpotsDemo" do
   core_pods
-  pod 'Compass', git: 'https://github.com/hyperoslo/Compass', branch: 'swift-3'
+  pod 'Compass', '~> 4.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', branch: 'swift-3'
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar', branch: 'swift-3'
+  pod 'Sugar', '~> 2.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', branch: 'swift-3'
-  pod 'Hue', git: 'https://github.com/hyperoslo/Hue', branch: 'swift3'
+  pod 'Hue', '~> 2.0'
 end

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -1,85 +1,55 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
-  - Compass (3.0.0)
+  - Compass (4.0.0)
   - CryptoSwift (0.6.0)
-  - Hue (1.2.0)
+  - Hue (2.0.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
-  - Compass (from `https://github.com/hyperoslo/Compass`, branch `swift-3`)
+  - Brick
+  - Cache
+  - Compass (~> 4.0)
   - CryptoSwift (= 0.6.0)
-  - Hue (from `https://github.com/hyperoslo/Hue`, branch `swift3`)
+  - Hue (~> 2.0)
   - Imaginary (from `https://github.com/hyperoslo/Imaginary`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar (~> 2.0)
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :branch: swift3
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :commit: 89f4e49c67483d4b7951279d1829ba47876d5ddb
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :commit: c21ca81d4fa002309f8f8f554317bf9ec3167365
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
-  Compass: 107bfda77a4296f1ec213956e50fdacde545e1b5
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
-  Hue: '0705083b7aff40334033373e6293ec1215285ac2'
+  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
-PODFILE CHECKSUM: 104b38805befeec6a22028f6a6ec2e0515c07741
+PODFILE CHECKSUM: 684a50fe0987f41199ecd3d99146321f51368955
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/SpotsFeed/Podfile
+++ b/Examples/SpotsFeed/Podfile
@@ -6,9 +6,9 @@ inhibit_all_warnings!
 
 target "SpotsFeed" do
   core_pods
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar', :branch => 'swift-3'
-  pod 'Hue', git: 'https://github.com/hyperoslo/Hue', :branch => 'swift-3'
-  pod 'Compass', git: 'https://github.com/hyperoslo/Compass', :branch => 'swift-3'
+  pod 'Sugar', '~> 2.0'
+  pod 'Hue', '~> 2.0'
+  pod 'Compass', '~> 4.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', :branch => 'swift-3'
   pod 'Fakery', '2.0.0'
 end

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -1,88 +1,58 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
-  - Compass (3.0.0)
+  - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fakery (2.0.0)
   - Hue (2.0.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
-  - Compass (from `https://github.com/hyperoslo/Compass`, branch `swift-3`)
+  - Brick
+  - Cache
+  - Compass (~> 4.0)
   - CryptoSwift (= 0.6.0)
   - Fakery (= 2.0.0)
-  - Hue (from `https://github.com/hyperoslo/Hue`, branch `swift-3`)
+  - Hue (~> 2.0)
   - Imaginary (from `https://github.com/hyperoslo/Imaginary`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar (~> 2.0)
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Compass:
-    :commit: 89f4e49c67483d4b7951279d1829ba47876d5ddb
-    :git: https://github.com/hyperoslo/Compass
-  Hue:
-    :commit: d03fe87b19caf00e108d82f7e5c8da578699e3b4
-    :git: https://github.com/hyperoslo/Hue
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
-  Compass: 107bfda77a4296f1ec213956e50fdacde545e1b5
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
-PODFILE CHECKSUM: c4eb0fad65388cce560b6373ce81dc4ea302f893
+PODFILE CHECKSUM: 61d86035e810e852db8ae32d1aeb6d21dd24ad3b
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/SpotsNibDemo/Podfile
+++ b/Examples/SpotsNibDemo/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 
 target 'SpotsNibDemo' do
   core_pods
-  pod 'Hue', :git => 'https://github.com/hyperoslo/Hue', :branch => 'swift-3'
+  pod 'Hue', '~> 2.0'
 end

--- a/Examples/SpotsNibDemo/Podfile.lock
+++ b/Examples/SpotsNibDemo/Podfile.lock
@@ -1,57 +1,37 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
   - CryptoSwift (0.6.0)
   - Hue (2.0.0)
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
+    - Tailor (~> 2.0)
   - Tailor (2.0.1)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
+  - Brick
+  - Cache
   - CryptoSwift (= 0.6.0)
-  - Hue (from `https://github.com/hyperoslo/Hue`, branch `swift-3`)
+  - Hue (~> 2.0)
   - Spots (from `../../`)
-  - Tailor (= 2.0.1)
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
-  Hue:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Hue
   Spots:
     :path: "../../"
 
-CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
-  Hue:
-    :commit: d03fe87b19caf00e108d82f7e5c8da578699e3b4
-    :git: https://github.com/hyperoslo/Hue
-
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
-PODFILE CHECKSUM: 5e38d91c67d8b3de21c7dfd9d1db21d9707eb084
+PODFILE CHECKSUM: 0f82781f79b3957e854c3d49f6f54f3271306b76
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Examples/tvOS Dashboard/Podfile
+++ b/Examples/tvOS Dashboard/Podfile
@@ -6,6 +6,6 @@ inhibit_all_warnings!
 
 target "tvOS Dashboard" do
   core_pods
-  pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar', branch: 'swift-3'
+  pod 'Sugar', '~> 2.0'
   pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary', branch: 'swift-3'
 end

--- a/Examples/tvOS Dashboard/Podfile.lock
+++ b/Examples/tvOS Dashboard/Podfile.lock
@@ -1,67 +1,49 @@
 PODS:
-  - Brick (1.0.0):
-    - Tailor
-  - Cache (1.5.1):
+  - Brick (2.0.1):
+    - Tailor (~> 2.0)
+  - Cache (2.0.0):
     - CryptoSwift
   - CryptoSwift (0.6.0)
   - Imaginary (0.1.0):
     - Cache
-  - Spots (5.0.0):
-    - Brick (= 1.0.0)
-    - Cache (= 1.5.1)
+  - Spots (5.0.4):
+    - Brick (~> 2.0)
+    - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
-    - Tailor (= 2.0.1)
-  - Sugar (1.2.0)
+    - Tailor (~> 2.0)
+  - Sugar (2.0.0)
   - Tailor (2.0.1)
 
 DEPENDENCIES:
-  - Brick (from `https://github.com/hyperoslo/Brick`, branch `swift-3`)
-  - Cache (from `https://github.com/hyperoslo/Cache`, branch `swift-3`)
+  - Brick
+  - Cache
   - CryptoSwift (= 0.6.0)
   - Imaginary (from `https://github.com/hyperoslo/Imaginary`, branch `swift-3`)
   - Spots (from `../../`)
-  - Sugar (from `https://github.com/hyperoslo/Sugar`, branch `swift-3`)
-  - Tailor (= 2.0.1)
+  - Sugar (~> 2.0)
+  - Tailor
 
 EXTERNAL SOURCES:
-  Brick:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Cache
   Imaginary:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Imaginary
   Spots:
     :path: "../../"
-  Sugar:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Sugar
 
 CHECKOUT OPTIONS:
-  Brick:
-    :commit: 8c3040e96b8e8d62b534d40def925de30b7f8853
-    :git: https://github.com/hyperoslo/Brick
-  Cache:
-    :commit: 0246e9e9e8faae93f2c83d15824789577f4720bf
-    :git: https://github.com/hyperoslo/Cache
   Imaginary:
     :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
     :git: https://github.com/hyperoslo/Imaginary
-  Sugar:
-    :commit: 7fba82b649ae53636b451762eb165e8c8de69751
-    :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  Brick: 2de240889550c54ea20b146c72f31e9b256c71ad
-  Cache: db4c6908069c442e5de02c7271fb38b38fb60a67
+  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
+  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
-  Spots: 51933c15f351d072e22627ccbd1455daaecb2464
-  Sugar: 80c69044df1b48d4c9e3f66196afac827f076134
+  Spots: dcb63e3502abd314c84fe201adf4b112a03326b1
+  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
-PODFILE CHECKSUM: 75f069e06500b8bd7cac942fb7187df1dcd546e5
+PODFILE CHECKSUM: 91c38cdec6ecbb512cde3f96e1c4a9f397c5cc66
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.0.rc.3

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -57,7 +57,14 @@ public extension Spotable where Self : Gridable {
             component.items[index].size.width = collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
           }
         #else
-          component.items[index].size.width = collectionView.bounds.size.width / CGFloat(component.span)
+          var spotWidth = collectionView.frame.size.width
+
+          if spotWidth == 0.0 {
+            spotWidth = UIScreen.main.bounds.width
+          }
+
+          let newWidth = spotWidth / CGFloat(component.span)
+          component.items[index].size.width = newWidth
         #endif
       }
     }

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -30,12 +30,28 @@ public extension Spotable where Self : Gridable {
   ///
   /// - parameter size: The size of the superview
   public func setup(_ size: CGSize) {
-    layout.prepare()
     collectionView.frame.size.width = size.width
     #if !os(OSX)
-      collectionView.frame.size.height = layout.contentSize.height
       GridSpot.configure?(collectionView, layout)
+
+      if let resolve = type(of: self).headers.make(component.header),
+        let view = resolve.view as? Componentable,
+        !component.header.isEmpty {
+
+        layout.headerReferenceSize.width = collectionView.frame.size.width
+        layout.headerReferenceSize.height = view.frame.size.height ?? 0.0
+
+        if layout.headerReferenceSize.width == 0.0 {
+          layout.headerReferenceSize.width = size.width
+        }
+
+        if layout.headerReferenceSize.height == 0.0 {
+          layout.headerReferenceSize.height = view.preferredHeaderHeight
+        }
+      }
+      collectionView.frame.size.height = layout.contentSize.height
     #endif
+    layout.prepare()
     component.size = collectionView.frame.size
   }
 

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -39,7 +39,7 @@ public extension Spotable where Self : Gridable {
         !component.header.isEmpty {
 
         layout.headerReferenceSize.width = collectionView.frame.size.width
-        layout.headerReferenceSize.height = view.frame.size.height ?? 0.0
+        layout.headerReferenceSize.height = view.frame.size.height
 
         if layout.headerReferenceSize.width == 0.0 {
           layout.headerReferenceSize.width = size.width

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -62,27 +62,4 @@ public extension Spotable where Self : Gridable {
     layout.invalidateLayout()
     collectionView.frame.size.width = size.width
   }
-
-  /// Prepare items in component
-  public func prepareItems() {
-    component.items.enumerated().forEach { (index: Int, _) in
-      configureItem(at: index, usesViewSize: true)
-      if component.span > 0 {
-        #if os(OSX)
-          if let layout = layout as? NSCollectionViewFlowLayout {
-            component.items[index].size.width = collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
-          }
-        #else
-          var spotWidth = collectionView.frame.size.width
-
-          if spotWidth == 0.0 {
-            spotWidth = UIScreen.main.bounds.width
-          }
-
-          let newWidth = spotWidth / CGFloat(component.span)
-          component.items[index].size.width = newWidth
-        #endif
-      }
-    }
-  }
 }

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -22,7 +22,7 @@ public extension Spotable where Self : Gridable {
   /// - returns: Returns a UICollectionView as a UIScrollView
   ///
   public func render() -> ScrollView {
-  return collectionView
+    return collectionView
   }
   #endif
 

--- a/Sources/Shared/Extensions/Item+Extensions.swift
+++ b/Sources/Shared/Extensions/Item+Extensions.swift
@@ -19,7 +19,7 @@ public extension Item {
     let newChildren = newModels.flatMap { $0.children }
     let oldChildren = oldModels.flatMap { $0.children }
 
-    guard !(oldModels === newModels) || !(newChildren as NSArray).isEqual(to: oldChildren) else {
+    guard !(oldModels == newModels) || !(newChildren as NSArray).isEqual(to: oldChildren) else {
       return nil
     }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -327,6 +327,9 @@ public extension Spotable {
     }
 
     if index < component.items.count && index > -1 {
+      if item.size.width == 0 && component.span > 0 {
+        item.size.width = UIScreen.main.bounds.width / CGFloat(component.span)
+      }
       component.items[index] = item
     }
   }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -153,6 +153,24 @@ public extension Spotable {
   func prepareItems() {
     component.items.enumerated().forEach { (index: Int, _) in
       configureItem(at: index, usesViewSize: true)
+
+      if component.span > 0.0 {
+        #if os(OSX)
+          if let gridable = self as? Gridable,
+            let layout = gridable.layout as? NSCollectionViewFlowLayout {
+            component.items[index].size.width = gridable.collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
+          }
+        #else
+          var spotWidth = render().frame.size.width
+
+          if spotWidth == 0.0 {
+            spotWidth = UIScreen.main.bounds.width
+          }
+
+          let newWidth = spotWidth / CGFloat(component.span)
+          component.items[index].size.width = newWidth
+        #endif
+      }
     }
   }
 
@@ -328,7 +346,7 @@ public extension Spotable {
 
     if index < component.items.count && index > -1 {
       #if !os(OSX)
-        if item.size.width == 0 && component.span > 0 {
+        if component.span > 0.0 || item.size.width == 0 {
           item.size.width = UIScreen.main.bounds.width / CGFloat(component.span)
         }
       #endif

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -19,12 +19,12 @@ public extension Spotable {
     guard usesDynamicHeight else {
       return self.render().frame.height
     }
-    
+
     var height: CGFloat = 0
     component.items.forEach {
       height += $0.size.height
     }
-    
+
     return height
   }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -327,9 +327,11 @@ public extension Spotable {
     }
 
     if index < component.items.count && index > -1 {
-      if item.size.width == 0 && component.span > 0 {
-        item.size.width = UIScreen.main.bounds.width / CGFloat(component.span)
-      }
+      #if !os(OSX)
+        if item.size.width == 0 && component.span > 0 {
+          item.size.width = UIScreen.main.bounds.width / CGFloat(component.span)
+        }
+      #endif
       component.items[index] = item
     }
   }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -158,7 +158,6 @@ public extension Spotable {
   func prepareItems() {
     component.items.enumerated().forEach { (index: Int, _) in
       configureItem(at: index, usesViewSize: true)
-
       if component.span > 0.0 {
         #if os(OSX)
           if let gridable = self as? Gridable,
@@ -321,14 +320,8 @@ public extension Spotable {
           view.frame.size = UIScreen.main.bounds.size
         }
 
-        if let view = view as? UITableViewCell {
-          view.contentView.frame = view.bounds
-        }
-
-        if let view = view as? UICollectionViewCell {
-          view.contentView.frame = view.bounds
-        }
-
+        (view as? UITableViewCell)?.contentView.frame = view.bounds
+        (view as? UICollectionViewCell)?.contentView.frame = view.bounds
         (view as? SpotConfigurable)?.configure(&item)
       }
     #else
@@ -336,22 +329,22 @@ public extension Spotable {
     #endif
 
     if let itemView = view as? SpotConfigurable, usesViewSize {
-      if item.size.height == 0 {
+      if item.size.height == 0.0 {
         item.size.height = itemView.preferredViewSize.height
       }
 
-      if item.size.width == 0 {
+      if item.size.width == 0.0 {
         item.size.width = itemView.preferredViewSize.width
       }
 
-      if item.size.width == 0 {
+      if item.size.width == 0.0 {
         item.size.width = view.bounds.width
       }
     }
 
     if index < component.items.count && index > -1 {
       #if !os(OSX)
-        if component.span > 0.0 || item.size.width == 0 {
+        if self is Gridable && (component.span > 0.0 || item.size.width == 0) {
           item.size.width = UIScreen.main.bounds.width / CGFloat(component.span)
         }
       #endif

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -161,7 +161,7 @@ public extension Spotable {
       if component.span > 0.0 {
         #if os(OSX)
           if let gridable = self as? Gridable,
-            let layout = gridable.layout as? NSCollectionViewFlowLayout {
+            let layout = gridable.layout as? FlowLayout {
             component.items[index].size.width = gridable.collectionView.frame.width / CGFloat(component.span) - layout.sectionInset.left - layout.sectionInset.right
           }
         #else

--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -41,7 +41,7 @@ import Cache
               var yOffset: CGFloat = 0.0
               for spot in weakSelf.spots {
                 #if !os(OSX)
-                (spot as? Gridable)?.layout.yOffset = yOffset
+                (spot as? CarouselSpot)?.layout.yOffset = yOffset
                 #endif
                 yOffset += spot.render().frame.size.height
               }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -95,7 +95,7 @@ extension SpotsProtocol {
     self.spots[index] = spot
     self.setupSpot(at: index, spot: spot)
     self.scrollView.contentView.insertSubview(spot.render(), at: index)
-    (spot as? Gridable)?.layout.yOffset = yOffset
+    (spot as? CarouselSpot)?.layout.yOffset = yOffset
     yOffset += spot.render().frame.size.height
   }
 
@@ -103,7 +103,7 @@ extension SpotsProtocol {
     let spot = Factory.resolve(component: newComponents[index])
     spots.append(spot)
     setupSpot(at: index, spot: spot)
-    (spot as? Gridable)?.layout.yOffset = yOffset
+    (spot as? CarouselSpot)?.layout.yOffset = yOffset
     scrollView.contentView.addSubview(spot.render())
     yOffset += spot.render().frame.size.height
   }

--- a/Sources/Shared/Protocols/Componentable.swift
+++ b/Sources/Shared/Protocols/Componentable.swift
@@ -11,7 +11,7 @@ public protocol Componentable {
 
   /// A structure that contains the location and dimensions of a rectangle.
   var frame: CGRect { get }
-  
+
   /// Configure object with Component struct.
   ///
   /// - parameter component: The component that should be used for configuration.

--- a/Sources/Shared/Protocols/Componentable.swift
+++ b/Sources/Shared/Protocols/Componentable.swift
@@ -8,6 +8,10 @@
 public protocol Componentable {
   /// The preferred header height for the Componentable object.
   var preferredHeaderHeight: CGFloat { get }
+
+  /// A structure that contains the location and dimensions of a rectangle.
+  var frame: CGRect { get }
+  
   /// Configure object with Component struct.
   ///
   /// - parameter component: The component that should be used for configuration.

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -137,9 +137,16 @@ public struct Component: Mappable, Equatable {
     title     <- map.property("title")
     kind      <- map.property("kind")
     header    <- map.property("header")
-    span      <- map.property("span")
     items     <- map.relations("items")
     meta      <- map.property("meta")
+
+    if let span: Int = map.property("span") {
+      self.span = Double(span)
+    } else if let span: Float = map.property("span") {
+      self.span = Double(span)
+    } else {
+      self.span <- map.property("span")
+    }
 
     let width: Double = map.resolve(keyPath: "size.width") ?? 0.0
     let height: Double = map.resolve(keyPath: "size.height") ?? 0.0

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -141,10 +141,9 @@ public struct Component: Mappable, Equatable {
     items     <- map.relations("items")
     meta      <- map.property("meta")
 
-    if let size = map["size"] as? [String : Any] {
-      self.size = CGSize(width: size.property(Key.Width.string) ?? 0.0,
-                         height: size.property(Key.Height.string) ?? 0.0)
-    }
+    let width: Double = map.resolve(keyPath: "size.width") ?? 0.0
+    let height: Double = map.resolve(keyPath: "size.height") ?? 0.0
+    size = CGSize(width: width, height: height)
   }
 
   /// Initializes a component and configures it with the provided parameters

--- a/Sources/Shared/Structs/GridableMeta.swift
+++ b/Sources/Shared/Structs/GridableMeta.swift
@@ -14,5 +14,9 @@ public struct GridableMeta {
     public static let minimumInteritemSpacing = "item-spacing"
     /// A key used for looking up meta property line spacing
     public static let minimumLineSpacing = "line-spacing"
+    /// A key used for looking up meta property left content inset
+    public static let contentInsetLeft = "content-inset"
+    /// A key used for looking up meta property right content inset
+    public static let contentInsetRight = "content-right"
   }
 }

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -20,6 +20,8 @@ public typealias Completion = (() -> Void)?
   public typealias Nib = NSNib
   /// A type alias to reference a collection layout
   public typealias CollectionLayout = NSCollectionViewLayout
+  /// A type alias to reference a collection flow layout
+  public typealias FlowLayout = NSCollectionViewFlowLayout
   /// A type alias for scrollable views
   public typealias ScrollableView = SpotsScrollView
 
@@ -40,6 +42,8 @@ public typealias Completion = (() -> Void)?
   public typealias Nib = UINib
   /// A type alias to reference a collection layout
   public typealias CollectionLayout = GridableLayout
+  /// A type alias to reference a collection flow layout
+  public typealias FlowLayout = UICollectionViewFlowLayout
   /// A type alias to reference a edge insets
   public typealias EdgeInsets = UIEdgeInsets
   /// A type alias for scrollable views

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -59,7 +59,7 @@ open class CarouselSpot: NSObject, Gridable {
     willSet(value) {
       #if os(iOS)
         dynamicSpan = component.meta(Key.dynamicSpan, Default.dynamicSpan)
-        if component.items.count > 1 && component.span > 0 {
+        if component.items.count > 1 && component.span > 0.0 {
           pageControl.numberOfPages = Int(floor(Double(component.items.count) / component.span))
         }
       #endif

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -30,6 +30,10 @@ open class CarouselSpot: NSObject, Gridable {
     public static var minimumInteritemSpacing: CGFloat = 0.0
     /// Default minimum line spacing
     public static var minimumLineSpacing: CGFloat = 0.0
+    /// Default left section inset
+    public static var contentInsetLeft: CGFloat = 0.0
+    /// Default right section inset
+    public static var contentInsetRight: CGFloat = 0.0
   }
 
   /// A boolean value that affects the sizing of items when using span, if enabled and the item count is less than the span, the CarouselSpot will even out the space between the items to align them
@@ -241,6 +245,8 @@ open class CarouselSpot: NSObject, Gridable {
     layout.minimumInteritemSpacing = component.meta(GridableMeta.Key.minimumInteritemSpacing, Default.minimumInteritemSpacing)
     layout.minimumLineSpacing = component.meta(GridableMeta.Key.minimumLineSpacing, Default.minimumLineSpacing)
     dynamicSpan = component.meta(Key.dynamicSpan, false)
+    collectionView.contentInset.left = component.meta(GridableMeta.Key.contentInsetLeft, Default.contentInsetLeft)
+    collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }
 
   /// Register default header for the CarouselSpot

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -285,7 +285,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
       setupSpot(at: index, spot: spot)
       scrollView.contentView.addSubview(spot.render())
       animated?(spot.render())
-      (spot as? Gridable)?.layout.yOffset = yOffset
+      (spot as? CarouselSpot)?.layout.yOffset = yOffset
       yOffset += spot.render().frame.size.height
     }
   }

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -299,6 +299,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
     spot.render().frame.origin.x = 0.0
     spot.spotsCompositeDelegate = self
     spots[index].component.index = index
+    spot.registerAndPrepare()
     spot.setup(scrollView.frame.size)
     spot.component.size = CGSize(
       width: view.frame.size.width,

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -152,7 +152,6 @@ open class GridSpot: NSObject, Gridable {
       right: component.meta(GridableMeta.Key.sectionInsetRight, Default.sectionInsetRight))
     layout.minimumInteritemSpacing = component.meta(GridableMeta.Key.minimumInteritemSpacing, Default.minimumInteritemSpacing)
     layout.minimumLineSpacing = component.meta(GridableMeta.Key.minimumLineSpacing, Default.minimumLineSpacing)
-
     collectionView.contentInset.left = component.meta(GridableMeta.Key.contentInsetLeft, Default.contentInsetLeft)
     collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -30,6 +30,10 @@ open class GridSpot: NSObject, Gridable {
     public static var minimumInteritemSpacing: CGFloat = 0.0
     /// Default minimum line spacing
     public static var minimumLineSpacing: CGFloat = 0.0
+    /// Default left section inset
+    public static var contentInsetLeft: CGFloat = 0.0
+    /// Default right section inset
+    public static var contentInsetRight: CGFloat = 0.0
   }
 
   /// A Registry object that holds identifiers and classes for cells used in the GridSpot
@@ -148,6 +152,9 @@ open class GridSpot: NSObject, Gridable {
       right: component.meta(GridableMeta.Key.sectionInsetRight, Default.sectionInsetRight))
     layout.minimumInteritemSpacing = component.meta(GridableMeta.Key.minimumInteritemSpacing, Default.minimumInteritemSpacing)
     layout.minimumLineSpacing = component.meta(GridableMeta.Key.minimumLineSpacing, Default.minimumLineSpacing)
+
+    collectionView.contentInset.left = component.meta(GridableMeta.Key.contentInsetLeft, Default.contentInsetLeft)
+    collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }
 }
 

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -94,7 +94,8 @@ open class GridSpot: NSObject, Gridable {
 
     registerDefault(view: GridSpotCell.self)
     registerComposite(view: GridComposite.self)
-    registerAndPrepare()
+    register()
+    prepareItems()
     configureLayout()
 
     if GridSpot.views.composite == nil {

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -19,21 +19,23 @@ open class GridableLayout: UICollectionViewFlowLayout {
   open override func prepare() {
     super.prepare()
 
-    guard let spot = collectionView?.delegate as? Gridable,
-      let firstItem = spot.items.first else { return }
-    contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
-    contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
-    contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
-    contentSize.width = ceil(contentSize.width)
+    guard let spot = collectionView?.delegate as? Gridable else { return }
 
     if scrollDirection == .horizontal {
+      guard let firstItem = spot.items.first else { return }
+
       contentSize.height = firstItem.size.height + headerReferenceSize.height
       contentSize.height += sectionInset.top + sectionInset.bottom
-
+      
+      contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
+      contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
+      contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
+      contentSize.width = ceil(contentSize.width)
       if let spot = spot as? CarouselSpot, spot.pageIndicator {
         contentSize.height += spot.pageControl.frame.height
       }
     } else {
+      contentSize.width = spot.render().frame.width
       contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
       if spot.component.span > 1 {
         let count = spot.items.count

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -104,7 +104,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
             itemAttribute.frame.origin.x = offset
             offset += itemAttribute.size.width + minimumInteritemSpacing
           } else {
-            itemAttribute.frame.origin.y = itemAttribute.frame.origin.y + headerReferenceSize.height
+            itemAttribute.frame.origin.y = itemAttribute.frame.origin.y
             itemAttribute.frame.origin.x = itemAttribute.frame.origin.x
           }
           attributes.append(itemAttribute)

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -35,7 +35,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
         contentSize.height += spot.pageControl.frame.height
       }
     } else {
-      contentSize.width = spot.render().frame.width
+      contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
       contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
       if spot.component.span > 1 {
         let count = spot.items.count

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -46,6 +46,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
         contentSize.height += CGFloat(spot.items.count) * minimumLineSpacing
         contentSize.height /= CGFloat(spot.component.span)
         contentSize.height += sectionInset.top + sectionInset.bottom
+        contentSize.height += headerReferenceSize.height
       } else {
         contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
         contentSize.height += sectionInset.top + sectionInset.bottom

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -24,13 +24,14 @@ open class GridableLayout: UICollectionViewFlowLayout {
     if scrollDirection == .horizontal {
       guard let firstItem = spot.items.first else { return }
 
-      contentSize.height = firstItem.size.height + headerReferenceSize.height
-      contentSize.height += sectionInset.top + sectionInset.bottom
-      
       contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
       contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
       contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
       contentSize.width = ceil(contentSize.width)
+
+      contentSize.height = firstItem.size.height + headerReferenceSize.height
+      contentSize.height += sectionInset.top + sectionInset.bottom
+
       if let spot = spot as? CarouselSpot, spot.pageIndicator {
         contentSize.height += spot.pageControl.frame.height
       }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -36,8 +36,8 @@ open class GridableLayout: UICollectionViewFlowLayout {
       }
     } else {
       contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
-      contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
       if spot.component.span > 1 {
+        contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
         let count = spot.items.count
         if let last = spot.items.last, count % Int(spot.component.span) != 0 {
           contentSize.height += last.size.height
@@ -48,7 +48,22 @@ open class GridableLayout: UICollectionViewFlowLayout {
         contentSize.height += sectionInset.top + sectionInset.bottom
         contentSize.height += headerReferenceSize.height
       } else {
-        contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
+
+        var height: CGFloat = 0.0
+        var remainingHeight: CGFloat = contentSize.width
+        for item in spot.items {
+          remainingHeight -= item.size.height
+          if remainingHeight <= 0.0 {
+            height += item.size.height
+            remainingHeight = contentSize.width
+          }
+        }
+
+        if let last = spot.items.last, remainingHeight > 0.0 {
+          height += last.size.height
+        }
+
+        contentSize.height = height
         contentSize.height += sectionInset.top + sectionInset.bottom
       }
     }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -10,6 +10,10 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
   // Subclasses must override this method and use it to return the width and height of the collection view’s content. These values represent the width and height of all the content, not just the content that is currently visible. The collection view uses this information to configure its own content size to facilitate scrolling.
   open override var collectionViewContentSize: CGSize {
+    if scrollDirection != .horizontal {
+      contentSize.height = super.collectionViewContentSize.height
+    }
+
     return contentSize
   }
 
@@ -37,36 +41,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
       }
     } else {
       contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
-      if spot.component.span > 1 {
-        contentSize.height = spot.items.reduce(0, { $0 + $1.size.height })
-        let count = spot.items.count
-        if let last = spot.items.last, count % Int(spot.component.span) != 0 {
-          contentSize.height += last.size.height
-        }
-
-        contentSize.height += CGFloat(spot.items.count) * minimumLineSpacing
-        contentSize.height /= CGFloat(spot.component.span)
-        contentSize.height += sectionInset.top + sectionInset.bottom
-        contentSize.height += headerReferenceSize.height
-      } else {
-
-        var height: CGFloat = 0.0
-        var remainingHeight: CGFloat = contentSize.width
-        for item in spot.items {
-          remainingHeight -= item.size.height
-          if remainingHeight <= 0.0 {
-            height += item.size.height
-            remainingHeight = contentSize.width
-          }
-        }
-
-        if let last = spot.items.last, remainingHeight > 0.0 {
-          height += last.size.height
-        }
-
-        contentSize.height = height
-        contentSize.height += sectionInset.top + sectionInset.bottom
-      }
     }
   }
 

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -113,7 +113,10 @@ open class ListSpot: NSObject, Listable {
   ///
   /// - parameter size: The size of the superview.
   open func setup(_ size: CGSize) {
-    let height = component.items.reduce(component.meta(Key.headerHeight, 0.0), { $0 + $1.size.height })
+    var height: CGFloat = component.meta(Key.headerHeight, 0.0)
+    for item in component.items {
+      height += item.size.height
+    }
 
     tableView.frame.size = size
     tableView.contentSize = CGSize(

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -172,7 +172,8 @@ open class SpotsScrollView: UIScrollView {
         let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
 
         frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
-        frame.size.width = ceil(contentView.frame.size.width)
+        frame.size.width = ceil(contentView.frame.size.width) - scrollView.contentInset.left - scrollView.contentInset.right
+        frame.origin.x = scrollView.contentInset.left
 
         scrollView.frame = frame
         scrollView.contentOffset = contentOffset

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -116,17 +116,17 @@ open class SpotsScrollView: UIScrollView {
     if let change = change, context == subviewContext {
       if let scrollView = object as? UIScrollView {
         guard let change = change[NSKeyValueChangeKey.oldKey] else { return }
-        if let oldContentSize = (change as AnyObject).cgSizeValue,
-          keyPath == #keyPath(contentSize) {
+        if keyPath == #keyPath(contentSize) {
 
           let newContentSize = scrollView.contentSize
+          let oldContentSize = (change as AnyObject).cgSizeValue
           if !compare(size: newContentSize, to: oldContentSize) {
             setNeedsLayout()
             layoutIfNeeded()
           }
         } else if keyPath == #keyPath(contentOffset)
-          && (isDragging == false && isTracking == false),
-          let oldOffset = (change as AnyObject).cgPointValue {
+          && (isDragging == false && isTracking == false) {
+          let oldOffset = (change as AnyObject).cgPointValue
           let newOffset = scrollView.contentOffset
 
           if !compare(point: newOffset, to: oldOffset) {
@@ -134,13 +134,13 @@ open class SpotsScrollView: UIScrollView {
             layoutIfNeeded()
           }
         }
-      } else if let view = object as? UIView,
-        let oldFrame = (change[NSKeyValueChangeKey.oldKey] as AnyObject).cgRectValue {
+      } else if let view = object as? UIView {
+        let oldFrame = (change[NSKeyValueChangeKey.oldKey] as AnyObject).cgRectValue
         let newFrame = view.frame
 
         if !compare(rect: newFrame, to: oldFrame) {
-          self.setNeedsLayout()
-          self.layoutIfNeeded()
+          setNeedsLayout()
+          layoutIfNeeded()
         }
       }
     } else {
@@ -219,7 +219,8 @@ open class SpotsScrollView: UIScrollView {
   /// - parameter p2: Right hand side CGPoint
   ///
   /// - returns: A boolean value, true if they are equal
-  private func compare(point lhs: CGPoint, to rhs: CGPoint) -> Bool {
+  private func compare(point lhs: CGPoint, to rhs: CGPoint?) -> Bool {
+    guard let rhs = rhs else { return false }
     return Int(lhs.x) == Int(rhs.x) && Int(lhs.y) == Int(rhs.y)
   }
 
@@ -229,7 +230,8 @@ open class SpotsScrollView: UIScrollView {
   /// - parameter p2: Right hand side CGPoint
   ///
   /// - returns: A boolean value, true if they are equal
-  private func compare(size lhs: CGSize, to rhs: CGSize) -> Bool {
+  private func compare(size lhs: CGSize, to rhs: CGSize?) -> Bool {
+    guard let rhs = rhs else { return false }
     return Int(lhs.width) == Int(rhs.width) && Int(lhs.height) == Int(rhs.height)
   }
 
@@ -239,7 +241,8 @@ open class SpotsScrollView: UIScrollView {
   /// - parameter rhs: Right hand side CGRect
   ///
   /// - returns: A boolean value, true if they are equal
-  private func compare(rect lhs: CGRect, to rhs: CGRect) -> Bool {
+  private func compare(rect lhs: CGRect, to rhs: CGRect?) -> Bool {
+    guard let rhs = rhs else { return false }
     return lhs.integral.equalTo(rhs.integral)
   }
 }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -116,18 +116,20 @@ open class SpotsScrollView: UIScrollView {
     if let change = change, context == subviewContext {
       if let scrollView = object as? UIScrollView {
         guard let change = change[NSKeyValueChangeKey.oldKey] else { return }
-        if keyPath == #keyPath(contentSize) {
-          let oldContentSize = (change as AnyObject).cgSizeValue
+        if let oldContentSize = (change as AnyObject).cgSizeValue,
+          keyPath == #keyPath(contentSize) {
+
           let newContentSize = scrollView.contentSize
-          if !newContentSize.equalTo(oldContentSize!) {
+          if !compare(size: newContentSize, to: oldContentSize) {
             setNeedsLayout()
             layoutIfNeeded()
           }
         } else if keyPath == #keyPath(contentOffset)
-          && (isDragging == false && isTracking == false) {
-          let oldOffset = (change as AnyObject).cgPointValue
+          && (isDragging == false && isTracking == false),
+          let oldOffset = (change as AnyObject).cgPointValue {
           let newOffset = scrollView.contentOffset
-          if !newOffset.equalTo(oldOffset!) {
+
+          if !compare(point: newOffset, to: oldOffset) {
             setNeedsLayout()
             layoutIfNeeded()
           }
@@ -136,7 +138,7 @@ open class SpotsScrollView: UIScrollView {
         let oldFrame = (change[NSKeyValueChangeKey.oldKey] as AnyObject).cgRectValue {
         let newFrame = view.frame
 
-        if !newFrame.equalTo(oldFrame) {
+        if !compare(rect: newFrame, to: oldFrame) {
           self.setNeedsLayout()
           self.layoutIfNeeded()
         }
@@ -209,5 +211,35 @@ open class SpotsScrollView: UIScrollView {
     guard !initialContentOffset.equalTo(contentOffset) else { return }
     setNeedsLayout()
     layoutIfNeeded()
+  }
+
+  /// Compare points
+  ///
+  /// - parameter p1: Left hand side CGPoint
+  /// - parameter p2: Right hand side CGPoint
+  ///
+  /// - returns: A boolean value, true if they are equal
+  private func compare(point lhs: CGPoint, to rhs: CGPoint) -> Bool {
+    return Int(lhs.x) == Int(rhs.x) && Int(lhs.y) == Int(rhs.y)
+  }
+
+  /// Compare sizes
+  ///
+  /// - parameter p1: Left hand side CGPoint
+  /// - parameter p2: Right hand side CGPoint
+  ///
+  /// - returns: A boolean value, true if they are equal
+  private func compare(size lhs: CGSize, to rhs: CGSize) -> Bool {
+    return Int(lhs.width) == Int(rhs.width) && Int(lhs.height) == Int(rhs.height)
+  }
+
+  /// Compare rectangles
+  ///
+  /// - parameter lhs: Left hand side CGRect
+  /// - parameter rhs: Right hand side CGRect
+  ///
+  /// - returns: A boolean value, true if they are equal
+  private func compare(rect lhs: CGRect, to rhs: CGRect) -> Bool {
+    return lhs.integral.equalTo(rhs.integral)
   }
 }

--- a/Sources/iOS/Extensions/CarouselSpot+iOS.swift
+++ b/Sources/iOS/Extensions/CarouselSpot+iOS.swift
@@ -12,7 +12,7 @@ extension CarouselSpot {
     guard indexPath.item < component.items.count else { return CGSize.zero }
     var width = collectionView.frame.width
 
-    if component.span > 0 {
+    if component.span > 0.0 {
       if dynamicSpan && Double(component.items.count) < component.span {
         width = collectionView.frame.width / CGFloat(component.items.count)
         width -= layout.sectionInset.left / CGFloat(component.items.count)

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -36,7 +36,7 @@ extension Gridable {
   ///
   /// - returns: Size of the object at index path as CGSize
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    let width = (item(at: indexPath)?.size.width ?? 0) - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
+    let width = (item(at: indexPath)?.size.width ?? 0) - layout.sectionInset.left - layout.sectionInset.right
     let height = item(at: indexPath)?.size.height ?? 0
 
     // Never return a negative width

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -36,10 +36,6 @@ extension Gridable {
   ///
   /// - returns: Size of the object at index path as CGSize
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    if component.span > 0 {
-      component.items[indexPath.item].size.width = collectionView.frame.width / CGFloat(component.span) - layout.minimumInteritemSpacing
-    }
-
     let width = (item(at: indexPath)?.size.width ?? 0) - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
     let height = item(at: indexPath)?.size.height ?? 0
 

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -36,7 +36,7 @@ extension Gridable {
   ///
   /// - returns: Size of the object at index path as CGSize
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    let width = (item(at: indexPath)?.size.width ?? 0) - layout.sectionInset.left - layout.sectionInset.right
+    let width = (item(at: indexPath)?.size.width ?? 0) - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
     let height = item(at: indexPath)?.size.height ?? 0
 
     // Never return a negative width

--- a/Sources/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Sources/iOS/Extensions/UICollectionView+Indexes.swift
@@ -73,11 +73,12 @@ public extension UICollectionView {
       return
     }
 
-    performBatchUpdates({
-      self.insertItems(at: insertions)
-      self.reloadItems(at: reloads)
-      self.deleteItems(at: deletions)
-      }) { _ in
+    UIView.performWithoutAnimation {
+      performBatchUpdates({
+        self.insertItems(at: insertions)
+        self.reloadItems(at: reloads)
+        self.deleteItems(at: deletions)
+      }) { _ in }
     }
     completion?()
   }

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -85,13 +85,13 @@ class CarouselSpotTests: XCTestCase {
       "items" : [
         ["title" : "foo",
           "size" : [
-            "width" : 120,
-            "height" : 180]
+            "width" : 120.0,
+            "height" : 180.0]
         ],
         ["title" : "bar",
           "size" : [
-            "width" : 120,
-            "height" : 180]
+            "width" : 120.0,
+            "height" : 180.0]
         ],
         ["title" : "baz",
           "size" : [

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -23,20 +23,20 @@ class SpotsScrollViewTests: XCTestCase {
   var initialJSON: [String : Any] {
     let listItems: [[String : Any]] = [
       [
-        "title" : "Item" as AnyObject,
-        "size" : ["height" : 80]
+        "title" : "Item",
+        "size" : ["height" : 80.0]
       ],
       [
         "title" : "Item",
-        "size" : ["height" : 80]
+        "size" : ["height" : 80.0]
       ],
       [
         "title" : "Item",
-        "size" : ["height" : 80]
+        "size" : ["height" : 80.0]
       ],
       [
         "title" : "Item",
-        "size" : ["height" : 80]
+        "size" : ["height" : 80.0]
       ]
     ]
 


### PR DESCRIPTION
This PR reduces the complexity of the `GridableLayout` by leveraging from `superview.collectionViewContentSize.height`.

Performing updates to a collection view is now done without animations to reduce the amount of glitches that can occur when a layout is being invalidated.

We have had some bad experiences with using `reduce`, it can throw for some yet unknown reason. So in some parts we have refactored `reduce` into a normal `for-loop`.

It also reverts the comparison on `oldModels` vs `newModels`. It will not consider `size` as it is not relevant in this context. It should be enough to diff the content.

This PR also 🍒-picks the commits from the hotfix for the legacy version of `Spots`. This is a refactoring inside of `SpotsScrollView` to sanitize the rectangular values before trying to set them to a view. This has been known to cause some crashes so we hope that this should fix things.

The pod files for the examples are also updated and uses versions instead of `swift-3` branches.

A bonus feature is that `SpotsScrollView` can now handle `contentInset`'s on individual `Spots` when manipulating the frames when scrolling. This can be useful if you want to add margins on the side of a container.