### PR TITLE
Feature data & delegate abstraction

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "krzyzanowskim/CryptoSwift" "0.6.4"
+github "krzyzanowskim/CryptoSwift" "0.6.6"
 github "zenangst/Tailor" "2.0.1"
 github "hyperoslo/Brick" "2.0.2"
 github "hyperoslo/Cache" "2.1.1"

--- a/Examples/Apple News/AppleNews/AppDelegate.swift
+++ b/Examples/Apple News/AppleNews/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarDelegate {
       searchController,
       savedController
     ]
-    tabBarController.selectedIndex = 0
+    tabBarController.selectedIndex = 1
     tabBarController.tabBar.isTranslucent = true
 
     navigationController = UINavigationController(rootViewController: tabBarController)

--- a/Examples/Apple News/AppleNews/AppDelegate.swift
+++ b/Examples/Apple News/AppleNews/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarDelegate {
       searchController,
       savedController
     ]
-    tabBarController.selectedIndex = 1
+    tabBarController.selectedIndex = 0
     tabBarController.tabBar.isTranslucent = true
 
     navigationController = UINavigationController(rootViewController: tabBarController)

--- a/Examples/Apple News/AppleNews/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Apple News/AppleNews/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fakery (2.0.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Spots (5.1.3):
@@ -49,7 +49,7 @@ SPEC CHECKSUMS:
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - CryptoSwift
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Keychain (1.0.0)
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   Cache: 525a292370641881d7e350f0d451fd276790243a
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fashion (2.0.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - JWTDecode (2.0.0)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fashion: f5cd202dcd048edd35217349527ac446d0853cd7
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   JWTDecode: 178e47e5d28d3abcff778bacced8342858cd6cb5
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/AlbumsBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/AlbumsBlueprint.swift
@@ -7,6 +7,21 @@ struct AlbumsBlueprint: BlueprintContainer {
 
   static let key = "albums"
   static var drawing: Blueprint {
+    let template = [
+      "components" : [
+        [
+          "title" : "Saved albums",
+          "kind" : Component.Kind.Grid.rawValue,
+          "items" : [
+            "title" : "Loading..."
+          ],
+          "meta" : [
+            GridSpot.Key.layout : GridSpot.LayoutType.left.rawValue,
+          ]
+        ]
+      ]
+    ]
+
     return Blueprint(
       cacheKey: "albums",
       requests: [
@@ -39,20 +54,7 @@ struct AlbumsBlueprint: BlueprintContainer {
             return viewModels
           }
         )],
-      template: [
-        "components" : [
-          [
-            "title" : "Saved albums",
-            "kind" : Component.Kind.Grid.rawValue,
-            "items" : [
-              "title" : "Loading..."
-            ],
-            "meta" : [
-              GridSpot.Key.layout : GridSpot.LayoutType.Left.rawValue,
-            ]
-          ]
-        ]
-      ]
+      template: template
     )
   }
 }

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/BrowseBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/BrowseBlueprint.swift
@@ -7,6 +7,54 @@ struct BrowseBlueprint: BlueprintContainer {
 
   static let key = "browse"
   static var drawing: Blueprint {
+    let template = [
+      "components" : [
+        [
+          "kind" : Component.Kind.List.rawValue,
+          "span" : 1,
+          "items" : [
+            [
+              "title" : "",
+              "image" : "http://i1.wp.com/fusion.net/wp-content/uploads/2015/06/150623-album-covers.png?resize=1600%2C900&quality=80&strip=all",
+              "kind" : "hero",
+              "size" : ["width" : 0.0, "height": 250]
+            ]
+          ],
+          "meta" : [
+            ListSpot.Key.contentInsetsLeft : 0,
+            ListSpot.Key.contentInsetsRight : 0
+          ]
+        ],
+        [
+          "title" : "Featured Playlists",
+          "kind" : Component.Kind.Carousel.rawValue,
+          "meta" : [
+            GridableMeta.Key.sectionInsetRight : 10.0,
+          ]
+        ],
+        ["kind" : Component.Kind.Grid.rawValue,
+         "span" : 3,
+         "title" : "New Releases",
+         "meta" : [
+          GridableMeta.Key.sectionInsetLeft : 10.0,
+          GridableMeta.Key.sectionInsetRight : 0.0,
+          GridSpot.Key.minimumInteritemSpacing : 0.0,
+          GridSpot.Key.minimumLineSpacing : 0.0,
+          GridSpot.Key.layout : GridSpot.LayoutType.left.rawValue
+          ]
+        ],
+        ["kind" : Component.Kind.Grid.rawValue,
+         "title" : "Categories",
+         "meta" : [
+          GridSpot.Key.layout : GridSpot.LayoutType.left.rawValue,
+          GridableMeta.Key.sectionInsetLeft : 10.0,
+          GridableMeta.Key.sectionInsetRight : 0.0,
+          GridableMeta.Key.sectionInsetBottom : 10.0,
+          ]
+        ],
+      ]
+    ]
+
     return Blueprint(
       cacheKey: "browse",
       requests: [
@@ -116,53 +164,7 @@ struct BrowseBlueprint: BlueprintContainer {
           controller.cache()
         }
       },
-      template: [
-        "components" : [
-          [
-            "kind" : Component.Kind.List.rawValue,
-            "span" : 1,
-            "items" : [
-              [
-                "title" : "",
-                "image" : "http://i1.wp.com/fusion.net/wp-content/uploads/2015/06/150623-album-covers.png?resize=1600%2C900&quality=80&strip=all",
-                "kind" : "hero",
-                "size" : ["width" : 0.0, "height": 250]
-              ]
-            ],
-            "meta" : [
-              ListSpot.Key.contentInsetsLeft : 0,
-              ListSpot.Key.contentInsetsRight : 0
-            ]
-          ],
-          [
-            "title" : "Featured Playlists",
-            "kind" : Component.Kind.Carousel.rawValue,
-            "meta" : [
-              GridableMeta.Key.sectionInsetRight : 10.0,
-            ]
-          ],
-          ["kind" : Component.Kind.Grid.rawValue,
-            "span" : 3,
-            "title" : "New Releases",
-            "meta" : [
-              GridableMeta.Key.sectionInsetLeft : 10.0,
-              GridableMeta.Key.sectionInsetRight : 0.0,
-              GridSpot.Key.minimumInteritemSpacing : 0.0,
-              GridSpot.Key.minimumLineSpacing : 0.0,
-              GridSpot.Key.layout : GridSpot.LayoutType.Left.rawValue
-            ]
-          ],
-          ["kind" : Component.Kind.Grid.rawValue,
-            "title" : "Categories",
-            "meta" : [
-              GridSpot.Key.layout : GridSpot.LayoutType.Left.rawValue,
-              GridableMeta.Key.sectionInsetLeft : 10.0,
-              GridableMeta.Key.sectionInsetRight : 0.0,
-              GridableMeta.Key.sectionInsetBottom : 10.0,
-            ]
-          ],
-        ]
-      ]
+      template: template
     )
   }
 }

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/CategoryBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/CategoryBlueprint.swift
@@ -7,6 +7,17 @@ struct CategoryBlueprint: BlueprintContainer {
 
   static let key = "category"
   static var drawing: Blueprint {
+    let template = [
+      "components" : [
+        [
+          "kind" : Component.Kind.Grid.rawValue,
+          "meta" : [
+            GridSpot.Key.layout : GridSpot.LayoutType.left.rawValue,
+          ]
+        ]
+      ]
+    ]
+
     return Blueprint(cacheKey: "", requests: [(
       request: nil,
       rootKey: "playlists",
@@ -37,15 +48,6 @@ struct CategoryBlueprint: BlueprintContainer {
         }
         return viewModels
       }
-      )], template: [
-        "components" : [
-          [
-            "kind" : Component.Kind.Grid.rawValue,
-            "meta" : [
-              GridSpot.Key.layout : GridSpot.LayoutType.Left.rawValue,
-            ]
-          ]
-        ]
-      ])
+      )], template: template)
   }
 }

--- a/Examples/SpotifyMac/Spotify Mac/Blueprints/PlaylistsBlueprint.swift
+++ b/Examples/SpotifyMac/Spotify Mac/Blueprints/PlaylistsBlueprint.swift
@@ -7,6 +7,18 @@ struct PlaylistsBlueprint: BlueprintContainer {
 
   static let key = "playlists"
   static var drawing: Blueprint {
+    let template = [
+      "components" : [
+        [
+          "title" : "Playlists",
+          "kind" : Component.Kind.Grid.rawValue,
+          "meta" : [
+            GridSpot.Key.layout : GridSpot.LayoutType.left.rawValue,
+          ]
+        ]
+      ]
+    ]
+
     return Blueprint(
       cacheKey: "playlists",
       requests: [
@@ -40,17 +52,7 @@ struct PlaylistsBlueprint: BlueprintContainer {
           }
         )
       ],
-      template: [
-        "components" : [
-          [
-            "title" : "Playlists",
-            "kind" : Component.Kind.Grid.rawValue,
-            "meta" : [
-              GridSpot.Key.layout : GridSpot.LayoutType.Left.rawValue,
-            ]
-          ]
-        ]
-      ]
+      template: template
     )
   }
 }

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - CryptoSwift
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Spots (5.1.3):
@@ -36,7 +36,7 @@ SPEC CHECKSUMS:
   Cache: 525a292370641881d7e350f0d451fd276790243a
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - CryptoSwift
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Spots (5.1.3):
@@ -36,7 +36,7 @@ SPEC CHECKSUMS:
   Cache: 525a292370641881d7e350f0d451fd276790243a
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fakery (2.0.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Spots (5.1.3):
@@ -39,7 +39,7 @@ SPEC CHECKSUMS:
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'

--- a/Examples/SpotsNibDemo/Podfile.lock
+++ b/Examples/SpotsNibDemo/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - Cache (2.1.1):
     - CryptoSwift
   - CryptoSwift (0.6.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Spots (5.1.3):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Brick: a7cf051da76f833e46281477d91b04cee63593f7
   Cache: 525a292370641881d7e350f0d451fd276790243a
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Spots: 373205df3c919d96b20291f76b0f6d4c568dd2de
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 

--- a/Sources/Mac/Classes/CarouselSpot.swift
+++ b/Sources/Mac/Classes/CarouselSpot.swift
@@ -93,6 +93,9 @@ open class CarouselSpot: NSObject, Gridable {
     return lineView
   }()
 
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
+
   /// A required initializer to instantiate a CarouselSpot with a component.
   ///
   /// - parameter component: A component
@@ -100,8 +103,12 @@ open class CarouselSpot: NSObject, Gridable {
   /// - returns: An initialized carousel spot.
   public required init(component: Component) {
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     self.collectionView = CollectionView()
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Carousel.string
@@ -136,6 +143,8 @@ open class CarouselSpot: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
+    spotDataSource.spot = nil
+    spotDelegate.spot = nil
   }
 
   fileprivate func configureLayoutInsets(_ component: Component) {
@@ -158,8 +167,8 @@ open class CarouselSpot: NSObject, Gridable {
 
     let view = NSView()
     collectionView.backgroundView = view
-    collectionView.delegate = self
-    collectionView.dataSource = self
+    collectionView.dataSource = spotDataSource
+    collectionView.delegate = spotDelegate
     collectionView.collectionViewLayout = layout
   }
 
@@ -246,43 +255,5 @@ open class CarouselSpot: NSObject, Gridable {
     return CGSize(
       width: ceil(component.items[indexPath.item].size.width),
       height: ceil(component.items[indexPath.item].size.height))
-  }
-}
-
-extension CarouselSpot: NSCollectionViewDataSource {
-
-  public func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
-    return component.items.count
-  }
-
-  public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
-    let reuseIdentifier = identifier(at: indexPath.item)
-    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath as IndexPath)
-
-    (item as? SpotConfigurable)?.configure(&component.items[indexPath.item])
-    return item
-  }
-}
-
-extension CarouselSpot : NSCollectionViewDelegate {
-
-  public func collectionView(_ collectionView: NSCollectionView, didSelectItemsAt indexPaths: Set<IndexPath>) {
-    /*
-     This delay is here to avoid an assertion that happens inside the collection view binding,
-     it tries to resolve the item at index but it no longer exists so the assertion is thrown.
-     This can probably be fixed in a more convenient way in the future without delays.
-     */
-    Dispatch.delay(for: 0.1) { [weak self] in
-      guard let weakSelf = self, let first = indexPaths.first,
-        let item = self?.item(at: first.item), first.item < weakSelf.items.count else { return }
-      weakSelf.delegate?.didSelect(item: item, in: weakSelf)
-    }
-  }
-}
-
-extension CarouselSpot: NSCollectionViewDelegateFlowLayout {
-
-  public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
-    return sizeForItem(at: indexPath)
   }
 }

