### PR TITLE
Improve/test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 osx_image: xcode8
 language: objective-c
 
+cache:
+  directories:
+  - Carthage
+
 before_install:
-- travis_wait 35 carthage bootstrap --platform iOS,Mac,tvOS
+- travis_wait 35; bin/bootstrap-if-needed
 
 script:
 - set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator | xcpretty

--- a/Sources/Mac/Classes/Controller.swift
+++ b/Sources/Mac/Classes/Controller.swift
@@ -175,11 +175,11 @@ open class Controller: NSViewController, SpotsProtocol {
    */
   open override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     view.addSubview(scrollView)
     scrollView.hasVerticalScroller = true
     scrollView.autoresizingMask = [ .viewWidthSizable, .viewHeightSizable ]
-    
+
     setupSpots()
     Controller.configure?(scrollView)
   }

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -8,8 +8,16 @@ public struct StateCache {
   public let key: String
   /// The cache name used by Cache
   static let cacheName = String(describing: StateCache.self)
+  /// Computed bundle identifier
+  static let bundleIdentifer: String = {
+    if let bundleIdentifier = Bundle.main.bundleIdentifier {
+      return bundleIdentifier
+    }
+    return "Spots.bundle.identifier"
+  }()
+
   /// A JSON Cache object
-  let cache = Cache<JSON>(name: "\(StateCache.cacheName)/\(Bundle.main.bundleIdentifier!)")
+  let cache = Cache<JSON>(name: "\(StateCache.cacheName)/\(bundleIdentifer)")
 
   /// The path of the cache
   var path: String {

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -50,8 +50,10 @@ public struct StateCache {
   }
 
   /// Clear the current StateCache
-  public func clear() {
-    cache.remove(key)
+  public func clear(completion: (() -> Void)? = nil) {
+    cache.remove(key) {
+      completion?()
+    }
   }
 
   /// The StateCache file name

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -4,10 +4,13 @@ import CryptoSwift
 
 /// A StateCache struct used for Controller and Spotable object caching
 public struct StateCache {
+
   /// A unique identifer string for the StateCache
   public let key: String
+
   /// The cache name used by Cache
   static let cacheName = String(describing: StateCache.self)
+
   /// Computed bundle identifier
   static let bundleIdentifer: String = {
     if let bundleIdentifier = Bundle.main.bundleIdentifier {

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -87,7 +87,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
 
   /// A custom scroll view that handles the scrolling for all internal scroll views.
   open var scrollView: SpotsScrollView = SpotsScrollView()
-  
+
 #if os(iOS)
   /// A UIRefresh control.
   /// Note: Only available on iOS.
@@ -152,7 +152,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
     }
     NotificationCenter.default.removeObserver(self)
     #endif
-    
+
     // http://stackoverflow.com/questions/3686803/uiscrollview-exc-bad-access-crash-in-ios-sdk
     scrollView.delegate = nil
   }
@@ -206,7 +206,7 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
   /// Called after the spot controller's view is loaded into memory.
   open override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     view.addSubview(scrollView)
     scrollView.frame = view.bounds
     scrollView.alwaysBounceVertical = true

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -167,12 +167,14 @@
 		BD4295581D81D45D00E07E1C /* TestViewSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295571D81D45D00E07E1C /* TestViewSpot.swift */; };
 		BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295571D81D45D00E07E1C /* TestViewSpot.swift */; };
 		BD677E851DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
-		BD677E861DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
 		BD677E871DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
 		BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
 		BD677E8A1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
 		BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
 		BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */; };
+		BD677E8F1DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
+		BD677E901DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
+		BD677E911DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
 		BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponent.swift */; };
 		BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
 		BD7397401D718CDB000AF2DE /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
