### PR TITLE
Improve mapping

### DIFF
--- a/Examples/SpotifyMac/Podfile
+++ b/Examples/SpotifyMac/Podfile
@@ -10,7 +10,7 @@ target "Spotify Mac" do
   pod 'Sugar'
   pod 'JWTDecode', '2.0.0'
   pod 'Fashion', '2.0.0'
-  pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary.git', branch: 'swift-3'
+  pod 'Imaginary', '~> 1.0'
   pod 'Hue'
   pod 'Compass'
   pod 'Malibu', '2.0.0'

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -1,30 +1,29 @@
 PODS:
   - Alamofire (4.0.1)
-  - Brick (2.0.1):
+  - Brick (2.0.2):
     - Tailor (~> 2.0)
-  - Cache (2.0.0):
+  - Cache (2.1.1):
     - CryptoSwift
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fashion (2.0.0)
   - Hue (2.0.0)
-  - Imaginary (0.1.0):
-    - Cache
+  - Imaginary (1.0.1):
+    - Cache (~> 2.0)
   - JWTDecode (2.0.0)
   - Keychain (1.0.0)
   - Malibu (2.0.0):
     - When (~> 2.0)
   - OhMyAuth (0.2.0):
-    - Alamofire
     - JWTDecode
     - Keychain
-    - Sugar
-  - Spots (5.1.1):
+    - Malibu
+  - Spots (5.1.3):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
     - Tailor (~> 2.0)
-  - Sugar (2.0.0)
+  - Sugar (3.0.0)
   - Tailor (2.0.1)
   - When (2.0.0)
 
@@ -36,7 +35,7 @@ DEPENDENCIES:
   - CryptoSwift (= 0.6.0)
   - Fashion (= 2.0.0)
   - Hue
-  - Imaginary (from `https://github.com/hyperoslo/Imaginary.git`, branch `swift-3`)
+  - Imaginary (~> 1.0)
   - JWTDecode (= 2.0.0)
   - Keychain (from `https://github.com/hyperoslo/Keychain.git`, branch `swift-3`)
   - Malibu (= 2.0.0)
@@ -46,9 +45,6 @@ DEPENDENCIES:
   - Tailor
 
 EXTERNAL SOURCES:
-  Imaginary:
-    :branch: swift-3
-    :git: https://github.com/hyperoslo/Imaginary.git
   Keychain:
     :branch: swift-3
     :git: https://github.com/hyperoslo/Keychain.git
@@ -59,34 +55,31 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 CHECKOUT OPTIONS:
-  Imaginary:
-    :commit: 40bb9f4cb935200289976f7c64464b78bb5cea0a
-    :git: https://github.com/hyperoslo/Imaginary.git
   Keychain:
     :commit: aba620997062a2082a9d1a57fb5c81e4e0fe79df
     :git: https://github.com/hyperoslo/Keychain.git
   OhMyAuth:
-    :commit: 11bfb1d489b685c77c8a68eb836e253b8d51383a
+    :commit: c3d9c2f5846a8a54a2fb8c1a16c602ca49c8cd2d
     :git: https://github.com/hyperoslo/OhMyAuth.git
 
 SPEC CHECKSUMS:
   Alamofire: 7682d43245de14874acd142ec137b144aa1dd335
-  Brick: 76695ebcf3c3a581b0159911c63cd804f63cf02a
-  Cache: 86c7a082ce5a734df15a103581d81d29002a171e
+  Brick: a7cf051da76f833e46281477d91b04cee63593f7
+  Cache: 525a292370641881d7e350f0d451fd276790243a
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fashion: f5cd202dcd048edd35217349527ac446d0853cd7
   Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
-  Imaginary: 62a9ce1e6d7831ede429c8221a183f03ec2a90bc
+  Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   JWTDecode: 178e47e5d28d3abcff778bacced8342858cd6cb5
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
   Malibu: d697d750eba061696ddafa097b6cb325ba6037f7
-  OhMyAuth: e10e5ab7a2a3d77c8e056b0d2aa495b9cefec19c
-  Spots: 7bacfcb939e2d7c2ade1a2b7f49d9efbe458a00b
-  Sugar: f45b46cae3d198222a042b9ecf1ce3d44ab8e764
+  OhMyAuth: a18f116df4a9fd1ea06cb6b6e3191537645dc04b
+  Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
+  Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   When: 3df626af4891607ea7dd3f46a451176c5642c528
 
