### PR TITLE
Remove lazy variable and set delegate to nil upon deallocation

### DIFF
--- a/Sources/Mac/Classes/Controller.swift
+++ b/Sources/Mac/Classes/Controller.swift
@@ -54,12 +54,7 @@ open class Controller: NSViewController, SpotsProtocol {
   }
 
   /// A custom scroll view that handles the scrolling for all internal scroll views
-  lazy public var scrollView: SpotsScrollView = {
-    let scrollView = SpotsScrollView()
-    scrollView.autoresizingMask = [ .viewWidthSizable, .viewHeightSizable ]
-
-    return scrollView
-  }()
+  public var scrollView: SpotsScrollView = SpotsScrollView()
 
   /// A scroll delegate for handling didReachBeginning and didReachEnd
   weak open var scrollDelegate: ScrollDelegate?
@@ -180,8 +175,11 @@ open class Controller: NSViewController, SpotsProtocol {
    */
   open override func viewDidLoad() {
     super.viewDidLoad()
+    
     view.addSubview(scrollView)
     scrollView.hasVerticalScroller = true
+    scrollView.autoresizingMask = [ .viewWidthSizable, .viewHeightSizable ]
+    
     setupSpots()
     Controller.configure?(scrollView)
   }

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -86,15 +86,8 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
   weak public var scrollDelegate: ScrollDelegate?
 
   /// A custom scroll view that handles the scrolling for all internal scroll views.
-  lazy open var scrollView: SpotsScrollView = {  [unowned self] in
-    let scrollView = SpotsScrollView()
-    scrollView.alwaysBounceVertical = true
-    scrollView.clipsToBounds = true
-    scrollView.delegate = self
-
-    return scrollView
-  }()
-
+  open var scrollView: SpotsScrollView = SpotsScrollView()
+  
 #if os(iOS)
   /// A UIRefresh control.
   /// Note: Only available on iOS.
@@ -159,6 +152,8 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
     }
     NotificationCenter.default.removeObserver(self)
     #endif
+    
+    scrollView.delegate = nil
   }
 
   ///  A generic look up method for resolving spots based on index
@@ -210,8 +205,12 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
   /// Called after the spot controller's view is loaded into memory.
   open override func viewDidLoad() {
     super.viewDidLoad()
+    
     view.addSubview(scrollView)
     scrollView.frame = view.bounds
+    scrollView.alwaysBounceVertical = true
+    scrollView.clipsToBounds = true
+    scrollView.delegate = self
 
     setupSpots()
 

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -153,6 +153,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
     NotificationCenter.default.removeObserver(self)
     #endif
     
+    // http://stackoverflow.com/questions/3686803/uiscrollview-exc-bad-access-crash-in-ios-sdk
     scrollView.delegate = nil
   }
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -23,7 +23,7 @@ open class SpotsScrollView: UIScrollView {
   }
 
   /// A container view that works as a proxy layer for scroll view
-  lazy open var contentView: SpotsContentView = SpotsContentView()
+  open var contentView: SpotsContentView = SpotsContentView()
 
 
   /// A deinitiazlier that removes all subviews from contentView


### PR DESCRIPTION
Even if `UIScrollViewDelegate` is declared as

```swift
weak var delegate: UIScrollViewDelegate? { get set }
```

There may be some rare cases that may cause http://stackoverflow.com/questions/3686803/uiscrollview-exc-bad-access-crash-in-ios-sdk

I don't know if should be problem for now, but seeing that the benefit of `lazy` is not that much, I think we can go safe and remove it