@@ -301,6 +303,7 @@
 		BD677E841DC616B2006D1654 /* TestSpotable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotable.swift; sourceTree = "<group>"; };
 		BD677E881DC61EFC006D1654 /* TestStateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStateCache.swift; sourceTree = "<group>"; };
 		BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIViewControllerExtensions.swift; sourceTree = "<group>"; };
+		BD677E8E1DC65D63006D1654 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		BD73972F1D718CD2000AF2DE /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD7397461D718CDB000AF2DE /* Spots-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
@@ -677,6 +680,7 @@
 				BD01BD0D1DAEA464009C10FF /* TestParser.swift */,
 				BD677E841DC616B2006D1654 /* TestSpotable.swift */,
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
+				BD677E8E1DC65D63006D1654 /* Helpers.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1101,6 +1105,7 @@
 				BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */,
 				BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
+				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDD9ABCF1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 			);
@@ -1178,6 +1183,7 @@
 				D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */,
 				D58478551C43FFEF006EBA49 /* TestController.swift in Sources */,
 				BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */,
+				BD677E8F1DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
@@ -1244,9 +1250,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D58478E71C440645006EBA49 /* TestComponent.swift in Sources */,
+				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
-				BD677E861DC616B2006D1654 /* TestSpotable.swift in Sources */,
 				BD677E8A1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -166,6 +166,13 @@
 		BD4295551D81D39700E07E1C /* TestCarouselSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* TestCarouselSpot.swift */; };
 		BD4295581D81D45D00E07E1C /* TestViewSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295571D81D45D00E07E1C /* TestViewSpot.swift */; };
 		BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295571D81D45D00E07E1C /* TestViewSpot.swift */; };
+		BD677E851DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
+		BD677E861DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
+		BD677E871DC616B2006D1654 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
+		BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
+		BD677E8A1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
+		BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
+		BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */; };
 		BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponent.swift */; };
 		BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
 		BD7397401D718CDB000AF2DE /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
@@ -291,6 +298,9 @@
 		BD4295511D81D32400E07E1C /* TestListSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListSpot.swift; sourceTree = "<group>"; };
 		BD4295541D81D39700E07E1C /* TestCarouselSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCarouselSpot.swift; sourceTree = "<group>"; };
 		BD4295571D81D45D00E07E1C /* TestViewSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewSpot.swift; sourceTree = "<group>"; };
+		BD677E841DC616B2006D1654 /* TestSpotable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotable.swift; sourceTree = "<group>"; };
+		BD677E881DC61EFC006D1654 /* TestStateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStateCache.swift; sourceTree = "<group>"; };
+		BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIViewControllerExtensions.swift; sourceTree = "<group>"; };
 		BD73972F1D718CD2000AF2DE /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD7397461D718CDB000AF2DE /* Spots-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
@@ -654,6 +664,7 @@
 				BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */,
 				BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */,
 				BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */,
+				BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -664,6 +675,8 @@
 				D584782B1C43FF34006EBA49 /* TestComponent.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
 				BD01BD0D1DAEA464009C10FF /* TestParser.swift */,
+				BD677E841DC616B2006D1654 /* TestSpotable.swift */,
+				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1078,10 +1091,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */,
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
+				BD677E871DC616B2006D1654 /* TestSpotable.swift in Sources */,
 				BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */,
 				BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */,
@@ -1158,11 +1173,14 @@
 				D58478571C43FFFD006EBA49 /* TestComponent.swift in Sources */,
 				BD42954F1D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
+				BD677E851DC616B2006D1654 /* TestSpotable.swift in Sources */,
 				BD4295521D81D32400E07E1C /* TestListSpot.swift in Sources */,
 				D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */,
 				D58478551C43FFEF006EBA49 /* TestController.swift in Sources */,