-PODFILE CHECKSUM: 39f2a9e027a6ee4ad115021b6dd32f51c3550795
+PODFILE CHECKSUM: 2507abbb7eb0b30edb2488a8770928626393a43a
 
 COCOAPODS: 1.1.1

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/AlbumBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/AlbumBlueprint.swift
@@ -87,7 +87,7 @@ struct AlbumBlueprint: BlueprintContainer {
           [
             "kind" : "list",
             "meta" : [
-              "doubleClick" : true,
+              "double-click" : true,
               ListSpot.Key.contentInsetsLeft : 25,
               ListSpot.Key.contentInsetsRight : 20
             ]

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/ArtistBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/ArtistBlueprint.swift
@@ -58,26 +58,27 @@ struct ArtistBlueprint: BlueprintContainer {
             "title" : "Top Albums",
             "kind" : Component.Kind.Carousel.rawValue,
             "meta" : [
-              "insetBottom":  30.0,
-              "insetRight" : 10.0,
+              "inset-bottom":  30.0,
+              "inset-left" : 10.0,
+              "inset-right" : 10.0,
             ]
           ],
           ["kind" : Component.Kind.List.rawValue,
             "span" : 3,
             "title" : "Top Tracks",
             "meta" : [
-              "insetRight" : 10.0,
-              "insetBottom" : 30.0,
-              "itemSpacing" : 0.0,
-              "doubleClick" : true,
+              "inset-right" : 10.0,
+              "inset-bottom" : 30.0,
+              "item-spacing" : 0.0,
+              "double-click" : true,
             ]
           ],
           ["kind" : Component.Kind.Carousel.rawValue,
             "title" : "Related artist",
             "meta" : [
               GridableMeta.Key.sectionInsetBottom: 20,
-              "insetRight" : 10.0,
-              "lineSpacing" : 10.0
+              "inset-right" : 10.0,
+              "line-spacing" : 10.0
             ]
           ],
         ]

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/PlaylistBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/PlaylistBlueprint.swift
@@ -83,7 +83,7 @@ struct PlaylistBlueprint: BlueprintContainer {
             "title" : "Songs",
             "kind" : "list",
             "meta" : [
-              "doubleClick" : true,
+              "double-click" : true,
               ListSpot.Key.contentInsetsLeft : 25.0,
               ListSpot.Key.contentInsetsRight : 25.0,
               GridSpot.Key.minimumInteritemSpacing : 0.0,

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/SongsBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/SongsBlueprint.swift
@@ -45,9 +45,9 @@ struct SongsBlueprint: BlueprintContainer {
               "title" : "Loading..."
             ],
             "meta" : [
-              "doubleClick" : true,
-              "insetRight" : 10.0,
-              "insetBottom" : 20.0,
+              "double-click" : true,
+              "inset-right" : 10.0,
+              "inset-bottom" : 20.0,
             ]
           ]
         ]

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/TopTracksBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/TopTracksBlueprint.swift
@@ -64,7 +64,7 @@ struct TopTracksBlueprint: BlueprintContainer {
             "title" : "Top Tracks",
             "kind" : "list",
             "meta" : [
-              "doubleClick" : true,
+              "double-click" : true,
             ]
           ]
         ]

--- a/Examples/SpotifyMac/Spotify Mac/Configuration/OhMyAuthConfigurator.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Configuration/OhMyAuthConfigurator.swift
@@ -23,9 +23,5 @@ public struct OhMyAuthConfigurator: Configurator {
     let locker = UserDefaultsLocker(name: name)
     let service = AuthService(name: name, config: config, locker: locker)
     AuthContainer.addService(service)
-
-    AuthConfig.parse = { response in
-      return response["error"] as? JSONDictionary
-    }
   }
 }