--- a/Sources/Mac/Classes/CarouselSpot.swift
+++ b/Sources/Mac/Classes/CarouselSpot.swift
@@ -93,8 +93,8 @@ open class CarouselSpot: NSObject, Gridable {
     return lineView
   }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /// A required initializer to instantiate a CarouselSpot with a component.
   ///
@@ -103,12 +103,10 @@ open class CarouselSpot: NSObject, Gridable {
   /// - returns: An initialized carousel spot.
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     self.collectionView = CollectionView()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Carousel.string
@@ -143,8 +141,8 @@ open class CarouselSpot: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource.spot = nil
-    spotDelegate.spot = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   fileprivate func configureLayoutInsets(_ component: Component) {

--- a/Sources/Mac/Classes/Controller.swift
+++ b/Sources/Mac/Classes/Controller.swift
@@ -119,18 +119,21 @@ open class Controller: NSViewController, SpotsProtocol {
     fatalError("init(coder:) has not been implemented")
   }
 
-  /**
-   A generic look up method for resolving spots based on index
-
-   - parameter index: The index of the spot that you are trying to resolve
-   - parameter type: The generic type for the spot you are trying to resolve
-
-   - returns: An optional Spotable object
-   */
-  public func spot<T>(at index: Int = 0, ofType type: T.Type) -> T? {
+  ///  A generic look up method for resolving spots based on index
+  ///
+  /// - parameter index: The index of the spot that you are trying to resolve.
+  /// - parameter type: The generic type for the spot you are trying to resolve.
+  ///
+  /// - returns: An optional Spotable object of inferred type.
+  open func spot<T>(at index: Int = 0, ofType type: T.Type) -> T? {
     return spots.filter({ $0.index == index }).first as? T
   }
 
+  /// A look up method for resolving a spot at index as a Spotable object.
+  ///
+  /// - parameter index: The index of the spot that you are trying to resolve.
+  ///
+  /// - returns: An optional Spotable object.
   open func spot(at index: Int = 0) -> Spotable? {
     return spots.filter({ $0.index == index }).first
   }

--- a/Sources/Mac/Classes/GridSpot.swift
+++ b/Sources/Mac/Classes/GridSpot.swift
@@ -127,8 +127,8 @@ open class GridSpot: NSObject, Gridable {
     return lineView
   }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /**
    A required initializer for creating a GridSpot
@@ -137,13 +137,11 @@ open class GridSpot: NSObject, Gridable {
    */
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     self.collectionView = CollectionView()
     self.layout = GridSpot.setupLayout(component)
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Grid.string
@@ -185,8 +183,8 @@ open class GridSpot: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource.spot = nil
-    spotDelegate.spot = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   @discardableResult fileprivate static func configureLayoutInsets(_ component: Component, layout: NSCollectionViewFlowLayout) -> NSCollectionViewFlowLayout {

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -107,16 +107,14 @@ open class ListSpot: NSObject, Listable {
     return lineView
   }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.List.string
@@ -137,8 +135,8 @@ open class ListSpot: NSObject, Listable {
   deinit {
     tableView.delegate = nil
     tableView.dataSource = nil
-    spotDataSource.spot = nil
-    spotDelegate.spot = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   open func doubleAction(_ sender: Any?) {

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -218,4 +218,9 @@ open class ListSpot: NSObject, Listable {
       }
     }
   }
+
+  public func afterUpdate() {
+    /// This is to set the proper height after reloading a list when initially it didn't contain any items.
+    layout(render().frame.size)
+  }
 }

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -107,9 +107,16 @@ open class ListSpot: NSObject, Listable {
     return lineView
   }()
 
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
+
   public required init(component: Component) {
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.List.string
@@ -130,6 +137,8 @@ open class ListSpot: NSObject, Listable {
   deinit {
     tableView.delegate = nil
     tableView.dataSource = nil
+    spotDataSource.spot = nil
+    spotDelegate.spot = nil
   }
 
   open func doubleAction(_ sender: Any?) {
@@ -166,8 +175,8 @@ open class ListSpot: NSObject, Listable {
       component.items[$0.offset].size.width = size.width
     }
 
-    tableView.delegate = self
-    tableView.dataSource = self
+    tableView.dataSource = spotDataSource
+    tableView.delegate = spotDelegate
     tableView.target = self
     tableView.addTableColumn(tableColumn)
     tableView.action = #selector(self.action(_:))
@@ -208,72 +217,5 @@ open class ListSpot: NSObject, Listable {
         self.tableView.register(nib, forIdentifier: identifier)
       }
     }
-  }
-}
-
-extension ListSpot: NSTableViewDataSource {
-
-  public func numberOfRows(in tableView: NSTableView) -> Int {
-    return component.items.count
-  }
-
-  public func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableViewDropOperation) -> Bool {
-    return false
-  }
-}
-
-extension ListSpot: NSTableViewDelegate {
-
-  public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-    guard let item = item(at: row), row > -1 && row < component.items.count
-      else {
-        return false
-    }
-
-    if component.meta(ListSpot.Key.doubleAction, type: Bool.self) != true {
-      delegate?.didSelect(item: item, in: self)
-    }
-
-    return true
-  }
-
-  public func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-    component.size = CGSize(
-      width: tableView.frame.width,
-      height: tableView.frame.height)
-
-    let height = row < component.items.count ? item(at: row)?.size.height ?? 0 : 1.0
-
-    if height == 0 { return 1.0 }
-
-    return height
-  }
-
-  public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    guard row >= 0 && row < component.items.count else { return nil }
-
-    let reuseIdentifier = identifier(at: row)
-    guard let cachedView = type(of: self).views.make(reuseIdentifier) else { return nil }
-
-    var view: View? = nil
-    if let type = cachedView.type {
-      switch type {
-      case .regular:
-        view = cachedView.view
-      case .nib:
-        view = tableView.make(withIdentifier: reuseIdentifier, owner: nil)
-      }
-    }
-
-    (view as? SpotConfigurable)?.configure(&component.items[row])
-    (view as? NSTableRowView)?.identifier = reuseIdentifier
-
-    return view as? NSTableRowView
-  }
-
-  public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {}
-
-  public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-    return nil
   }
 }

--- a/Sources/Mac/Classes/RowSpot.swift
+++ b/Sources/Mac/Classes/RowSpot.swift
@@ -127,8 +127,8 @@ open class RowSpot: NSObject, Gridable {
     return lineView
   }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /**
    A required initializer for creating a RowSpot
@@ -139,13 +139,11 @@ open class RowSpot: NSObject, Gridable {
     var component = component
     component.span = 1
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     self.collectionView = CollectionView()
     self.layout = RowSpot.setupLayout(component)
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Grid.string
@@ -187,8 +185,8 @@ open class RowSpot: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource.spot = nil
-    spotDelegate.spot = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   @discardableResult fileprivate static func configureLayoutInsets(_ component: Component, layout: NSCollectionViewFlowLayout) -> NSCollectionViewFlowLayout {

--- a/Sources/Mac/Classes/RowSpot.swift
+++ b/Sources/Mac/Classes/RowSpot.swift
@@ -133,6 +133,8 @@ open class RowSpot: NSObject, Gridable {
    - parameter component: A component struct
    */
   public required init(component: Component) {
+    var component = component
+    component.span = 1
     self.component = component
     self.collectionView = CollectionView()
     self.layout = RowSpot.setupLayout(component)

--- a/Sources/Mac/Classes/RowSpot.swift
+++ b/Sources/Mac/Classes/RowSpot.swift
@@ -127,6 +127,9 @@ open class RowSpot: NSObject, Gridable {
     return lineView
   }()
 
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
+
   /**
    A required initializer for creating a RowSpot
 
@@ -136,9 +139,13 @@ open class RowSpot: NSObject, Gridable {
     var component = component
     component.span = 1
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     self.collectionView = CollectionView()
     self.layout = RowSpot.setupLayout(component)
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Grid.string
@@ -180,6 +187,8 @@ open class RowSpot: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
+    spotDataSource.spot = nil
+    spotDelegate.spot = nil
   }
 
   @discardableResult fileprivate static func configureLayoutInsets(_ component: Component, layout: NSCollectionViewFlowLayout) -> NSCollectionViewFlowLayout {
@@ -238,15 +247,14 @@ open class RowSpot: NSObject, Gridable {
     collectionView.allowsEmptySelection = true
     collectionView.layer = CALayer()
     collectionView.wantsLayer = true
-    collectionView.delegate = self
-    collectionView.dataSource = self
+    collectionView.dataSource = spotDataSource
+    collectionView.delegate = spotDelegate
     collectionView.collectionViewLayout = layout
   }
 
   /// Return collection view as a scroll view
   ///
   /// - returns: UIScrollView: Returns a UICollectionView as a UIScrollView
-  ///
   open func render() -> ScrollView {
     return scrollView
   }
@@ -310,47 +318,5 @@ open class RowSpot: NSObject, Gridable {
     titleView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
     titleView.frame.origin.y = titleView.frame.size.height / 2
     lineView.frame.origin.y = titleView.frame.maxY + 8
-  }
-}
-
-extension RowSpot: NSCollectionViewDataSource {
-
-  @nonobjc public func numberOfSectionsInCollectionView(_ collectionView: NSCollectionView) -> Int {
-    return 1
-  }
-
-  public func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
-    return component.items.count
-  }
-
-  public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
-    let reuseIdentifier = identifier(at: indexPath.item)
-    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath as IndexPath)
-
-    (item as? SpotConfigurable)?.configure(&component.items[indexPath.item])
-    return item
-  }
-}
-
-extension RowSpot : NSCollectionViewDelegate {
-
-  public func collectionView(_ collectionView: NSCollectionView, didSelectItemsAt indexPaths: Set<IndexPath>) {
-    /*
-     This delay is here to avoid an assertion that happens inside the collection view binding,
-     it tries to resolve the item at index but it no longer exists so the assertion is thrown.
-     This can probably be fixed in a more convenient way in the future without delays.
-     */
-    Dispatch.delay(for: 0.1) { [weak self] in
-      guard let weakSelf = self, let first = indexPaths.first,
-        let item = self?.item(at: first.item), first.item < weakSelf.items.count else { return }
-      weakSelf.delegate?.didSelect(item: item, in: weakSelf)
-    }
-  }
-}
-
-extension RowSpot: NSCollectionViewDelegateFlowLayout {
-
-  public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
-    return sizeForItem(at: indexPath)
   }
 }

--- a/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
@@ -7,10 +7,18 @@ extension DataSource: NSCollectionViewDataSource {
   }
 
   public func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 
   public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
+    guard let spot = spot else {
+      return NSCollectionViewItem()
+    }
+
     let reuseIdentifier: String
 
     if let gridable = spot as? Gridable {
@@ -29,6 +37,10 @@ extension DataSource: NSCollectionViewDataSource {
 extension DataSource: NSTableViewDataSource {
 
   public func numberOfRows(in tableView: NSTableView) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 

--- a/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
@@ -22,7 +22,6 @@ extension DataSource: NSCollectionViewDataSource {
     let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
 
     (item as? SpotConfigurable)?.configure(&spot.component.items[indexPath.item])
-    
     return item
   }
 }

--- a/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
@@ -1,0 +1,39 @@
+import Cocoa
+
+extension DataSource: NSCollectionViewDataSource {
+
+  @nonobjc public func numberOfSectionsInCollectionView(_ collectionView: NSCollectionView) -> Int {
+    return 1
+  }
+
+  public func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
+    return spot.component.items.count
+  }
+
+  public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
+    let reuseIdentifier: String
+
+    if let gridable = spot as? Gridable {
+      reuseIdentifier = gridable.identifier(at: indexPath.item)
+    } else {
+      reuseIdentifier = spot.identifier(at: indexPath.item)
+    }
+
+    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
+
+    (item as? SpotConfigurable)?.configure(&spot.component.items[indexPath.item])
+    
+    return item
+  }
+}
+
+extension DataSource: NSTableViewDataSource {
+
+  public func numberOfRows(in tableView: NSTableView) -> Int {
+    return spot.component.items.count
+  }
+
+  public func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableViewDropOperation) -> Bool {
+    return false
+  }
+}

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -10,8 +10,9 @@ extension Delegate: NSCollectionViewDelegate {
      */
     Dispatch.delay(for: 0.1) { [weak self] in
       guard let weakSelf = self, let first = indexPaths.first,
-        let item = self?.spot.item(at: first.item), first.item < weakSelf.spot.items.count else { return }
-      weakSelf.spot.delegate?.didSelect(item: item, in: weakSelf.spot)
+        let spot = weakSelf.spot,
+        let item = spot.item(at: first.item), first.item < spot.items.count else { return }
+      spot.delegate?.didSelect(item: item, in: spot)
     }
   }
 }
@@ -19,6 +20,9 @@ extension Delegate: NSCollectionViewDelegate {
 extension Delegate: NSCollectionViewDelegateFlowLayout {
 
   public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
+    guard let spot = spot else {
+      return CGSize.zero
+    }
     return spot.sizeForItem(at: indexPath)
   }
 }
