### PR TITLE
Improve/comparing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ before_install:
 - travis_wait 35 carthage bootstrap --platform iOS,Mac,tvOS
 
 script:
-- xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator | xcpretty
-- xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty
-- xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
-- xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
-- xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
-- xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator | xcpretty
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
 
 notifications:
   email: false

--- a/Sources/Shared/Extensions/Item+Extensions.swift
+++ b/Sources/Shared/Extensions/Item+Extensions.swift
@@ -19,7 +19,7 @@ public extension Item {
     let newChildren = newModels.flatMap { $0.children }
     let oldChildren = oldModels.flatMap { $0.children }
 
-    guard !(oldModels == newModels) || !(newChildren as NSArray).isEqual(to: oldChildren) else {
+    guard !(oldModels === newModels) || !(newChildren as NSArray).isEqual(to: oldChildren) else {
       return nil
     }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -227,13 +227,14 @@ public extension Spotable {
   }
 
   /// Refresh indexes for all items to ensure that the indexes are unique and in ascending order.
-  public func refreshIndexes() {
+  public func refreshIndexes(completion: Completion = nil) {
     var updatedItems  = items
     updatedItems.enumerated().forEach {
       updatedItems[$0.offset].index = $0.offset
     }
 
     items = updatedItems
+    completion?()
   }
 
   /// Reloads a spot only if it changes
@@ -414,6 +415,16 @@ public extension Spotable {
     prepareItems()
   }
 
+
+  /// Update height and refresh indexes for the Spotable object.
+  ///
+  /// - parameter completion: A completion closure that will be run when the computations are complete.
+  public func sanitize(completion: Completion = nil) {
+    updateHeight() { [weak self] in
+      self?.refreshIndexes()
+      completion?()
+    }
+  }
 
   /// Register default view for the Spotable object
   ///

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -162,7 +162,7 @@ public extension Spotable {
   func prepare(items: [Item]) -> [Item] {
     var preparedItems = items
     preparedItems.enumerated().forEach { (index: Int, item: Item) in
-      if let configuredItem = configure(item: item, usesViewSize: true) {
+      if let configuredItem = configure(item: item, at: index, usesViewSize: true) {
         preparedItems[index].index = index
         preparedItems[index] = configuredItem
       }
@@ -301,12 +301,12 @@ public extension Spotable {
   /// - parameter usesViewSize: A boolean value to determine if the view uses the views height
   public func configureItem(at index: Int, usesViewSize: Bool = false) {
     guard let item = item(at: index),
-      let configuredItem = configure(item: item, usesViewSize: usesViewSize) else { return }
+      let configuredItem = configure(item: item, at: index, usesViewSize: usesViewSize) else { return }
 
     component.items[index] = configuredItem
   }
 
-  func configure(item: Item, usesViewSize: Bool = false) -> Item? {
+  func configure(item: Item, at index: Int, usesViewSize: Bool = false) -> Item? {
     var item = item
     item.index = index
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -236,11 +236,19 @@ extension SpotsProtocol {
             self?.compositeSpots[spot.index]?[item.index] = oldContent
           }
         }
-        spot.update(item, index: index, withAnimation: animation) {
-          guard index == executeClosure else { return }
-          closure?()
-          self?.scrollView.layoutSubviews()
-          if spot is Gridable { CATransaction.commit() }
+
+        if !spot.items.filter({ !$0.children.isEmpty }).isEmpty {
+          spot.reload(nil, withAnimation: animation) {
+            if spot is Gridable { CATransaction.commit() }
+            closure?()
+          }
+        } else {
+          spot.update(item, index: index, withAnimation: animation) {
+            guard index == executeClosure else { return }
+            closure?()
+            self?.scrollView.layoutSubviews()
+            if spot is Gridable { CATransaction.commit() }
+          }
         }
       }
     }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -531,7 +531,6 @@ extension SpotsProtocol {
   public func update(_ item: Item, index: Int = 0, spotIndex: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
     guard let oldItem = spot(at: spotIndex, ofType: Spotable.self)?.item(at: index), item != oldItem
       else {
-        spot(at: spotIndex, ofType: Spotable.self)?.refreshIndexes()
         completion?()
         return
     }
@@ -547,7 +546,6 @@ extension SpotsProtocol {
         if animation == .none { CATransaction.commit() }
       #endif
     }
-    spot(at: spotIndex, ofType: Spotable.self)?.refreshIndexes()
   }
 
   /**

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -238,11 +238,13 @@ extension SpotsProtocol {
         }
 
         if !spot.items.filter({ !$0.children.isEmpty }).isEmpty {
+          if spot is Gridable { CATransaction.begin() }
           spot.reload(nil, withAnimation: animation) {
             if spot is Gridable { CATransaction.commit() }
             closure?()
           }
         } else {
+          if spot is Gridable { CATransaction.begin() }
           spot.update(item, index: index, withAnimation: animation) {
             guard index == executeClosure else { return }
             closure?()

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -336,7 +336,7 @@ extension SpotsProtocol {
    - parameter completion: A closure that will be run after reload has been performed on all spots
    */
   public func reloadIfNeeded(_ json: [String : Any],
-                             compare: @escaping CompareClosure = { lhs, rhs in return lhs != rhs },
+                             compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              animated: ((_ view: View) -> Void)? = nil,
                              completion: Completion = nil) {
     Dispatch.mainQueue { [weak self] in

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -62,19 +62,19 @@ public struct Component: Mappable, Equatable {
   /// Identifier
   public var identifier: String?
   /// The index of the Item when appearing in a list, should be computed and continuously updated by the data source
-  public var index = 0
+  public var index: Int = 0
   /// The title for the component
-  public var title = ""
+  public var title: String = ""
   /// Determines which spotable component that should be used
   /// Default kinds are; list, grid and carousel
-  public var kind = ""
+  public var kind: String = ""
   /// The header identifier
-  public var header = ""
+  public var header: String = ""
   /// Configures the span that should be used for items in one row
   /// Used by gridable components
   public var span: Double = 0
   /// A collection of view models
-  public var items = [Item]()
+  public var items: [Item] = [Item]()
   /// The width and height of the component, usually calculated and updated by the UI component
   public var size: CGSize?
   /// A key-value dictionary for any additional information

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -36,7 +36,7 @@ extension Gridable {
   ///
   /// - returns: Size of the object at index path as CGSize
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    let width = (item(at: indexPath)?.size.width ?? 0) - collectionView.contentInset.left - layout.sectionInset.left - layout.sectionInset.right
+    let width = (item(at: indexPath)?.size.width ?? 0) - collectionView.contentInset.left - collectionView.contentInset.right - layout.sectionInset.left - layout.sectionInset.right
     let height = item(at: indexPath)?.size.height ?? 0
 
     // Never return a negative width

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -192,9 +192,7 @@ extension Gridable {
       } else {
         weakSelf.collectionView.reloadData()
       }
-      weakSelf.updateHeight() {
-        completion?()
-      }
+      weakSelf.sanitize { completion?() }
     }
   }
 
@@ -217,9 +215,7 @@ extension Gridable {
       guard let weakSelf = self else { completion?(); return }
 
       weakSelf.collectionView.insert(indexes) {
-        weakSelf.updateHeight() {
-          completion?()
-        }
+        weakSelf.sanitize { completion?() }
       }
     }
   }
@@ -240,10 +236,8 @@ extension Gridable {
       weakSelf.component.items.remove(at: index)
       weakSelf.collectionView.delete([index], completion: nil)
       if animation == .none { UIView.setAnimationsEnabled(true) }
-      weakSelf.updateHeight() {
-        self?.refreshIndexes()
-        completion?()
-      }
+
+      weakSelf.sanitize { completion?() }
     }
   }
 
@@ -264,10 +258,7 @@ extension Gridable {
     Dispatch.mainQueue { [weak self] in
       guard let weakSelf = self else { completion?(); return }
       weakSelf.collectionView.delete(indexes) {
-        weakSelf.updateHeight() {
-          self?.refreshIndexes()
-          completion?()
-        }
+        weakSelf.sanitize { completion?() }
       }
     }
   }
@@ -286,9 +277,7 @@ extension Gridable {
         weakSelf.component.items.remove(at: index)
         weakSelf.collectionView.delete([index], completion: nil)
         if animation == .none { UIView.setAnimationsEnabled(true) }
-        weakSelf.updateHeight() {
-          completion?()
-        }
+        weakSelf.sanitize { completion?() }
       }
     }
   }
@@ -302,9 +291,7 @@ extension Gridable {
     Dispatch.mainQueue { [weak self] in
       guard let weakSelf = self else { return }
       weakSelf.collectionView.delete(indexes) {
-        weakSelf.updateHeight() {
-          completion?()
-        }
+        weakSelf.sanitize { completion?() }
       }
     }
   }

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -241,6 +241,7 @@ extension Gridable {
       weakSelf.collectionView.delete([index], completion: nil)
       if animation == .none { UIView.setAnimationsEnabled(true) }
       weakSelf.updateHeight() {
+        self?.refreshIndexes()
         completion?()
       }
     }
@@ -264,6 +265,7 @@ extension Gridable {
       guard let weakSelf = self else { completion?(); return }
       weakSelf.collectionView.delete(indexes) {
         weakSelf.updateHeight() {
+          self?.refreshIndexes()
           completion?()
         }
       }

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -99,9 +99,7 @@ extension Listable {
 
     Dispatch.mainQueue { [weak self] in
       self?.tableView.insert([index], animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 
@@ -123,9 +121,7 @@ extension Listable {
       }
 
       self?.tableView.insert(indexes, animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 
@@ -142,10 +138,7 @@ extension Listable {
 
     Dispatch.mainQueue { [weak self] in
       self?.tableView.delete([index], animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        self?.refreshIndexes()
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 
@@ -165,10 +158,7 @@ extension Listable {
 
     Dispatch.mainQueue { [weak self] in
       self?.tableView.delete(indexPaths, animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        self?.refreshIndexes()
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 
@@ -181,9 +171,7 @@ extension Listable {
     Dispatch.mainQueue { [weak self] in
       self?.component.items.remove(at: index)
       self?.tableView.delete([index], animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 
@@ -196,9 +184,7 @@ extension Listable {
     Dispatch.mainQueue { [weak self] in
       indexes.forEach { self?.component.items.remove(at: $0) }
       self?.tableView.delete(indexes, section: 0, animation: animation.tableViewAnimation)
-      self?.updateHeight() {
-        completion?()
-      }
+      self?.sanitize { completion?() }
     }
   }
 

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -143,6 +143,7 @@ extension Listable {
     Dispatch.mainQueue { [weak self] in
       self?.tableView.delete([index], animation: animation.tableViewAnimation)
       self?.updateHeight() {
+        self?.refreshIndexes()
         completion?()
       }
     }
@@ -165,6 +166,7 @@ extension Listable {
     Dispatch.mainQueue { [weak self] in
       self?.tableView.delete(indexPaths, animation: animation.tableViewAnimation)
       self?.updateHeight() {
+        self?.refreshIndexes()
         completion?()
       }
     }


### PR DESCRIPTION
This PR aims to improve the reliability of comparing new towards old component collections.

It also removes the need for refreshing indexes when calling `update`. This is redundant as the index shouldn’t change updating an item at a given position.

It fixes one bug in `configure(item:at:usesViewSize:)` that the index wasn’t passed along to the new configured item. This could cause the item to appear in the wrong location.

Default comparison for `reloadIfNeeded` with `JSON` now compares using `!==` instead of `!=` so it takes size into account to determine if it should reload or not.
The same applies to comparing old and new models in `Item+Extensions`.

In `SpotsProtocol+Mutation`, update will only be called if the `spot` has children. This should increase performance as it won’t do unnecessary mutation when updating the data source.