--- a/Examples/SpotifyMac/Spotify Mac/Views/AlbumGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/AlbumGridItem.swift
@@ -67,7 +67,7 @@ open class AlbumGridItem: NSCollectionViewItem, SpotConfigurable {
     customImageView.frame.size.height = item.size.height
 
     if item.image.isPresent && item.image.hasPrefix("http") {
-      customImageView.setImage(NSURL(string: item.image) as URL?) { [weak self] image in
+      customImageView.setImage(url: NSURL(string: item.image) as URL?) { [weak self] image in
         self?.customImageView.contentMode = .scaleToAspectFill
       }
     }

--- a/Examples/SpotifyMac/Spotify Mac/Views/ArtistGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/ArtistGridItem.swift
@@ -93,7 +93,7 @@ open class ArtistGridItem: NSCollectionViewItem, SpotConfigurable {
     customImageView.layer?.cornerRadius = (item.size.width - 40) / 2
 
     if item.image.isPresent && item.image.hasPrefix("http") {
-      customImageView.setImage(NSURL(string: item.image) as URL?) { [weak self] image in
+      customImageView.setImage(url: NSURL(string: item.image) as URL?) { [weak self] image in
         self?.customImageView.contentMode = .scaleToAspectFill
       }
     }

--- a/Examples/SpotifyMac/Spotify Mac/Views/CategoryGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/CategoryGridItem.swift
@@ -75,7 +75,7 @@ open class CategoryGridItem: NSCollectionViewItem, SpotConfigurable {
       customImageView.frame.size.height = item.size.height
       customImageView.frame.origin.y = customView.frame.height - imageView.frame.height
       customImageView.imageAlignment = .alignCenter
-      customImageView.setImage(NSURL(string: item.image) as URL?)
+      customImageView.setImage(url: NSURL(string: item.image) as URL?)
 
       titleLabel.frame.origin.x = imageView.frame.width / 2 - titleLabel.frame.width / 2
       titleLabel.frame.origin.y = imageView.frame.height / 5

--- a/Examples/SpotifyMac/Spotify Mac/Views/FeaturedGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/FeaturedGridItem.swift
@@ -131,7 +131,7 @@ open class FeaturedGridItem: NSCollectionViewItem, SpotConfigurable {
     titleLabel.rightAnchor.constraint(equalTo: customImageView.rightAnchor).isActive = true
 
     if item.image.isPresent && item.image.hasPrefix("http") {
-      customImageView.setImage(NSURL(string: item.image) as URL?) { [customImageView = customImageView] _ in
+      customImageView.setImage(url: NSURL(string: item.image) as URL?) { [customImageView = customImageView] _ in
         customImageView.contentMode = .scaleToAspectFill
       }
     }

--- a/Examples/SpotifyMac/Spotify Mac/Views/HeaderGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/HeaderGridItem.swift
@@ -129,7 +129,7 @@ open class HeaderGridItem: NSTableRowView, SpotConfigurable {
     subtitleLabel.stringValue = item.subtitle
 
     if item.image.isPresent && item.image.hasPrefix("http") {
-      customImageView.setImage(NSURL(string: item.image) as URL?) { [weak self] image in
+      customImageView.setImage(url: NSURL(string: item.image) as URL?) { [weak self] image in
         self?.customImageView.contentMode = .scaleToAspectFill
       }
     }

--- a/Examples/SpotifyMac/Spotify Mac/Views/HeroGridItem.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/HeroGridItem.swift
@@ -84,7 +84,7 @@ open class HeroGridItem: NSTableRowView, SpotConfigurable {
       shadow.shadowOffset = CGSize(width: -20, height: 0)
       shadow.shadowBlurRadius = 20.0
       customImageView.shadow = shadow
-      customImageView.setImage(NSURL(string: item.image) as URL?) { [weak self] _ in
+      customImageView.setImage(url: NSURL(string: item.image) as URL?) { [weak self] _ in
         guard let weakSelf = self else { return }
         weakSelf.customImageView.layer?.mask = weakSelf.gradientLayer
       }

--- a/Examples/SpotifyMac/Spotify Mac/Views/TableRow.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/TableRow.swift
@@ -121,7 +121,7 @@ open class TableRow: NSTableRowView, SpotConfigurable {
         imageView.frame.origin.x = 5
         imageView.frame.origin.y = item.size.height / 2 - imageView.frame.size.height / 2
 
-        imageView.setImage(URL(string: item.image))
+        imageView.setImage(url: URL(string: item.image))
       } else {
         imageView.image = NSImage(named: item.image)
         imageView.frame.size.width = 18

--- a/Examples/SpotifyMac/Spotify Mac/Views/TrackRow.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Views/TrackRow.swift
@@ -207,7 +207,7 @@ open class TrackRow: NSTableRowView, SpotConfigurable {
     if item.image.isPresent && item.image.hasPrefix("http") {
       imageView.heightAnchor.constraint(equalToConstant: 40).isActive = true
       imageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
-      imageView.setImage(URL(string: item.image))
+      imageView.setImage(url: URL(string: item.image))
     } else {
       imageView.image = NSImage(named: item.image)
       imageView.heightAnchor.constraint(equalToConstant: 18).isActive = true

--- a/Sources/Mac/Classes/GridSpot.swift
+++ b/Sources/Mac/Classes/GridSpot.swift
@@ -16,23 +16,23 @@ open class GridSpot: NSObject, Gridable {
 
   public struct Key {
     /// The key for minimum interitem spacing
-    public static let minimumInteritemSpacing = "itemSpacing"
+    public static let minimumInteritemSpacing = "item-spacing"
     /// The key for minimum line spacing
-    public static let minimumLineSpacing = "lineSpacing"
+    public static let minimumLineSpacing = "line-spacing"
     /// The key for title left margin
-    public static let titleLeftMargin = "titleLeftMargin"
+    public static let titleLeftMargin = "title-left-margin"
     /// The key for title font size
     public static let titleFontSize = "title-font-size"
     /// The key for layout
     public static let layout = "layout"
     /// The key for grid layout maximum item width
-    public static let gridLayoutMaximumItemWidth = "itemWidthMax"
+    public static let gridLayoutMaximumItemWidth = "item-width-max"
     /// The key for grid layout maximum item height
-    public static let gridLayoutMaximumItemHeight = "itemHeightMax"
+    public static let gridLayoutMaximumItemHeight = "item-height-max"
     /// The key for grid layout minimum item width
-    public static let gridLayoutMinimumItemWidth = "itemMinWidth"
+    public static let gridLayoutMinimumItemWidth = "item-min-width"
     /// The key for grid layout minimum item height
-    public static let gridLayoutMinimumItemHeight = "itemMinHeight"
+    public static let gridLayoutMinimumItemHeight = "item-min-height"
   }
 
   public struct Default {

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -13,7 +13,7 @@ open class ListSpot: NSObject, Listable {
     public static let contentInsetsLeft = "inset-left"
     public static let contentInsetsBottom = "inset-bottom"
     public static let contentInsetsRight = "inset-right"
-    public static let doubleAction = "doubleClick"
+    public static let doubleAction = "double-click"
   }
 
   public struct Default {

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -184,14 +184,20 @@ public struct Component: Mappable, Equatable {
 
   /// A generic convenience method for resolving meta attributes
   ///
-  /// - parameter key: String
-  /// - parameter defaultValue: A generic value that works as a fallback if the key value object cannot be cast into the generic type
+  /// - Parameter key: String
+  /// - Parameter defaultValue: A generic value that works as a fallback if the key value object cannot be cast into the generic type
   ///
-  /// - returns: A generic value based on `defaultValue`, it falls back to `defaultValue` if type casting fails
+  /// - Returns: A generic value based on `defaultValue`, it falls back to `defaultValue` if type casting fails
   public func meta<T>(_ key: String, _ defaultValue: T) -> T {
     return meta[key] as? T ?? defaultValue
   }
 
+  /// A convenience method for resolving meta attributes for CGFloats.
+  ///
+  /// - Parameter key: String.
+  /// - Parameter defaultValue: A CGFloat value to be used as default if meta key is not found.
+  ///
+  /// - Returns: A generic value based on `defaultValue`, it falls back to `defaultValue` if type casting fails
   public func meta(_ key: String, _ defaultValue: CGFloat) -> CGFloat {
     if let doubleValue = meta[key] as? Double {
       return CGFloat(doubleValue)

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -195,6 +195,8 @@ public struct Component: Mappable, Equatable {
   public func meta(_ key: String, _ defaultValue: CGFloat) -> CGFloat {
     if let doubleValue = meta[key] as? Double {
       return CGFloat(doubleValue)
+    } else if let intValue = meta[key] as? Int {
+      return CGFloat(intValue)
     }
     return defaultValue
   }


### PR DESCRIPTION
This PR improves mapping `Int` values to `CGFloat` when configuring `Component` using `meta`.

It also updates and migrates the Spotify Mac example.

Mapping of keys are now done using dash casing to be consistent with the iOS version of Spots.