@@ -26,7 +30,9 @@ extension Delegate: NSCollectionViewDelegateFlowLayout {
 extension Delegate: NSTableViewDelegate {
 
   public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-    guard let item = spot.item(at: row), row > -1 && row < spot.component.items.count
+    guard let spot = spot,
+      let item = spot.item(at: row),
+      row > -1 && row < spot.component.items.count
       else {
         return false
     }
@@ -39,6 +45,10 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+    guard let spot = spot else {
+      return 1.0
+    }
+
     spot.component.size = CGSize(
       width: tableView.frame.width,
       height: tableView.frame.height)
@@ -53,7 +63,9 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    guard row >= 0 && row < spot.component.items.count else { return nil }
+    guard let spot = spot, row >= 0 && row < spot.component.items.count else {
+        return nil
+    }
 
     let reuseIdentifier = spot.identifier(at: row)
     guard let cachedView = spot.type.views.make(reuseIdentifier) else { return nil }

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -1,0 +1,82 @@
+import Cocoa
+
+extension Delegate: NSCollectionViewDelegate {
+
+  public func collectionView(_ collectionView: NSCollectionView, didSelectItemsAt indexPaths: Set<IndexPath>) {
+    /*
+     This delay is here to avoid an assertion that happens inside the collection view binding,
+     it tries to resolve the item at index but it no longer exists so the assertion is thrown.
+     This can probably be fixed in a more convenient way in the future without delays.
+     */
+    Dispatch.delay(for: 0.1) { [weak self] in
+      guard let weakSelf = self, let first = indexPaths.first,
+        let item = self?.spot.item(at: first.item), first.item < weakSelf.spot.items.count else { return }
+      weakSelf.spot.delegate?.didSelect(item: item, in: weakSelf.spot)
+    }
+  }
+}
+
+extension Delegate: NSCollectionViewDelegateFlowLayout {
+
+  public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
+    return spot.sizeForItem(at: indexPath)
+  }
+}
+
+extension Delegate: NSTableViewDelegate {
+
+  public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+    guard let item = spot.item(at: row), row > -1 && row < spot.component.items.count
+      else {
+        return false
+    }
+
+    if spot.component.meta(ListSpot.Key.doubleAction, type: Bool.self) != true {
+      spot.delegate?.didSelect(item: item, in: spot)
+    }
+
+    return true
+  }
+
+  public func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+    spot.component.size = CGSize(
+      width: tableView.frame.width,
+      height: tableView.frame.height)
+
+    let height = row < spot.component.items.count
+      ? spot.item(at: row)?.size.height ?? 0
+      : 1.0
+
+    if height == 0 { return 1.0 }
+
+    return height
+  }
+
+  public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+    guard row >= 0 && row < spot.component.items.count else { return nil }
+
+    let reuseIdentifier = spot.identifier(at: row)
+    guard let cachedView = spot.type.views.make(reuseIdentifier) else { return nil }
+
+    var view: View? = nil
+    if let type = cachedView.type {
+      switch type {
+      case .regular:
+        view = cachedView.view
+      case .nib:
+        view = tableView.make(withIdentifier: reuseIdentifier, owner: nil)
+      }
+    }
+
+    (view as? SpotConfigurable)?.configure(&spot.component.items[row])
+    (view as? NSTableRowView)?.identifier = reuseIdentifier
+
+    return view as? NSTableRowView
+  }
+
+  public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {}
+
+  public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+    return nil
+  }
+}

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public class DataSource: NSObject {
-  weak var spot: Spotable!
+  weak var spot: Spotable?
 }

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -1,11 +1,5 @@
 import Foundation
 
 public class DataSource: NSObject {
-
-  var component: Component
   weak var spot: Spotable!
-
-  init(component: Component) {
-    self.component = component
-  }
 }

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class DataSource: NSObject {
+
+  var component: Component
+  weak var spot: Spotable!
+
+  init(component: Component) {
+    self.component = component
+  }
+}

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -2,4 +2,8 @@ import Foundation
 
 public class DataSource: NSObject {
   weak var spot: Spotable?
+
+  init(spot: Spotable) {
+    self.spot = spot
+  }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,11 +1,5 @@
 import Foundation
 
 public class Delegate: NSObject {
-
-  var component: Component
-  weak var spot: Spotable!
-
-  init(component: Component) {
-    self.component = component
-  }
+  var spot: Spotable!
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public class Delegate: NSObject {
-  weak var spot: Spotable!
+  weak var spot: Spotable?
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -2,4 +2,8 @@ import Foundation
 
 public class Delegate: NSObject {
   weak var spot: Spotable?
+
+  init(spot: Spotable) {
+    self.spot = spot
+  }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class Delegate: NSObject {
+
+  var component: Component
+  weak var spot: Spotable!
+
+  init(component: Component) {
+    self.component = component
+  }
+}

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public class Delegate: NSObject {
-  var spot: Spotable!
+  weak var spot: Spotable!
 }

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -18,6 +18,7 @@ open class ViewSpot: NSObject, Spotable, Viewable {
 
 
   /// A Registry struct that contains all register components, used for resolving what UI component to use
+  open static var headers = Registry()
   open static var views = Registry()
   open static var configure: ((_ view: View) -> Void)?
   open static var defaultView: View.Type = View.self

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -52,6 +52,7 @@ public extension Spotable where Self : Gridable {
       collectionView.frame.size.height = layout.contentSize.height
     #endif
     layout.prepare()
+
     component.size = collectionView.frame.size
   }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -421,9 +421,9 @@ public extension Spotable {
   ///
   /// - returns: A string identifier for the view, defaults to the `defaultIdentifier` on the Spotable object.
   public func identifier(at index: Int) -> String {
-    guard let item = item(at: index), type(of: self).views.storage[item.kind] != nil
+    guard let item = item(at: index), type.views.storage[item.kind] != nil
       else {
-        return type(of: self).views.defaultIdentifier
+        return type.views.defaultIdentifier
     }
 
     return item.kind

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -28,6 +28,13 @@ public extension Spotable {
     return height
   }
 
+  /// A helper method to return self as a Spotable type.
+  ///
+  /// - returns: Self as a Spotable type
+  public var type: Spotable.Type {
+    return type(of: self)
+  }
+
   /// Resolve a UI component at index with inferred type
   ///
   /// - parameter index: The index of the UI component

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -441,7 +441,10 @@ extension SpotsProtocol {
         if animation != .none { spot.render().layer.frame.size.height = spotHeight }
       #endif
 
-      weakSelf.spot(at: index, ofType: Spotable.self)?.reload(nil, withAnimation: animation) { [weak self] in
+      let spot = weakSelf.spot(at: index, ofType: Spotable.self)
+
+      spot?.reload(nil, withAnimation: animation) { [weak self] in
+        spot?.afterUpdate()
         completion?()
         self?.scrollView.layoutSubviews()
       }

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -9,7 +9,9 @@ import Brick
 /// A class protocol that is used for all components inside of Controller
 public protocol Spotable: class {
 
+  #if !os(OSX)
   static var headers: Registry { get set }
+  #endif
   static var views: Registry { get set }
 
   #if !os(OSX)

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -9,6 +9,7 @@ import Brick
 /// A class protocol that is used for all components inside of Controller
 public protocol Spotable: class {
 
+  static var headers: Registry { get set }
   static var views: Registry { get set }
 
   #if !os(OSX)

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -27,7 +27,9 @@ public typealias Completion = (() -> Void)?
 
   /// Extension for macOS to gain layoutSubviews
   extension NSView {
-    func layoutSubviews() { layoutSubtreeIfNeeded() }
+    func layoutSubviews() {
+      layoutSubtreeIfNeeded()
+    }
   }
 #else
   /// A type alias to reference a normal platform view

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -197,8 +197,8 @@ open class CarouselSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource = nil
-    self.spotDelegate = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   /// Configure collection view with data source, delegate and background view

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -141,8 +141,8 @@ open class CarouselSpot: NSObject, Gridable {
   /// The collection views background view
   open lazy var backgroundView = UIView()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /// A required initializer to instantiate a CarouselSpot with a component.
   ///
@@ -151,11 +151,9 @@ open class CarouselSpot: NSObject, Gridable {
   /// - returns: An initialized carousel spot.
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Carousel.string
@@ -199,8 +197,8 @@ open class CarouselSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource.spot = nil
-    self.spotDelegate.spot = nil
+    self.spotDataSource = nil
+    self.spotDelegate = nil
   }
 
   /// Configure collection view with data source, delegate and background view

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -198,6 +198,11 @@ open class CarouselSpot: NSObject, Gridable {
     self.stateCache = stateCache
   }
 
+  deinit {
+    self.spotDataSource.spot = nil
+    self.spotDelegate.spot = nil
+  }
+
   /// Configure collection view with data source, delegate and background view
   public func configureCollectionView() {
     register()

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -81,8 +81,8 @@ open class GridSpot: NSObject, Gridable {
     return collectionView
   }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /// A required initializer to instantiate a GridSpot with a component.
   ///
@@ -91,11 +91,9 @@ open class GridSpot: NSObject, Gridable {
   /// - returns: An initialized grid spot with component.
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Grid.string
@@ -161,8 +159,8 @@ open class GridSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource.spot = nil
-    self.spotDelegate.spot = nil
+    self.spotDataSource = nil
+    self.spotDelegate = nil
   }
 
   /// Configure section insets and layout spacing for the UICollectionViewFlow using component meta data

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -103,7 +103,6 @@ open class GridSpot: NSObject, Gridable {
 
     registerDefault(view: GridSpotCell.self)
     registerComposite(view: GridComposite.self)
-    register()
     configureLayout()
     prepareItems()
     configureCollectionView()

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -159,8 +159,8 @@ open class GridSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource = nil
-    self.spotDelegate = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   /// Configure section insets and layout spacing for the UICollectionViewFlow using component meta data

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -160,6 +160,11 @@ open class GridSpot: NSObject, Gridable {
     collectionView.delegate = spotDelegate
   }
 
+  deinit {
+    self.spotDataSource.spot = nil
+    self.spotDelegate.spot = nil
+  }
+
   /// Configure section insets and layout spacing for the UICollectionViewFlow using component meta data
   func configureLayout() {
     layout.sectionInset = UIEdgeInsets(

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -76,12 +76,13 @@ open class GridSpot: NSObject, Gridable {
   /// A UICollectionView, used as the main UI component for a GridSpot
   open lazy var collectionView: UICollectionView = { [unowned self] in
     let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.layout)
-    collectionView.dataSource = self
-    collectionView.delegate = self
     collectionView.isScrollEnabled = false
 
     return collectionView
   }()
+
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
 
   /// A required initializer to instantiate a GridSpot with a component.
   ///
@@ -90,7 +91,11 @@ open class GridSpot: NSObject, Gridable {
   /// - returns: An initialized grid spot with component.
   public required init(component: Component) {
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Grid.string
@@ -99,8 +104,9 @@ open class GridSpot: NSObject, Gridable {
     registerDefault(view: GridSpotCell.self)
     registerComposite(view: GridComposite.self)
     register()
-    prepareItems()
     configureLayout()
+    prepareItems()
+    configureCollectionView()
 
     if GridSpot.views.composite == nil {
       GridSpot.views.composite =  Registry.Item.classType(GridComposite.self)
@@ -148,6 +154,13 @@ open class GridSpot: NSObject, Gridable {
     layout.minimumLineSpacing = lineSpacing
   }
 
+  /// Configure collection view with data source, delegate and background view
+  public func configureCollectionView() {
+    register()
+    collectionView.dataSource = spotDataSource
+    collectionView.delegate = spotDelegate
+  }
+
   /// Configure section insets and layout spacing for the UICollectionViewFlow using component meta data
   func configureLayout() {
     layout.sectionInset = UIEdgeInsets(
@@ -159,109 +172,6 @@ open class GridSpot: NSObject, Gridable {
     layout.minimumLineSpacing = component.meta(GridableMeta.Key.minimumLineSpacing, Default.minimumLineSpacing)
     collectionView.contentInset.left = component.meta(GridableMeta.Key.contentInsetLeft, Default.contentInsetLeft)
     collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
-  }
-}
-
-extension GridSpot : UICollectionViewDataSource {
-
-  /// Asks your data source object to provide a supplementary view to display in the collection view.
-  /// A configured supplementary view object. You must not return nil from this method.
-  ///
-  /// - parameter collectionView: The collection view requesting this information.
-  /// - parameter kind:           The kind of supplementary view to provide. The value of this string is defined by the layout object that supports the supplementary view.
-  /// - parameter indexPath:      The index path that specifies the location of the new supplementary view.
-  ///
-  /// - returns: A configured supplementary view object.
-  public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-    let header = component.header.isEmpty
-      ? type(of: self).headers.defaultIdentifier
-      : component.header
-
-    let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader, withReuseIdentifier: header, for: indexPath)
-    (view as? Componentable)?.configure(component)
-
-    return view
-  }
-
-  /// Asks the data source for the number of items in the specified section. (required)
-  ///
-  /// - parameter collectionView: An object representing the collection view requesting this information.
-  /// - parameter section:        An index number identifying a section in collectionView. This index value is 0-based.
-  ///
-  /// - returns: The number of rows in section.
-  public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return component.items.count
-  }
-
-  /// Asks the data source for the cell that corresponds to the specified item in the collection view. (required)
-  ///
-  /// - parameter collectionView: collectionView: An object representing the collection view requesting this information.
-  /// - parameter indexPath:      The index path that specifies the location of the item.
-  ///
-  /// - returns: A configured cell object. You must not return nil from this method.
-  public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    component.items[indexPath.item].index = indexPath.item
-
-    let reuseIdentifier = identifier(at: indexPath)
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
-    if let composite = cell as? Composable {
-      let spots = spotsCompositeDelegate?.resolve(index, itemIndex: (indexPath as NSIndexPath).item)
-      composite.configure(&component.items[indexPath.item], spots: spots)
-    } else if let cell = cell as? SpotConfigurable {
-      cell.configure(&component.items[indexPath.item])
-      if component.items[indexPath.item].size.height == 0.0 {
-        component.items[indexPath.item].size = cell.preferredViewSize
-      }
-      configure?(cell)
-    }
-
-    return cell
-  }
-}
-
-extension GridSpot : UICollectionViewDelegate {
-
-  /// Asks the delegate for the size of the specified item’s cell.
-  ///
-  /// - parameter collectionView: The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter indexPath: The index path of the item.
-  ///
-  /// - returns: The width and height of the specified item. Both values must be greater than 0.
-  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return sizeForItem(at: indexPath)
-  }
-
-  /// Tells the delegate that the item at the specified index path was selected.
-  ///
-  /// - parameter collectionView: The collection view object that is notifying you of the selection change.
-  /// - parameter indexPath: The index path of the cell that was selected.
-  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    guard let item = item(at: indexPath) else { return }
-    delegate?.didSelect(item: item, in: self)
-  }
-
-  /// Asks the delegate whether the item at the specified index path can be focused.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter indexPath:      The index path of an item in the collection view.
-  ///
-  /// - returns: YES if the item can receive be focused or NO if it can not.
-  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    return true
-  }
-
-  ///Asks the delegate whether a change in focus should occur.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter context:        The context object containing metadata associated with the focus change.
-  /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
-
-  /// - returns: YES if the focus change should occur or NO if it should not.
-  @available(iOS 9.0, *)
-  public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
-    guard let indexPaths = collectionView.indexPathsForSelectedItems else { return true }
-    return indexPaths.isEmpty
   }
 }
 

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -27,10 +27,10 @@ open class GridableLayout: UICollectionViewFlowLayout {
      let spot = delegate.spot as? Gridable else { return }
 
     if scrollDirection == .horizontal {
-      guard let firstItem = delegate.spot.items.first else { return }
+      guard let firstItem = spot.items.first else { return }
 
-      contentSize.width = delegate.spot.items.reduce(0, { $0 + $1.size.width })
-      contentSize.width += CGFloat(delegate.spot.items.count) * (minimumInteritemSpacing)
+      contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
+      contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
       contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
       contentSize.width = ceil(contentSize.width)
 
@@ -64,8 +64,11 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// - returns: An array of layout attribute objects containing the layout information for the enclosed items and views. The default implementation of this method returns nil.
   open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
     guard let collectionView = collectionView,
-      let dataSource = collectionView.dataSource as? DataSource
-      else { return nil }
+      let dataSource = collectionView.dataSource as? DataSource,
+      let spot = dataSource.spot
+      else {
+        return nil
+    }
 
     var attributes = [UICollectionViewLayoutAttributes]()
     var rect = CGRect(origin: CGPoint.zero, size: contentSize)
@@ -88,7 +91,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
           itemAttribute.frame.origin.x = collectionView.contentOffset.x
           attributes.append(itemAttribute)
         } else {
-          itemAttribute.size = dataSource.spot.sizeForItem(at: itemAttribute.indexPath)
+          itemAttribute.size = spot.sizeForItem(at: itemAttribute.indexPath)
 
           if scrollDirection == .horizontal {
             itemAttribute.frame.origin.y = headerReferenceSize.height

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -23,20 +23,21 @@ open class GridableLayout: UICollectionViewFlowLayout {
   open override func prepare() {
     super.prepare()
 
-    guard let spot = collectionView?.delegate as? Gridable else { return }
+    guard let delegate = collectionView?.delegate as? Delegate,
+     let spot = delegate.spot as? Gridable else { return }
 
     if scrollDirection == .horizontal {
-      guard let firstItem = spot.items.first else { return }
+      guard let firstItem = delegate.spot.items.first else { return }
 
-      contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
-      contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
+      contentSize.width = delegate.spot.items.reduce(0, { $0 + $1.size.width })
+      contentSize.width += CGFloat(delegate.spot.items.count) * (minimumInteritemSpacing)
       contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
       contentSize.width = ceil(contentSize.width)
 
       contentSize.height = firstItem.size.height + headerReferenceSize.height
       contentSize.height += sectionInset.top + sectionInset.bottom
 
-      if let spot = spot as? CarouselSpot, spot.pageIndicator {
+      if let spot = delegate.spot as? CarouselSpot, spot.pageIndicator {
         contentSize.height += spot.pageControl.frame.height
       }
     } else {
@@ -63,7 +64,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// - returns: An array of layout attribute objects containing the layout information for the enclosed items and views. The default implementation of this method returns nil.
   open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
     guard let collectionView = collectionView,
-      let spot = collectionView.dataSource as? Gridable
+      let dataSource = collectionView.dataSource as? DataSource
       else { return nil }
 
     var attributes = [UICollectionViewLayoutAttributes]()
@@ -87,7 +88,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
           itemAttribute.frame.origin.x = collectionView.contentOffset.x
           attributes.append(itemAttribute)
         } else {
-          itemAttribute.size = spot.sizeForItem(at: itemAttribute.indexPath)
+          itemAttribute.size = dataSource.spot.sizeForItem(at: itemAttribute.indexPath)
 
           if scrollDirection == .horizontal {
             itemAttribute.frame.origin.y = headerReferenceSize.height

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -49,6 +49,9 @@ open class ListSpot: NSObject, Listable {
   /// Indicator to calculate the height based on content
   open var usesDynamicHeight = true
 
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
+
   // MARK: - Initializers
 
   /// A required initializer to instantiate a ListSpot with a component.
@@ -58,7 +61,11 @@ open class ListSpot: NSObject, Listable {
   /// - returns: An initialized list spot with component.
   public required init(component: Component) {
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.List.string
@@ -126,11 +133,16 @@ open class ListSpot: NSObject, Listable {
     ListSpot.configure?(tableView)
   }
 
+  deinit {
+    self.spotDataSource.spot = nil
+    self.spotDelegate.spot = nil
+  }
+
   /// Configure and setup the data source, delegate and additional configuration options for the table view.
   public func setupTableView() {
     register()
-    tableView.dataSource = self
-    tableView.delegate = self
+    tableView.dataSource = spotDataSource
+    tableView.delegate = spotDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
 
     #if os(iOS)
@@ -178,122 +190,5 @@ open class ListSpot: NSObject, Listable {
   /// parameter header: The view type that you want to register as default header.
   open static func register(defaultHeader header: View.Type) {
     self.headers.storage[self.views.defaultIdentifier] = Registry.Item.classType(header)
-  }
-}
-
-/**
- A UITableViewDelegate extension on ListAdapter
- */
-extension ListSpot: UITableViewDelegate {
-
-  /// Asks the delegate for the height to use for the header of a particular section.
-  ///
-  /// - parameter tableView: The table-view object requesting this information.
-  /// - parameter heightForHeaderInSection: An index number identifying a section of tableView.
-  /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
-
-  public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    let header = type(of: self).headers.make(component.header)
-    return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
-  }
-
-  /// Asks the data source for the title of the header of the specified section of the table view.
-  ///
-  /// - parameter tableView: The table-view object asking for the title.
-  /// - parameter section: An index number identifying a section of tableView.
-  /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
-  public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    if let _ = type(of: self).headers.make(component.header) {
-      return nil
-    }
-    return !component.title.isEmpty ? component.title : nil
-  }
-
-  /// Tells the delegate that the specified row is now selected.
-  ///
-  /// - parameter tableView: A table-view object informing the delegate about the new row selection.
-  /// - parameter indexPath: An index path locating the new selected row in tableView.
-  public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    if let item = self.item(at: indexPath) {
-      delegate?.didSelect(item: item, in: self)
-    }
-  }
-
-  /// Asks the delegate for a view object to display in the header of the specified section of the table view.
-  ///
-  /// - parameter tableView: The table-view object asking for the view object.
-  /// - parameter section: An index number identifying a section of tableView.
-  /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
-  public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard !component.header.isEmpty else { return nil }
-
-    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: component.header)
-    view?.frame.size.height = component.meta(ListSpot.Key.headerHeight, 0.0)
-    view?.frame.size.width = tableView.frame.size.width
-    (view as? Componentable)?.configure(component)
-
-    return view
-  }
-
-  /// Asks the delegate for the height to use for a row in a specified location.
-  ///
-  /// - parameter tableView: The table-view object requesting this information.
-  /// - parameter indexPath: An index path that locates a row in tableView.
-  /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
-
-  public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    component.size = CGSize(
-      width: tableView.frame.size.width,
-      height: tableView.frame.size.height)
-
-    return item(at: indexPath)?.size.height ?? 0
-  }
-}
-
-/// MARK: - UITableViewDataSource
-extension ListSpot : UITableViewDataSource {
-
-  /// Tells the data source to return the number of rows in a given section of a table view. (required)
-  ///
-  /// - parameter tableView: The table-view object requesting this information.
-  /// - parameter section: An index number identifying a section in tableView.
-  ///
-  /// - returns: The number of rows in section.
-  public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return component.items.count
-  }
-
-  /// Asks the data source for a cell to insert in a particular location of the table view. (required)
-  ///
-  /// - parameter tableView: A table-view object requesting the cell.
-  /// - parameter indexPath: An index path locating a row in tableView.
-  ///
-  /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
-  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    if indexPath.item < component.items.count {
-      component.items[indexPath.item].index = indexPath.row
-    }
-
-    let reuseIdentifier = identifier(at: indexPath)
-    let cell: UITableViewCell = tableView
-      .dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
-
-    guard indexPath.item < component.items.count else { return cell }
-
-    if let composite = cell as? Composable {
-      let spots = spotsCompositeDelegate?.resolve(index, itemIndex: (indexPath as NSIndexPath).item)
-      composite.configure(&component.items[indexPath.item], spots: spots)
-    } else if let cell = cell as? SpotConfigurable {
-      cell.configure(&component.items[indexPath.item])
-
-      if component.items[indexPath.item].size.height == 0.0 {
-        component.items[indexPath.item].size = cell.preferredViewSize
-      }
-
-      configure?(cell)
-    }
-
-    return cell
   }
 }

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -132,8 +132,8 @@ open class ListSpot: NSObject, Listable {
   }
 
   deinit {
-    self.spotDataSource = nil
-    self.spotDelegate = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   /// Configure and setup the data source, delegate and additional configuration options for the table view.

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -49,8 +49,8 @@ open class ListSpot: NSObject, Listable {
   /// Indicator to calculate the height based on content
   open var usesDynamicHeight = true
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   // MARK: - Initializers
 
@@ -61,11 +61,9 @@ open class ListSpot: NSObject, Listable {
   /// - returns: An initialized list spot with component.
   public required init(component: Component) {
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.List.string
@@ -134,8 +132,8 @@ open class ListSpot: NSObject, Listable {
   }
 
   deinit {
-    self.spotDataSource.spot = nil
-    self.spotDelegate.spot = nil
+    self.spotDataSource = nil
+    self.spotDelegate = nil
   }
 
   /// Configure and setup the data source, delegate and additional configuration options for the table view.

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -81,8 +81,8 @@ open class RowSpot: NSObject, Gridable {
     return collectionView
     }()
 
-  var spotDataSource: DataSource
-  var spotDelegate: Delegate
+  var spotDataSource: DataSource?
+  var spotDelegate: Delegate?
 
   /// A required initializer to instantiate a RowSpot with a component.
   ///
@@ -93,11 +93,9 @@ open class RowSpot: NSObject, Gridable {
     var component = component
     component.span = 1
     self.component = component
-    self.spotDataSource = DataSource()
-    self.spotDelegate = Delegate()
     super.init()
-    self.spotDataSource.spot = self
-    self.spotDelegate.spot = self
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Row.string
@@ -169,8 +167,8 @@ open class RowSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource.spot = nil
-    self.spotDelegate.spot = nil
+    self.spotDataSource = nil
+    self.spotDelegate = nil
   }
 
   /// Configure collection view with data source, delegate and background view

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -76,12 +76,13 @@ open class RowSpot: NSObject, Gridable {
   /// A UICollectionView, used as the main UI component for a RowSpot
   open lazy var collectionView: UICollectionView = { [unowned self] in
     let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.layout)
-    collectionView.dataSource = self
-    collectionView.delegate = self
     collectionView.isScrollEnabled = false
 
     return collectionView
     }()
+
+  var spotDataSource: DataSource
+  var spotDelegate: Delegate
 
   /// A required initializer to instantiate a RowSpot with a component.
   ///
@@ -91,9 +92,12 @@ open class RowSpot: NSObject, Gridable {
   public required init(component: Component) {
     var component = component
     component.span = 1
-
     self.component = component
+    self.spotDataSource = DataSource()
+    self.spotDelegate = Delegate()
     super.init()
+    self.spotDataSource.spot = self
+    self.spotDelegate.spot = self
 
     if component.kind.isEmpty {
       self.component.kind = Component.Kind.Row.string
@@ -101,9 +105,9 @@ open class RowSpot: NSObject, Gridable {
 
     registerDefault(view: RowSpotCell.self)
     registerComposite(view: GridComposite.self)
-    register()
     prepareItems()
     configureLayout()
+    configureCollectionView()
 
     if RowSpot.views.composite == nil {
       RowSpot.views.composite = Registry.Item.classType(GridComposite.self)
@@ -163,108 +167,12 @@ open class RowSpot: NSObject, Gridable {
     collectionView.contentInset.left = component.meta(GridableMeta.Key.contentInsetLeft, Default.contentInsetLeft)
     collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }
-}
 
-extension RowSpot : UICollectionViewDataSource {
-
-  /// Asks your data source object to provide a supplementary view to display in the collection view.
-  /// A configured supplementary view object. You must not return nil from this method.
-  ///
-  /// - parameter collectionView: The collection view requesting this information.
-  /// - parameter kind:           The kind of supplementary view to provide. The value of this string is defined by the layout object that supports the supplementary view.
-  /// - parameter indexPath:      The index path that specifies the location of the new supplementary view.
-  ///
-  /// - returns: A configured supplementary view object.
-  public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-    let header = component.header.isEmpty
-      ? type(of: self).headers.defaultIdentifier
-      : component.header
-
-    let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader, withReuseIdentifier: header, for: indexPath)
-    (view as? Componentable)?.configure(component)
-
-    return view
-  }
-
-  /// Asks the data source for the number of items in the specified section. (required)
-  ///
-  /// - parameter collectionView: An object representing the collection view requesting this information.
-  /// - parameter section:        An index number identifying a section in collectionView. This index value is 0-based.
-  ///
-  /// - returns: The number of rows in section.
-  public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return component.items.count
-  }
-
-  /// Asks the data source for the cell that corresponds to the specified item in the collection view. (required)
-  ///
-  /// - parameter collectionView: collectionView: An object representing the collection view requesting this information.
-  /// - parameter indexPath:      The index path that specifies the location of the item.
-  ///
-  /// - returns: A configured cell object. You must not return nil from this method.
-  public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    component.items[indexPath.item].index = indexPath.item
-
-    let reuseIdentifier = identifier(at: indexPath)
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
-    if let composite = cell as? Composable {
-      let spots = spotsCompositeDelegate?.resolve(index, itemIndex: (indexPath as NSIndexPath).item)
-      composite.configure(&component.items[indexPath.item], spots: spots)
-    } else if let cell = cell as? SpotConfigurable {
-      cell.configure(&component.items[indexPath.item])
-      if component.items[indexPath.item].size.height == 0.0 {
-        component.items[indexPath.item].size = cell.preferredViewSize
-      }
-      configure?(cell)
-    }
-
-    return cell
-  }
-}
-
-extension RowSpot : UICollectionViewDelegate {
-
-  /// Asks the delegate for the size of the specified item’s cell.
-  ///
-  /// - parameter collectionView: The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter indexPath: The index path of the item.
-  ///
-  /// - returns: The width and height of the specified item. Both values must be greater than 0.
-  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return sizeForItem(at: indexPath)
-  }
-
-  /// Tells the delegate that the item at the specified index path was selected.
-  ///
-  /// - parameter collectionView: The collection view object that is notifying you of the selection change.
-  /// - parameter indexPath: The index path of the cell that was selected.
-  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    guard let item = item(at: indexPath) else { return }
-    delegate?.didSelect(item: item, in: self)
-  }
-
-  /// Asks the delegate whether the item at the specified index path can be focused.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter indexPath:      The index path of an item in the collection view.
-  ///
-  /// - returns: YES if the item can receive be focused or NO if it can not.
-  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    return true
-  }
-
-  ///Asks the delegate whether a change in focus should occur.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter context:        The context object containing metadata associated with the focus change.
-  /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
-
-  /// - returns: YES if the focus change should occur or NO if it should not.
-  @available(iOS 9.0, *)
-  public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
-    guard let indexPaths = collectionView.indexPathsForSelectedItems else { return true }
-    return indexPaths.isEmpty
+  /// Configure collection view with data source, delegate and background view
+  public func configureCollectionView() {
+    register()
+    collectionView.dataSource = spotDataSource
+    collectionView.delegate = spotDelegate
   }
 }
 

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -167,8 +167,8 @@ open class RowSpot: NSObject, Gridable {
   }
 
   deinit {
-    self.spotDataSource = nil
-    self.spotDelegate = nil
+    spotDataSource = nil
+    spotDelegate = nil
   }
 
   /// Configure collection view with data source, delegate and background view

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -168,6 +168,11 @@ open class RowSpot: NSObject, Gridable {
     collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }
 
+  deinit {
+    self.spotDataSource.spot = nil
+    self.spotDelegate.spot = nil
+  }
+
   /// Configure collection view with data source, delegate and background view
   public func configureCollectionView() {
     register()

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -10,6 +10,10 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 
@@ -22,6 +26,10 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: A configured supplementary view object.
   public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    guard let spot = spot else {
+      return UICollectionReusableView()
+    }
+
     let identifier: String
 
     if spot.component.header.isEmpty {
@@ -45,7 +53,9 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard indexPath.item < spot.component.items.count else { return UICollectionViewCell() }
+    guard let spot = spot, indexPath.item < spot.component.items.count else {
+        return UICollectionViewCell()
+    }
     spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.identifier(at: indexPath)
@@ -74,6 +84,8 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    guard let spot = spot else { return 0 }
+
     return spot.component.items.count
   }
 
@@ -84,7 +96,9 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard indexPath.item < spot.component.items.count else { return UITableViewCell() }
+    guard let spot = spot, indexPath.item < spot.component.items.count else {
+      return UITableViewCell()
+    }
 
     if indexPath.item < spot.component.items.count {
       spot.component.items[indexPath.item].index = indexPath.row

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -45,6 +45,7 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard indexPath.item < spot.component.items.count else { return UICollectionViewCell() }
     spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.identifier(at: indexPath)
@@ -83,6 +84,8 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    guard indexPath.item < spot.component.items.count else { return UITableViewCell() }
+
     if indexPath.item < spot.component.items.count {
       spot.component.items[indexPath.item].index = indexPath.row
     }
@@ -90,8 +93,6 @@ extension DataSource: UITableViewDataSource {
     let reuseIdentifier = spot.identifier(at: indexPath)
     let cell: UITableViewCell = tableView
       .dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
-
-    guard indexPath.item < spot.component.items.count else { return cell }
 
     if let composite = cell as? Composable {
       let spots = spot.spotsCompositeDelegate?.resolve(spot.component.index, itemIndex: (indexPath as NSIndexPath).item)

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -10,7 +10,7 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return component.items.count
+    return spot.component.items.count
   }
 
   /// Asks your data source object to provide a supplementary view to display in the collection view.
@@ -24,16 +24,16 @@ extension DataSource: UICollectionViewDataSource {
   public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
     let identifier: String
 
-    if component.header.isEmpty {
+    if spot.component.header.isEmpty {
       identifier = spot.type.headers.defaultIdentifier
     } else {
-      identifier = component.header
+      identifier = spot.component.header
     }
 
     let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader,
                                                                withReuseIdentifier: identifier,
                                                                for: indexPath)
-    (view as? Componentable)?.configure(component)
+    (view as? Componentable)?.configure(spot.component)
 
     return view
   }
@@ -45,17 +45,17 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    component.items[indexPath.item].index = indexPath.item
+    spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.identifier(at: indexPath)
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
     if let composite = cell as? Composable {
-      let spots = spot.spotsCompositeDelegate?.resolve(component.index, itemIndex: indexPath.item)
-      composite.configure(&component.items[indexPath.item], spots: spots)
+      let spots = spot.spotsCompositeDelegate?.resolve(spot.component.index, itemIndex: indexPath.item)
+      composite.configure(&spot.component.items[indexPath.item], spots: spots)
     } else if let cell = cell as? SpotConfigurable {
-      cell.configure(&component.items[indexPath.item])
-      if component.items[indexPath.item].size.height == 0.0 {
-        component.items[indexPath.item].size = cell.preferredViewSize
+      cell.configure(&spot.component.items[indexPath.item])
+      if spot.component.items[indexPath.item].size.height == 0.0 {
+        spot.component.items[indexPath.item].size = cell.preferredViewSize
       }
       spot.configure?(cell)
     }
@@ -73,7 +73,7 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return component.items.count
+    return spot.component.items.count
   }
 
   /// Asks the data source for a cell to insert in a particular location of the table view. (required)
@@ -83,24 +83,24 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    if indexPath.item < component.items.count {
-      component.items[indexPath.item].index = indexPath.row
+    if indexPath.item < spot.component.items.count {
+      spot.component.items[indexPath.item].index = indexPath.row
     }
 
     let reuseIdentifier = spot.identifier(at: indexPath)
     let cell: UITableViewCell = tableView
       .dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
 
-    guard indexPath.item < component.items.count else { return cell }
+    guard indexPath.item < spot.component.items.count else { return cell }
 
     if let composite = cell as? Composable {
-      let spots = spot.spotsCompositeDelegate?.resolve(component.index, itemIndex: (indexPath as NSIndexPath).item)
-      composite.configure(&component.items[indexPath.item], spots: spots)
+      let spots = spot.spotsCompositeDelegate?.resolve(spot.component.index, itemIndex: (indexPath as NSIndexPath).item)
+      composite.configure(&spot.component.items[indexPath.item], spots: spots)
     } else if let cell = cell as? SpotConfigurable {
-      cell.configure(&component.items[indexPath.item])
+      cell.configure(&spot.component.items[indexPath.item])
 
-      if component.items[indexPath.item].size.height == 0.0 {
-        component.items[indexPath.item].size = cell.preferredViewSize
+      if spot.component.items[indexPath.item].size.height == 0.0 {
+        spot.component.items[indexPath.item].size = cell.preferredViewSize
       }
 
       spot.configure?(cell)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -10,6 +10,8 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
   @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    guard let spot = spot else { return CGSize.zero }
+
     return spot.sizeForItem(at: indexPath)
   }
 
@@ -18,7 +20,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter collectionView: The collection view object that is notifying you of the selection change.
   /// - parameter indexPath: The index path of the cell that was selected.
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    guard let item = spot.item(at: indexPath) else { return }
+    guard let spot = spot, let item = spot.item(at: indexPath) else { return }
     spot.delegate?.didSelect(item: item, in: spot)
   }
 
@@ -29,7 +31,7 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: YES if the item can receive be focused or NO if it can not.
   public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    guard let _ = spot.item(at: indexPath) else { return  false }
+    guard let spot = spot, let _ = spot.item(at: indexPath) else { return  false }
     return true
   }
 
@@ -56,6 +58,10 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
   public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    guard let spot = spot else {
+      return 0.0
+    }
+
     let header = spot.type.headers.make(spot.component.header)
     return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
   }
@@ -67,9 +73,14 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
   @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    guard let spot = spot else {
+      return nil
+    }
+
     if let _ = spot.type.headers.make(spot.component.header) {
       return nil
     }
+
     return !spot.component.title.isEmpty ? spot.component.title : nil
   }
 
@@ -79,7 +90,7 @@ extension Delegate: UITableViewDelegate {
   /// - parameter indexPath: An index path locating the new selected row in tableView.
   public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     tableView.deselectRow(at: indexPath, animated: true)
-    if let item = spot.item(at: indexPath) {
+    if let spot = spot, let item = spot.item(at: indexPath) {
       spot.delegate?.didSelect(item: item, in: spot)
     }
   }
@@ -91,7 +102,7 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
   public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard !spot.component.header.isEmpty else { return nil }
+    guard let spot = spot, !spot.component.header.isEmpty else { return nil }
 
     let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.header)
     view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
@@ -108,6 +119,10 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
   public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    guard let spot = spot else {
+      return 0.0
+    }
+
     spot.component.size = CGSize(
       width: tableView.frame.size.width,
       height: tableView.frame.size.height)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -55,7 +55,7 @@ extension Delegate: UITableViewDelegate {
   /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
 
   public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    let header = spot.type.headers.make(component.header)
+    let header = spot.type.headers.make(spot.component.header)
     return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
   }
 
@@ -65,10 +65,10 @@ extension Delegate: UITableViewDelegate {
   /// - parameter section: An index number identifying a section of tableView.
   /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
   @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    if let _ = spot.type.headers.make(component.header) {
+    if let _ = spot.type.headers.make(spot.component.header) {
       return nil
     }
-    return !component.title.isEmpty ? component.title : nil
+    return !spot.component.title.isEmpty ? spot.component.title : nil
   }
 
   /// Tells the delegate that the specified row is now selected.
@@ -88,12 +88,12 @@ extension Delegate: UITableViewDelegate {
   /// - parameter section: An index number identifying a section of tableView.
   /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
   public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard !component.header.isEmpty else { return nil }
+    guard !spot.component.header.isEmpty else { return nil }
 
-    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: component.header)
-    view?.frame.size.height = component.meta(ListSpot.Key.headerHeight, 0.0)
+    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.header)
+    view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
     view?.frame.size.width = tableView.frame.size.width
-    (view as? Componentable)?.configure(component)
+    (view as? Componentable)?.configure(spot.component)
 
     return view
   }
@@ -105,7 +105,7 @@ extension Delegate: UITableViewDelegate {
   /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
 
   public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    component.size = CGSize(
+    spot.component.size = CGSize(
       width: tableView.frame.size.width,
       height: tableView.frame.size.height)
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -38,7 +38,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter collectionView: The collection view object requesting this information.
   /// - parameter context:        The context object containing metadata associated with the focus change.
   /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
-
+  ///
   /// - returns: YES if the focus change should occur or NO if it should not.
   @available(iOS 9.0, *)
   public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
@@ -53,8 +53,8 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - parameter tableView: The table-view object requesting this information.
   /// - parameter heightForHeaderInSection: An index number identifying a section of tableView.
+  ///
   /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
-
   public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     let header = spot.type.headers.make(spot.component.header)
     return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
@@ -64,6 +64,7 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - parameter tableView: The table-view object asking for the title.
   /// - parameter section: An index number identifying a section of tableView.
+  ///
   /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
   @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
     if let _ = spot.type.headers.make(spot.component.header) {
@@ -87,6 +88,7 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - parameter tableView: The table-view object asking for the view object.
   /// - parameter section: An index number identifying a section of tableView.
+  ///
   /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
   public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
     guard !spot.component.header.isEmpty else { return nil }
@@ -103,8 +105,8 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - parameter tableView: The table-view object requesting this information.
   /// - parameter indexPath: An index path that locates a row in tableView.
+  ///
   /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
-
   public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     spot.component.size = CGSize(
       width: tableView.frame.size.width,

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -29,6 +29,7 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: YES if the item can receive be focused or NO if it can not.
   public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
+    guard let _ = spot.item(at: indexPath) else { return  false }
     return true
   }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -1,0 +1,114 @@
+import UIKit
+
+extension Delegate: UICollectionViewDelegate {
+
+  /// Asks the delegate for the size of the specified item’s cell.
+  ///
+  /// - parameter collectionView: The collection view object displaying the flow layout.
+  /// - parameter collectionViewLayout: The layout object requesting the information.
+  /// - parameter indexPath: The index path of the item.
+  ///
+  /// - returns: The width and height of the specified item. Both values must be greater than 0.
+  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    return spot.sizeForItem(at: indexPath)
+  }
+
+  /// Tells the delegate that the item at the specified index path was selected.
+  ///
+  /// - parameter collectionView: The collection view object that is notifying you of the selection change.
+  /// - parameter indexPath: The index path of the cell that was selected.
+  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let item = spot.item(at: indexPath) else { return }
+    spot.delegate?.didSelect(item: item, in: spot)
+  }
+
+  /// Asks the delegate whether the item at the specified index path can be focused.
+  ///
+  /// - parameter collectionView: The collection view object requesting this information.
+  /// - parameter indexPath:      The index path of an item in the collection view.
+  ///
+  /// - returns: YES if the item can receive be focused or NO if it can not.
+  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
+    return true
+  }
+
+  ///Asks the delegate whether a change in focus should occur.
+  ///
+  /// - parameter collectionView: The collection view object requesting this information.
+  /// - parameter context:        The context object containing metadata associated with the focus change.
+  /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
+
+  /// - returns: YES if the focus change should occur or NO if it should not.
+  @available(iOS 9.0, *)
+  public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
+    guard let indexPaths = collectionView.indexPathsForSelectedItems else { return true }
+    return indexPaths.isEmpty
+  }
+}
+
+extension Delegate: UITableViewDelegate {
+
+  /// Asks the delegate for the height to use for the header of a particular section.
+  ///
+  /// - parameter tableView: The table-view object requesting this information.
+  /// - parameter heightForHeaderInSection: An index number identifying a section of tableView.
+  /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
+
+  public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    let header = spot.type.headers.make(component.header)
+    return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
+  }
+
+  /// Asks the data source for the title of the header of the specified section of the table view.
+  ///
+  /// - parameter tableView: The table-view object asking for the title.
+  /// - parameter section: An index number identifying a section of tableView.
+  /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
+  @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    if let _ = spot.type.headers.make(component.header) {
+      return nil
+    }
+    return !component.title.isEmpty ? component.title : nil
+  }
+
+  /// Tells the delegate that the specified row is now selected.
+  ///
+  /// - parameter tableView: A table-view object informing the delegate about the new row selection.
+  /// - parameter indexPath: An index path locating the new selected row in tableView.
+  public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    if let item = spot.item(at: indexPath) {
+      spot.delegate?.didSelect(item: item, in: spot)
+    }
+  }
+
+  /// Asks the delegate for a view object to display in the header of the specified section of the table view.
+  ///
+  /// - parameter tableView: The table-view object asking for the view object.
+  /// - parameter section: An index number identifying a section of tableView.
+  /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
+  public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    guard !component.header.isEmpty else { return nil }
+
+    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: component.header)
+    view?.frame.size.height = component.meta(ListSpot.Key.headerHeight, 0.0)
+    view?.frame.size.width = tableView.frame.size.width
+    (view as? Componentable)?.configure(component)
+
+    return view
+  }
+
+  /// Asks the delegate for the height to use for a row in a specified location.
+  ///
+  /// - parameter tableView: The table-view object requesting this information.
+  /// - parameter indexPath: An index path that locates a row in tableView.
+  /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
+
+  public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    component.size = CGSize(
+      width: tableView.frame.size.width,
+      height: tableView.frame.size.height)
+
+    return spot.item(at: indexPath)?.size.height ?? 0
+  }
+}

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -145,6 +145,14 @@ extension Gridable {
     self.headers.storage[identifier.string] = Registry.Item.nib(nib)
   }
 
+  /// Register default header for the CarouselSpot
+  ///
+  /// - parameter view: A header view
+  public func registerDefaultHeader(header view: View.Type) {
+    guard type(of: self).headers.storage[type(of: self).headers.defaultIdentifier] == nil else { return }
+    type(of: self).headers.defaultItem = Registry.Item.classType(view)
+  }
+
   ///Register a default header for the Gridable component
   ///
   /// - parameter defaultHeader: The default header class that should be used by the component

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -149,8 +149,8 @@ extension Gridable {
   ///
   /// - parameter view: A header view
   public func registerDefaultHeader(header view: View.Type) {
-    guard type(of: self).headers.storage[type(of: self).headers.defaultIdentifier] == nil else { return }
-    type(of: self).headers.defaultItem = Registry.Item.classType(view)
+    guard type.headers.storage[type.headers.defaultIdentifier] == nil else { return }
+    type.headers.defaultItem = Registry.Item.classType(view)
   }
 
   ///Register a default header for the Gridable component
@@ -158,6 +158,7 @@ extension Gridable {
   /// - parameter defaultHeader: The default header class that should be used by the component
   public static func register(defaultHeader header: View.Type) {
     self.headers.storage[self.views.defaultIdentifier] = Registry.Item.classType(header)
+    self.headers.defaultItem = Registry.Item.classType(header)
   }
 
   public func ui<T>(at index: Int) -> T? {

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		BDEFF5491DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */; };
 		BDEFF54B1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */; };
 		BDEFF54D1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */; };
+		BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
+		BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
 		D2FEDC1F1D9E845A004D5ABF /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */; };
 		D58478141C43FEB9006EBA49 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
@@ -357,6 +359,7 @@
 		BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+Mac+Extensions.swift"; sourceTree = "<group>"; };
 		BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+Mac+Extensions.swift"; sourceTree = "<group>"; };
+		BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDataSource.swift; sourceTree = "<group>"; };
 		D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478131C43FEB9006EBA49 /* Spots-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -731,6 +734,7 @@
 				BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */,
 				BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */,
 				BD4295571D81D45D00E07E1C /* TestViewSpot.swift */,
+				BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1166,6 +1170,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */,
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */,
@@ -1260,6 +1265,7 @@
 				BD42954F1D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDDF2CCC1DC7C23500B766BA /* TestAnimations.swift in Sources */,
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
+				BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BD677E851DC616B2006D1654 /* TestSpotable.swift in Sources */,
 				BD4295521D81D32400E07E1C /* TestListSpot.swift in Sources */,
 				D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 		BDEFF5461DD0F7FB00FC0537 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */; };
 		BDEFF5481DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */; };
 		BDEFF5491DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */; };
+		BDEFF54B1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */; };
+		BDEFF54D1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */; };
 		D2FEDC1F1D9E845A004D5ABF /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */; };
 		D58478141C43FEB9006EBA49 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
@@ -353,6 +355,8 @@
 		BDEFF53F1DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delegate.swift; sourceTree = "<group>"; };
 		BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+Extensions.swift"; sourceTree = "<group>"; };
+		BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+Mac+Extensions.swift"; sourceTree = "<group>"; };
+		BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+Mac+Extensions.swift"; sourceTree = "<group>"; };
 		D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478131C43FEB9006EBA49 /* Spots-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -519,6 +523,8 @@
 				BD129E1C1D7B2CDE009AC164 /* NSScrollView+Extensions.swift */,
 				BD129E1D1D7B2CDE009AC164 /* NSTableView+Indexes.swift */,
 				BD129E1E1D7B2CDE009AC164 /* Viewable+Mac.swift */,
+				BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */,
+				BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1310,11 +1316,13 @@
 				BD129E301D7B2CDE009AC164 /* Gridable+Extensions+Mac.swift in Sources */,
 				BD129F5E1D7B2F91009AC164 /* SpotsProtocol+Extensions.swift in Sources */,
 				BD129E241D7B2CDE009AC164 /* GridSpot.swift in Sources */,
+				BDEFF54B1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift in Sources */,
 				BD129E351D7B2CDE009AC164 /* NSTableView+Indexes.swift in Sources */,
 				BD129E2B1D7B2CDE009AC164 /* SpotsScrollView.swift in Sources */,
 				BD129F581D7B2F91009AC164 /* Gridable+Extensions.swift in Sources */,
 				BD129F641D7B2F91009AC164 /* SpotsProtocol+Mutation.swift in Sources */,
 				BD129F551D7B2F91009AC164 /* Component+Extension.swift in Sources */,
+				BDEFF54D1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift in Sources */,
 				BD129F941D7B2F91009AC164 /* TypeAlias.swift in Sources */,
 				BD129F821D7B2F91009AC164 /* SpotsProtocol.swift in Sources */,
 				BDA8DB001DCF4D0A00A4A8DD /* RowSpotItem.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -205,6 +205,16 @@
 		BDDF2CCD1DC7C23500B766BA /* TestAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */; };
 		BDDF2CD01DC7C50700B766BA /* TestAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */; };
 		BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */; };