+				BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
+				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BDD9ABCB1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
@@ -1228,6 +1246,8 @@
 				D58478E71C440645006EBA49 /* TestComponent.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
+				BD677E861DC616B2006D1654 /* TestSpotable.swift in Sources */,
+				BD677E8A1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,0 +1,27 @@
+import Spots
+#if os(OSX)
+import Foundation
+#else
+import UIKit
+#endif
+
+
+extension Controller {
+
+  func preloadView() {
+    let _ = view
+  }
+  #if !os(OSX)
+  func viewDidAppear() {
+    viewWillAppear(true)
+    viewDidAppear(true)
+  }
+  #endif
+
+  func scrollTo(_ point: CGPoint) {
+    #if !os(OSX)
+    scrollView.setContentOffset(point, animated: false)
+    scrollView.layoutSubviews()
+    #endif
+  }
+}

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -1,0 +1,45 @@
+@testable import Spots
+import Foundation
+import XCTest
+import Brick
+
+class SpotableTests : XCTestCase {
+
+  func testAppendingMultipleItemsToSpot() {
+    let listSpot = ListSpot(component: Component(title: "Component"))
+    listSpot.setup(UIScreen.main.bounds.size)
+    var items: [Item] = []
+
+    for i in 0..<10 {
+      items.append(Item(title: "Item: \(i)"))
+    }
+
+    measure {
+      for _ in 0..<5 {
+        listSpot.append(items)
+        listSpot.render().layoutSubviews()
+      }
+    }
+    XCTAssertEqual(listSpot.items.count, 500)
+  }
+
+  func testAppendingMultipleItemsToSpotInController() {
+    let controller = Controller(spots: [ListSpot(component: Component(title: "Component"))])
+    controller.preloadView()
+    controller.viewDidAppear()
+    var items: [Item] = []
+
+    for i in 0..<10 {
+      items.append(Item(title: "Item: \(i)"))
+    }
+
+    measure {
+      for _ in 0..<5 {
+        controller.append(items, spotIndex: 0, withAnimation: .automatic, completion: nil)
+        controller.spots.forEach { $0.render().layoutSubviews() }
+      }
+    }
+    XCTAssertEqual(controller.spots[0].items.count, 500)
+  }
+
+}

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -41,5 +41,4 @@ class SpotableTests : XCTestCase {
     }
     XCTAssertEqual(controller.spots[0].items.count, 500)
   }
-
 }

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -1,0 +1,53 @@
+@testable import Spots
+import Foundation
+import XCTest
+import Brick
+
+class StateCacheTests : XCTestCase {
+
+  let cacheKey: String = "state-cache-test"
+  var controller: Controller!
+
+  override func setUp() {
+    controller = Controller(cacheKey: cacheKey)
+  }
+
+  override func tearDown() {
+    controller = nil
+  }
+
+  func testStateCacheName() {
+    XCTAssertEqual(controller.stateCache!.fileName(), "1602c56d3ac0f61e5129b5915cccca7b")
+  }
+
+  func testStateCacheOnController() {
+    /// Check that cache exists
+    XCTAssertNotNil(controller.stateCache)
+    /// Check that cache is empty
+    XCTAssertEqual(controller.stateCache!.load().count, 0)
+
+    controller.spots = [ListSpot(component: Component())]
+
+    let exception = self.expectation(description: "Append item to Spotable object")
+    controller.append(Item(title: "foo"), spotIndex: 0, withAnimation: .automatic) {
+      self.controller.cache()
+      /// Check that the cache was saved to disk
+      XCTAssertEqual(self.controller.stateCache!.load().count, 1)
+      exception.fulfill()
+    }
+    waitForExpectations(timeout: 1.0, handler: nil)
+  }
+
+  func testRemovingStateCacheFromController() {
+    XCTAssert(controller.stateCache!.load().count != 0)
+    XCTAssertEqual(controller.stateCache!.cacheExists, true)
+
+    let exception = self.expectation(description: "Clear state cache")
+    controller.stateCache?.clear {
+      XCTAssertEqual(self.controller.stateCache!.load().count, 0)
+      XCTAssertEqual(self.controller.stateCache!.cacheExists, false)
+      exception.fulfill()
+    }
+    waitForExpectations(timeout: 1.0, handler: nil)
+  }
+}

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -39,9 +39,6 @@ class StateCacheTests : XCTestCase {
   }
 
   func testRemovingStateCacheFromController() {
-    XCTAssert(controller.stateCache!.load().count != 0)
-    XCTAssertEqual(controller.stateCache!.cacheExists, true)
-
     let exception = self.expectation(description: "Clear state cache")
     controller.stateCache?.clear {
       XCTAssertEqual(self.controller.stateCache!.load().count, 0)

--- a/SpotsTests/iOS/TestCarouselComposite.swift
+++ b/SpotsTests/iOS/TestCarouselComposite.swift
@@ -38,5 +38,4 @@ class CarouselCompositeTests: XCTestCase {
     view.prepareForReuse()
     XCTAssertTrue(view.contentView.subviews.count == 1)
   }
-  
 }

--- a/SpotsTests/iOS/TestGridComposite.swift
+++ b/SpotsTests/iOS/TestGridComposite.swift
@@ -38,5 +38,4 @@ class GridCompositeTests: XCTestCase {
     view.prepareForReuse()
     XCTAssertTrue(view.contentView.subviews.count == 1)
   }
-  
 }