+		BDEFF53C1DD0F18B00FC0537 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF53B1DD0F18B00FC0537 /* DataSource.swift */; };
+		BDEFF53D1DD0F18B00FC0537 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF53B1DD0F18B00FC0537 /* DataSource.swift */; };
+		BDEFF53E1DD0F18B00FC0537 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF53B1DD0F18B00FC0537 /* DataSource.swift */; };
+		BDEFF5401DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF53F1DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift */; };
+		BDEFF5421DD0F3CF00FC0537 /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF53F1DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift */; };
+		BDEFF5441DD0F7FB00FC0537 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */; };
+		BDEFF5451DD0F7FB00FC0537 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */; };
+		BDEFF5461DD0F7FB00FC0537 /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */; };
+		BDEFF5481DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */; };
+		BDEFF5491DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */; };
 		D2FEDC1F1D9E845A004D5ABF /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */; };
 		D58478141C43FEB9006EBA49 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
@@ -339,6 +349,10 @@
 		BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnimations.swift; sourceTree = "<group>"; };
 		BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnimations.swift; sourceTree = "<group>"; };
 		BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsScrollView.swift; sourceTree = "<group>"; };
+		BDEFF53B1DD0F18B00FC0537 /* DataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		BDEFF53F1DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+iOS+Extensions.swift"; sourceTree = "<group>"; };
+		BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delegate.swift; sourceTree = "<group>"; };
+		BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478131C43FEB9006EBA49 /* Spots-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -430,6 +444,8 @@
 				BD129D601D7B295F009AC164 /* UICollectionView+Indexes.swift */,
 				BD129D611D7B295F009AC164 /* UITableView+Indexes.swift */,
 				D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */,
+				BDEFF53F1DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift */,
+				BDEFF5471DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -534,6 +550,8 @@
 				BD129F271D7B2F91009AC164 /* Registry.swift */,
 				BD129F281D7B2F91009AC164 /* SpotFactory.swift */,
 				BD129F291D7B2F91009AC164 /* ViewSpot.swift */,
+				BDEFF53B1DD0F18B00FC0537 /* DataSource.swift */,
+				BDEFF5431DD0F7FB00FC0537 /* Delegate.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1091,6 +1109,8 @@
 				BD8B1EB41D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */,
 				BD129D901D7B295F009AC164 /* Composable+Extensions.swift in Sources */,
 				BD129F531D7B2F91009AC164 /* Animation.swift in Sources */,
+				BDEFF5491DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */,
+				BDEFF5421DD0F3CF00FC0537 /* DataSource+iOS+Extensions.swift in Sources */,
 				BD129DD01D7B2B6C009AC164 /* SpotsScrollView.swift in Sources */,
 				BD129F8F1D7B2F91009AC164 /* Parser.swift in Sources */,
 				BD129DBE1D7B2B6C009AC164 /* GridableLayout.swift in Sources */,
@@ -1124,9 +1144,11 @@
 				BD129F951D7B2F91009AC164 /* TypeAlias.swift in Sources */,
 				BD129F591D7B2F91009AC164 /* Gridable+Extensions.swift in Sources */,
 				BD129F561D7B2F91009AC164 /* Component+Extension.swift in Sources */,