--- a/SpotsTests/iOS/TestListComposite.swift
+++ b/SpotsTests/iOS/TestListComposite.swift
@@ -38,5 +38,4 @@ class ListCompositeTests: XCTestCase {
     view.prepareForReuse()
     XCTAssertTrue(view.contentView.subviews.count == 1)
   }
-
 }

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -3,23 +3,6 @@ import Brick
 import Foundation
 import XCTest
 
-extension Controller {
-
-  func preloadView() {
-    let _ = view
-  }
-
-  func viewDidAppear() {
-    viewWillAppear(true)
-    viewDidAppear(true)
-  }
-
-  func scrollTo(_ point: CGPoint) {
-    scrollView.setContentOffset(point, animated: false)
-    scrollView.layoutSubviews()
-  }
-}
-
 class SpotsScrollViewTests: XCTestCase {
 
   var bounds: CGRect!
@@ -69,13 +52,14 @@ class SpotsScrollViewTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-
     bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
     controller = Controller(initialJSON)
-    controller.view.autoresizingMask = []
-    controller.view.frame.size = CGSize(width: 375, height: 667)
     controller.preloadView()
+    controller.view.autoresizingMask = []
+    controller.view.frame.size = bounds.size
+    controller.configure(withSize: bounds.size)
     controller.viewWillAppear(true)
+    controller.scrollView.layoutViews()
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestUIViewControllerExtensions.swift
+++ b/SpotsTests/iOS/TestUIViewControllerExtensions.swift
@@ -1,0 +1,28 @@
+@testable import Spots
+import Foundation
+import XCTest
+import Brick
+
+class UIViewControllerExtensionsTests: XCTestCase {
+
+  var controller: Controller!
+
+  override func setUp() {
+    controller = Controller(spots: [])
+  }
+
+  override func tearDown() {
+    controller = nil
+  }
+
+  func testShouldAutorotateOnController() {
+    XCTAssertEqual(controller.spots_shouldAutorotate(), true)
+  }
+
+  func testShouldAutorotateOnChildController() {
+    let parentController = UIViewController()
+    parentController.addChildViewController(controller)
+    XCTAssertEqual(controller.spots_shouldAutorotate(), true)
+  }
+
+}

--- a/SpotsTests/iOS/TestUIViewControllerExtensions.swift
+++ b/SpotsTests/iOS/TestUIViewControllerExtensions.swift
@@ -24,5 +24,4 @@ class UIViewControllerExtensionsTests: XCTestCase {
     parentController.addChildViewController(controller)
     XCTAssertEqual(controller.spots_shouldAutorotate(), true)
   }
-
 }

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+carthage bootstrap
+cp Cartfile.resolved Carthage

--- a/bin/bootstrap-if-needed
+++ b/bin/bootstrap-if-needed
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
+  bin/bootstrap
+fi


### PR DESCRIPTION
This PR aims to improve the overall test coverage on Spots.
### New tests
- [x] Test state cache
- [x] Test UIViewController rotation extension
- [x] Test appending items in sequence to Spotable object
### Changes in the code

`clear` now adds a completion closure on `StateCache`.

Bundle identifier is now a computed value on `StateCache`, this is done to avoid force unwrapping the main bundle identifier. This does not work for tests.

<img width="581" alt="screen shot 2016-10-30 at 14 06 27" src="https://cloud.githubusercontent.com/assets/57446/19836744/14ad3604-9eaa-11e6-8931-90bc509be5db.png">