+				BDEFF5461DD0F7FB00FC0537 /* Delegate.swift in Sources */,
 				BD129F6B1D7B2F91009AC164 /* Item+Extensions.swift in Sources */,
 				BD129F801D7B2F91009AC164 /* SpotsDelegates.swift in Sources */,
 				BD129F651D7B2F91009AC164 /* SpotsProtocol+Mutation.swift in Sources */,
+				BDEFF53E1DD0F18B00FC0537 /* DataSource.swift in Sources */,
 				BD129F771D7B2F91009AC164 /* Spotable.swift in Sources */,
 				BD129DC81D7B2B6C009AC164 /* ListSpot.swift in Sources */,
 				BD129F711D7B2F91009AC164 /* Gridable.swift in Sources */,
@@ -1175,6 +1197,8 @@
 				BD129D951D7B295F009AC164 /* UITableView+Indexes.swift in Sources */,
 				BD129F511D7B2F91009AC164 /* Animation.swift in Sources */,
 				BD129F4B1D7B2F91009AC164 /* SpotFactory.swift in Sources */,
+				BDEFF5481DD0F8C000FC0537 /* Delegate+iOS+Extensions.swift in Sources */,
+				BDEFF5401DD0F3CC00FC0537 /* DataSource+iOS+Extensions.swift in Sources */,
 				BD129D8F1D7B295F009AC164 /* Composable+Extensions.swift in Sources */,
 				BD129F691D7B2F91009AC164 /* Item+Extensions.swift in Sources */,
 				BD1BFB561DA7A9A300BB55E1 /* ScrollDelegate+Extensions.swift in Sources */,
@@ -1208,9 +1232,11 @@
 				BD129DB71D7B2B6C009AC164 /* CarouselSpotCell.swift in Sources */,
 				BD129F871D7B2F91009AC164 /* Component.swift in Sources */,
 				BD129DBD1D7B2B6C009AC164 /* GridableLayout.swift in Sources */,
+				BDEFF5441DD0F7FB00FC0537 /* Delegate.swift in Sources */,
 				BD129DBF1D7B2B6C009AC164 /* GridComposite.swift in Sources */,
 				BD129D971D7B295F009AC164 /* Composable.swift in Sources */,
 				BD129F8D1D7B2F91009AC164 /* Parser.swift in Sources */,
+				BDEFF53C1DD0F18B00FC0537 /* DataSource.swift in Sources */,
 				BD129F751D7B2F91009AC164 /* Spotable.swift in Sources */,
 				BD129F901D7B2F91009AC164 /* StateCache.swift in Sources */,
 				BD129D8B1D7B295F009AC164 /* Listable+Extensions+iOS.swift in Sources */,
@@ -1259,10 +1285,12 @@
 				BD129F761D7B2F91009AC164 /* Spotable.swift in Sources */,
 				BD1BFB571DA7A9A300BB55E1 /* ScrollDelegate+Extensions.swift in Sources */,
 				BD129F7F1D7B2F91009AC164 /* SpotsDelegates.swift in Sources */,
+				BDEFF53D1DD0F18B00FC0537 /* DataSource.swift in Sources */,
 				BD129E291D7B2CDE009AC164 /* SpotsContentView.swift in Sources */,
 				BD129F7C1D7B2F91009AC164 /* SpotConfigurable.swift in Sources */,
 				BD129E361D7B2CDE009AC164 /* Viewable+Mac.swift in Sources */,
 				BD129F5B1D7B2F91009AC164 /* Spotable+Extensions.swift in Sources */,
+				BDEFF5451DD0F7FB00FC0537 /* Delegate.swift in Sources */,
 				BDCFCD471DCA82EC0047E84C /* Listable+Extension.swift in Sources */,
 				BD129F671D7B2F91009AC164 /* Viewable+Extensions.swift in Sources */,
 				BD129F611D7B2F91009AC164 /* SpotsProtocol+LiveEditing.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		BDEFF54D1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */; };
 		BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
 		BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
+		BDEFF5521DD1DA8000FC0537 /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */; };
+		BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */; };
 		D2FEDC1F1D9E845A004D5ABF /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */; };
 		D58478141C43FEB9006EBA49 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D58478531C43FFEB006EBA49 /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
@@ -360,6 +362,7 @@
 		BDEFF54A1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+Mac+Extensions.swift"; sourceTree = "<group>"; };
 		BDEFF54C1DD1A65800FC0537 /* Delegate+Mac+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+Mac+Extensions.swift"; sourceTree = "<group>"; };
 		BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDataSource.swift; sourceTree = "<group>"; };
+		BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDelegate.swift; sourceTree = "<group>"; };
 		D2FEDC1E1D9E845A004D5ABF /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58478131C43FEB9006EBA49 /* Spots-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -735,6 +738,7 @@
 				BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */,
 				BD4295571D81D45D00E07E1C /* TestViewSpot.swift */,
 				BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */,
+				BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1178,6 +1182,7 @@
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
+				BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
 				BD677E871DC616B2006D1654 /* TestSpotable.swift in Sources */,
 				BDDF2CCD1DC7C23500B766BA /* TestAnimations.swift in Sources */,
 				BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */,
@@ -1279,6 +1284,7 @@
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BDA8DAF51DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BDD9ABCB1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
+				BDEFF5521DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -31,30 +31,38 @@ extension Controller {
 }
 
 #if !os(OSX)
-class CustomListCell: UITableViewCell, SpotConfigurable {
+  class CustomListCell: UITableViewCell, SpotConfigurable {
 
-  var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
+    var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
 
-  func configure(_ item: inout Item) {
-    textLabel?.text = item.text
+    func configure(_ item: inout Item) {
+      textLabel?.text = item.text
+    }
   }
-}
 
-class CustomGridCell: UICollectionViewCell, SpotConfigurable {
+  class CustomListHeaderView: UITableViewHeaderFooterView, Componentable {
+    var preferredHeaderHeight: CGFloat = 88
 
-  var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
-
-  func configure(_ item: inout Item) {}
-}
-
-class CustomGridHeaderView: UICollectionReusableView, Componentable {
-
-  var preferredHeaderHeight: CGFloat = 88
-
-  lazy var textLabel = UILabel()
-
-  func configure(_ component: Component) {
-    textLabel.text = component.title
+    func configure(_ component: Component) {
+      textLabel?.text = component.title
+    }
   }
-}
+
+  class CustomGridCell: UICollectionViewCell, SpotConfigurable {
+
+    var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
+
+    func configure(_ item: inout Item) {}
+  }
+
+  class CustomGridHeaderView: UICollectionReusableView, Componentable {
+
+    var preferredHeaderHeight: CGFloat = 88
+
+    lazy var textLabel = UILabel()
+
+    func configure(_ component: Component) {
+      textLabel.text = component.title
+    }
+  }
 #endif

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -30,6 +30,7 @@ extension Controller {
   }
 }
 
+#if !os(OSX)
 class CustomListCell: UITableViewCell, SpotConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
@@ -43,7 +44,17 @@ class CustomGridCell: UICollectionViewCell, SpotConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
 
-  func configure(_ item: inout Item) {
-    
+  func configure(_ item: inout Item) {}
+}
+
+class CustomGridHeaderView: UICollectionReusableView, Componentable {
+
+  var preferredHeaderHeight: CGFloat = 88
+
+  lazy var textLabel = UILabel()
+
+  func configure(_ component: Component) {
+    textLabel.text = component.title
   }
 }
+#endif

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,4 +1,4 @@
-import Spots
+@testable import Spots
 import Brick
 #if os(OSX)
 import Foundation
@@ -27,6 +27,14 @@ extension Controller {
     scrollView.setContentOffset(point, animated: false)
     scrollView.layoutSubviews()
     #endif
+  }
+}
+
+struct Helper {
+  static func clearCache(for stateCache: StateCache?) {
+    if FileManager().fileExists(atPath: stateCache!.path) {
+      try! FileManager().removeItem(atPath: stateCache!.path)
+    }
   }
 }
 

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,4 +1,5 @@
 import Spots
+import Brick
 #if os(OSX)
 import Foundation
 #else
@@ -26,5 +27,23 @@ extension Controller {
     scrollView.setContentOffset(point, animated: false)
     scrollView.layoutSubviews()
     #endif
+  }
+}
+
+class CustomListCell: UITableViewCell, SpotConfigurable {
+
+  var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
+
+  func configure(_ item: inout Item) {
+    textLabel?.text = item.text
+  }
+}
+
+class CustomGridCell: UICollectionViewCell, SpotConfigurable {
+
+  var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
+
+  func configure(_ item: inout Item) {
+    
   }
 }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -1,3 +1,4 @@
+/*
 @testable import Spots
 import Foundation
 import XCTest
@@ -42,3 +43,4 @@ class SpotableTests : XCTestCase {
     XCTAssertEqual(controller.spots[0].items.count, 500)
   }
 }
+*/

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -47,4 +47,10 @@ class StateCacheTests : XCTestCase {
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
+
+  func testCacheWithEmptyKey() {
+    /// Expect to generate a MD5 hash from an empty key
+    let stateCache = StateCache(key: "")
+    XCTAssertNotEqual(stateCache.fileName(), "")
+  }
 }

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -11,11 +11,11 @@ class CarouselSpotTests: XCTestCase {
   override func setUp() {
     spot = CarouselSpot(component: Component())
     cachedSpot = CarouselSpot(cacheKey: "cached-carousel-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -244,8 +244,6 @@ class CarouselSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)
@@ -254,8 +252,9 @@ class CarouselSpotTests: XCTestCase {
     }
 
     var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
-    Dispatch.delay(for: 0.25) {
-      let cachedSpot = CarouselSpot(cacheKey: self.cachedSpot.stateCache!.key)
+    Dispatch.delay(for: 0.25) { [weak self] in
+      guard let weakSelf = self else { return }
+      let cachedSpot = CarouselSpot(cacheKey: weakSelf.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
       exception?.fulfill()

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -56,4 +56,37 @@ class DataSourceTests: XCTestCase {
     let spotConfigurable = itemCell1 as! CustomGridCell
     XCTAssertEqual(spot.component.items[0].size.height, spotConfigurable.preferredViewSize.height)
   }
+
+  func testDataSourceForGridableDefaultHeader() {
+    GridSpot.register(defaultHeader: CustomGridHeaderView.self)
+    let spot = GridSpot(component: Component(
+      header: "",
+      items: [
+        Item(title: "title 1"),
+        Item(title: "title 2")
+      ]))
+    spot.render().frame.size = CGSize(width: 100, height: 100)
+    spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
+    spot.render().layoutSubviews()
+
+    let header = spot.spotDataSource.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    XCTAssertNotNil(header)
+    XCTAssert(header is CustomGridHeaderView)
+  }
+
+  func testDataSourceForGridableCustomHeader() {
+    GridSpot.register(header: CustomGridHeaderView.self, identifier: "custom-header")
+    let spot = GridSpot(component: Component(
+      header: "custom-header",
+      items: [
+        Item(title: "title 1"),
+        Item(title: "title 2")
+      ]))
+    spot.render().frame.size = CGSize(width: 100, height: 100)
+    spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
+    spot.render().layoutSubviews()
+
+    let header = spot.spotDataSource.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    XCTAssertNotNil(header)
+  }
 }

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -1,0 +1,59 @@
+@testable import Spots
+import Brick
+import Foundation
+import XCTest
+
+class DataSourceTests: XCTestCase {
+
+  func testDataSourceForListableObject() {
+    ListSpot.register(view: CustomListCell.self, identifier: "custom")
+    let spot = ListSpot(component: Component(items: [
+      Item(title: "title 1"),
+      Item(title: "title 2")
+      ]))
+
+    var itemCell1 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    let itemCell2 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 1, section: 0))
+
+    XCTAssertNotNil(itemCell1)
+    XCTAssertNotNil(itemCell2)
+    XCTAssertEqual(itemCell1.textLabel?.text, spot.component.items[0].title)
+    XCTAssertEqual(itemCell2.textLabel?.text, spot.component.items[1].title)
+
+    /// Check that data source always returns a cell
+    let itemCell3 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
+    XCTAssertNotNil(itemCell3)
+
+    /// Check that preferred view size is applied if height is 0.0
+    spot.component.items[0].kind = "custom"
+    spot.component.items[0].size.height = 0.0
+    itemCell1 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    let spotConfigurable = itemCell1 as! CustomListCell
+    XCTAssertEqual(spot.component.items[0].size.height, spotConfigurable.preferredViewSize.height)
+  }
+
+  func testDataSourceForGridableObject() {
+    GridSpot.register(view: CustomGridCell.self, identifier: "custom")
+    let spot = GridSpot(component: Component(items: [
+      Item(title: "title 1"),
+      Item(title: "title 2")
+      ]))
+
+    var itemCell1 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    let itemCell2 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
+
+    XCTAssertNotNil(itemCell1)
+    XCTAssertNotNil(itemCell2)
+
+    /// Check that data source always returns a cell
+    let itemCell3 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 2, section: 0))
+    XCTAssertNotNil(itemCell3)
+
+    /// Check that preferred view size is applied if height is 0.0
+    spot.component.items[0].kind = "custom"
+    spot.component.items[0].size.height = 0.0
+    itemCell1 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    let spotConfigurable = itemCell1 as! CustomGridCell
+    XCTAssertEqual(spot.component.items[0].size.height, spotConfigurable.preferredViewSize.height)
+  }
+}

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -12,8 +12,8 @@ class DataSourceTests: XCTestCase {
       Item(title: "title 2")
       ]))
 
-    var itemCell1 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
-    let itemCell2 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 1, section: 0))
+    var itemCell1 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    let itemCell2 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 1, section: 0))
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
@@ -21,13 +21,13 @@ class DataSourceTests: XCTestCase {
     XCTAssertEqual(itemCell2.textLabel?.text, spot.component.items[1].title)
 
     /// Check that data source always returns a cell
-    let itemCell3 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
+    let itemCell3 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
     spot.component.items[0].kind = "custom"
     spot.component.items[0].size.height = 0.0
-    itemCell1 = spot.spotDataSource.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    itemCell1 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
     let spotConfigurable = itemCell1 as! CustomListCell
     XCTAssertEqual(spot.component.items[0].size.height, spotConfigurable.preferredViewSize.height)
   }
@@ -39,20 +39,20 @@ class DataSourceTests: XCTestCase {
       Item(title: "title 2")
       ]))
 
-    var itemCell1 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
-    let itemCell2 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
+    var itemCell1 = spot.spotDataSource!.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    let itemCell2 = spot.spotDataSource!.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
 
     /// Check that data source always returns a cell
-    let itemCell3 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 2, section: 0))
+    let itemCell3 = spot.spotDataSource!.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 2, section: 0))
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
     spot.component.items[0].kind = "custom"
     spot.component.items[0].size.height = 0.0
-    itemCell1 = spot.spotDataSource.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    itemCell1 = spot.spotDataSource!.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
     let spotConfigurable = itemCell1 as! CustomGridCell
     XCTAssertEqual(spot.component.items[0].size.height, spotConfigurable.preferredViewSize.height)
   }
@@ -69,7 +69,7 @@ class DataSourceTests: XCTestCase {
     spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
     spot.render().layoutSubviews()
 
-    let header = spot.spotDataSource.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    let header = spot.spotDataSource!.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)
     XCTAssert(header is CustomGridHeaderView)
   }
@@ -86,7 +86,7 @@ class DataSourceTests: XCTestCase {
     spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
     spot.render().layoutSubviews()
 
-    let header = spot.spotDataSource.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    let header = spot.spotDataSource!.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)
   }
 }

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -49,4 +49,10 @@ class DelegateTests: XCTestCase {
     XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
     XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
   }
+
+  func testHeightForRowOnListable() {
+    let spot = ListSpot(component: Component(items: [Item(title: "title 1")]))
+    XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+    XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
+  }
 }

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -14,6 +14,8 @@ class TestDelegate: SpotsDelegate {
 
 class DelegateTests: XCTestCase {
 
+  // MARK: - UICollectionView
+
   func testCollectionViewDelegateSelection() {
     let delegate = TestDelegate()
     let spot = GridSpot(component: Component(items: [
@@ -28,6 +30,14 @@ class DelegateTests: XCTestCase {
     spot.spotDelegate.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
+
+  func testCollectionViewCanFocus() {
+    let spot = GridSpot(component: Component(items: [Item(title: "title 1")]))
+    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
+    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
+  }
+
+  // MARK: - UITableView
 
   func testTableViewDelegateSelection() {
     let delegate = TestDelegate()
@@ -44,15 +54,44 @@ class DelegateTests: XCTestCase {
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
-  func testCollectionViewCanFocus() {
-    let spot = GridSpot(component: Component(items: [Item(title: "title 1")]))
-    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
-    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
-  }
-
-  func testHeightForRowOnListable() {
+  func testTableViewHeightForRowOnListable() {
     let spot = ListSpot(component: Component(items: [Item(title: "title 1")]))
     XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
     XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
+  }
+
+  func testDelegateTitleForHeader() {
+    ListSpot.register(header: CustomListHeaderView.self, identifier: "list")
+    let spot = ListSpot(component: Component(
+      title: "title",
+      header: "list",
+      items: [
+        Item(title: "title 1"),
+        Item(title: "title 2")
+      ]))
+    spot.render().frame.size = CGSize(width: 100, height: 100)
+    spot.render().layoutSubviews()
+
+    var view = spot.spotDelegate.tableView(spot.tableView, viewForHeaderInSection: 0)
+    XCTAssert(view is CustomListHeaderView)
+
+    /// Expect to return nil if header is in use.
+    var title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    XCTAssertEqual(title, nil)
+
+    /// Expect to return title if header is empty.
+    spot.component.header = ""
+    title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    XCTAssertEqual(title, spot.component.title)
+
+    /// Expect to return nil if title and header is empty.
+    spot.component.title = ""
+    title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    XCTAssertEqual(title, nil)
+
+    view = spot.spotDelegate.tableView(spot.tableView, viewForHeaderInSection: 0)
+    XCTAssertEqual(view, nil)
+
+
   }
 }

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -1,0 +1,52 @@
+@testable import Spots
+import Brick
+import Foundation
+import XCTest
+
+class TestDelegate: SpotsDelegate {
+  var countsInvoked = 0
+
+  func didSelect(item: Item, in spot: Spotable) {
+    spot.component.items[item.index].meta["selected"] = true
+    countsInvoked += 1
+  }
+}
+
+class DelegateTests: XCTestCase {
+
+  func testCollectionViewDelegateSelection() {
+    let delegate = TestDelegate()
+    let spot = GridSpot(component: Component(items: [
+      Item(title: "title 1")
+      ]))
+    spot.delegate = delegate
+    spot.spotDelegate.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+    
+    XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
+    XCTAssertEqual(delegate.countsInvoked, 1)
+
+    spot.spotDelegate.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
+    XCTAssertEqual(delegate.countsInvoked, 1)
+  }
+
+  func testTableViewDelegateSelection() {
+    let delegate = TestDelegate()
+    let spot = ListSpot(component: Component(items: [
+      Item(title: "title 1")
+      ]))
+    spot.delegate = delegate
+    spot.spotDelegate.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
+
+    XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
+    XCTAssertEqual(delegate.countsInvoked, 1)
+
+    spot.spotDelegate.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
+    XCTAssertEqual(delegate.countsInvoked, 1)
+  }
+
+  func testCollectionViewCanFocus() {
+    let spot = GridSpot(component: Component(items: [Item(title: "title 1")]))
+    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
+    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
+  }
+}

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -22,19 +22,19 @@ class DelegateTests: XCTestCase {
       Item(title: "title 1")
       ]))
     spot.delegate = delegate
-    spot.spotDelegate.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+    spot.spotDelegate?.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
     
     XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
-    spot.spotDelegate.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
+    spot.spotDelegate?.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
   func testCollectionViewCanFocus() {
     let spot = GridSpot(component: Component(items: [Item(title: "title 1")]))
-    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
-    XCTAssertEqual(spot.spotDelegate.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
+    XCTAssertEqual(spot.spotDelegate?.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
+    XCTAssertEqual(spot.spotDelegate?.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
   }
 
   // MARK: - UITableView
@@ -45,19 +45,19 @@ class DelegateTests: XCTestCase {
       Item(title: "title 1")
       ]))
     spot.delegate = delegate
-    spot.spotDelegate.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
+    spot.spotDelegate?.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
 
     XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
-    spot.spotDelegate.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
+    spot.spotDelegate?.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
   func testTableViewHeightForRowOnListable() {
     let spot = ListSpot(component: Component(items: [Item(title: "title 1")]))
-    XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
-    XCTAssertEqual(spot.spotDelegate.tableView(spot.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
+    XCTAssertEqual(spot.spotDelegate?.tableView(spot.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+    XCTAssertEqual(spot.spotDelegate?.tableView(spot.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
   }
 
   func testDelegateTitleForHeader() {
@@ -72,24 +72,24 @@ class DelegateTests: XCTestCase {
     spot.render().frame.size = CGSize(width: 100, height: 100)
     spot.render().layoutSubviews()
 
-    var view = spot.spotDelegate.tableView(spot.tableView, viewForHeaderInSection: 0)
+    var view = spot.spotDelegate?.tableView(spot.tableView, viewForHeaderInSection: 0)
     XCTAssert(view is CustomListHeaderView)
 
     /// Expect to return nil if header is in use.
-    var title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    var title = spot.spotDelegate?.tableView(spot.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, nil)
 
     /// Expect to return title if header is empty.
     spot.component.header = ""
-    title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    title = spot.spotDelegate?.tableView(spot.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, spot.component.title)
 
     /// Expect to return nil if title and header is empty.
     spot.component.title = ""
-    title = spot.spotDelegate.tableView(spot.tableView, titleForHeaderInSection: 0)
+    title = spot.spotDelegate?.tableView(spot.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, nil)
 
-    view = spot.spotDelegate.tableView(spot.tableView, viewForHeaderInSection: 0)
+    view = spot.spotDelegate?.tableView(spot.tableView, viewForHeaderInSection: 0)
     XCTAssertEqual(view, nil)
 
 

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -11,11 +11,11 @@ class GridSpotTests: XCTestCase {
   override func setUp() {
     spot = GridSpot(component: Component())
     cachedSpot = GridSpot(cacheKey: "cached-grid-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -130,13 +130,11 @@ class GridSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)
-    cachedSpot.append(item) {
-      self.cachedSpot.cache()
+    cachedSpot.append(item) { [weak self] in
+      self?.cachedSpot.cache()
     }
 
     var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -11,11 +11,11 @@ class RowSpotTests: XCTestCase {
   override func setUp() {
     spot = RowSpot(component: Component())
     cachedSpot = RowSpot(cacheKey: "cached-row-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -130,8 +130,6 @@ class RowSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)


### PR DESCRIPTION
This PR is taking another stab at abstracting data source and delegate related methods into their own classes, similar to what the adapters did previously. The public API remains unchanged, this is just an internal refactoring.

The class `DataSource` is now in charge of all data for all `Spotable` objects as it implements both `UITableViewDataSource` and `UICollectionViewDataSource`.
It gets all it's superpowers from extensions that are platform specific.

`Delegate` is the equivalent as `DataSource` but for delegate methods, same applies here, it gets its functionality from extensions.