### PR TITLE
Refactor Delegate and DataSource to use an optional instead of an unwrapped spot

### DIFF
--- a/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
@@ -7,10 +7,18 @@ extension DataSource: NSCollectionViewDataSource {
   }
 
   public func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 
   public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
+    guard let spot = spot else {
+      return NSCollectionViewItem()
+    }
+
     let reuseIdentifier: String
 
     if let gridable = spot as? Gridable {
@@ -29,6 +37,10 @@ extension DataSource: NSCollectionViewDataSource {
 extension DataSource: NSTableViewDataSource {
 
   public func numberOfRows(in tableView: NSTableView) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -10,8 +10,9 @@ extension Delegate: NSCollectionViewDelegate {
      */
     Dispatch.delay(for: 0.1) { [weak self] in
       guard let weakSelf = self, let first = indexPaths.first,
-        let item = self?.spot.item(at: first.item), first.item < weakSelf.spot.items.count else { return }
-      weakSelf.spot.delegate?.didSelect(item: item, in: weakSelf.spot)
+        let spot = weakSelf.spot,
+        let item = spot.item(at: first.item), first.item < spot.items.count else { return }
+      spot.delegate?.didSelect(item: item, in: spot)
     }
   }
 }
@@ -19,6 +20,9 @@ extension Delegate: NSCollectionViewDelegate {
 extension Delegate: NSCollectionViewDelegateFlowLayout {
 
   public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
+    guard let spot = spot else {
+      return CGSize.zero
+    }
     return spot.sizeForItem(at: indexPath)
   }
 }
@@ -26,7 +30,9 @@ extension Delegate: NSCollectionViewDelegateFlowLayout {
 extension Delegate: NSTableViewDelegate {
 
   public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-    guard let item = spot.item(at: row), row > -1 && row < spot.component.items.count
+    guard let spot = spot,
+      let item = spot.item(at: row),
+      row > -1 && row < spot.component.items.count
       else {
         return false
     }
@@ -39,6 +45,10 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+    guard let spot = spot else {
+      return 1.0
+    }
+
     spot.component.size = CGSize(
       width: tableView.frame.width,
       height: tableView.frame.height)
@@ -53,7 +63,9 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    guard row >= 0 && row < spot.component.items.count else { return nil }
+    guard let spot = spot, row >= 0 && row < spot.component.items.count else {
+        return nil
+    }
 
     let reuseIdentifier = spot.identifier(at: row)
     guard let cachedView = spot.type.views.make(reuseIdentifier) else { return nil }

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public class DataSource: NSObject {
-  weak var spot: Spotable!
+  weak var spot: Spotable?
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public class Delegate: NSObject {
-  weak var spot: Spotable!
+  weak var spot: Spotable?
 }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -27,10 +27,10 @@ open class GridableLayout: UICollectionViewFlowLayout {
      let spot = delegate.spot as? Gridable else { return }
 
     if scrollDirection == .horizontal {
-      guard let firstItem = delegate.spot.items.first else { return }
+      guard let firstItem = spot.items.first else { return }
 
-      contentSize.width = delegate.spot.items.reduce(0, { $0 + $1.size.width })
-      contentSize.width += CGFloat(delegate.spot.items.count) * (minimumInteritemSpacing)
+      contentSize.width = spot.items.reduce(0, { $0 + $1.size.width })
+      contentSize.width += CGFloat(spot.items.count) * (minimumInteritemSpacing)
       contentSize.width += sectionInset.left + (sectionInset.right / 2) - 3
       contentSize.width = ceil(contentSize.width)
 
@@ -64,8 +64,11 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// - returns: An array of layout attribute objects containing the layout information for the enclosed items and views. The default implementation of this method returns nil.
   open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
     guard let collectionView = collectionView,
-      let dataSource = collectionView.dataSource as? DataSource
-      else { return nil }
+      let dataSource = collectionView.dataSource as? DataSource,
+      let spot = dataSource.spot
+      else {
+        return nil
+    }
 
     var attributes = [UICollectionViewLayoutAttributes]()
     var rect = CGRect(origin: CGPoint.zero, size: contentSize)
@@ -88,7 +91,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
           itemAttribute.frame.origin.x = collectionView.contentOffset.x
           attributes.append(itemAttribute)
         } else {
-          itemAttribute.size = dataSource.spot.sizeForItem(at: itemAttribute.indexPath)
+          itemAttribute.size = spot.sizeForItem(at: itemAttribute.indexPath)
 
           if scrollDirection == .horizontal {
             itemAttribute.frame.origin.y = headerReferenceSize.height

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -10,6 +10,10 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let spot = spot else {
+      return 0
+    }
+
     return spot.component.items.count
   }
 
@@ -22,6 +26,10 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: A configured supplementary view object.
   public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    guard let spot = spot else {
+      return UICollectionReusableView()
+    }
+
     let identifier: String
 
     if spot.component.header.isEmpty {
@@ -45,7 +53,9 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard indexPath.item < spot.component.items.count else { return UICollectionViewCell() }
+    guard let spot = spot, indexPath.item < spot.component.items.count else {
+        return UICollectionViewCell()
+    }
     spot.component.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.identifier(at: indexPath)
@@ -74,6 +84,8 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    guard let spot = spot else { return 0 }
+
     return spot.component.items.count
   }
 
@@ -84,7 +96,9 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard indexPath.item < spot.component.items.count else { return UITableViewCell() }
+    guard let spot = spot, indexPath.item < spot.component.items.count else {
+      return UITableViewCell()
+    }
 
     if indexPath.item < spot.component.items.count {
       spot.component.items[indexPath.item].index = indexPath.row

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -10,6 +10,8 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
   @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    guard let spot = spot else { return CGSize.zero }
+
     return spot.sizeForItem(at: indexPath)
   }
 
@@ -18,7 +20,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter collectionView: The collection view object that is notifying you of the selection change.
   /// - parameter indexPath: The index path of the cell that was selected.
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    guard let item = spot.item(at: indexPath) else { return }
+    guard let spot = spot, let item = spot.item(at: indexPath) else { return }
     spot.delegate?.didSelect(item: item, in: spot)
   }
 
@@ -29,7 +31,7 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: YES if the item can receive be focused or NO if it can not.
   public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    guard let _ = spot.item(at: indexPath) else { return  false }
+    guard let spot = spot, let _ = spot.item(at: indexPath) else { return  false }
     return true
   }
 
@@ -56,6 +58,10 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
   public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    guard let spot = spot else {
+      return 0.0
+    }
+
     let header = spot.type.headers.make(spot.component.header)
     return (header?.view as? Componentable)?.preferredHeaderHeight ?? 0.0
   }
@@ -67,7 +73,7 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
   @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    if let _ = spot.type.headers.make(spot.component.header) {
+    guard let spot = spot, let _ = spot.type.headers.make(spot.component.header) else {
       return nil
     }
     return !spot.component.title.isEmpty ? spot.component.title : nil
@@ -79,7 +85,7 @@ extension Delegate: UITableViewDelegate {
   /// - parameter indexPath: An index path locating the new selected row in tableView.
   public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     tableView.deselectRow(at: indexPath, animated: true)
-    if let item = spot.item(at: indexPath) {
+    if let spot = spot, let item = spot.item(at: indexPath) {
       spot.delegate?.didSelect(item: item, in: spot)
     }
   }
@@ -91,7 +97,7 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
   public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard !spot.component.header.isEmpty else { return nil }
+    guard let spot = spot, !spot.component.header.isEmpty else { return nil }
 
     let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.header)
     view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
@@ -108,6 +114,10 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns:  A nonnegative floating-point value that specifies the height (in points) that row should be based on the view model height, defaults to 0.0.
   public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    guard let spot = spot else {
+      return 0.0
+    }
+
     spot.component.size = CGSize(
       width: tableView.frame.size.width,
       height: tableView.frame.size.height)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -73,9 +73,14 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on Component
   @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    guard let spot = spot, let _ = spot.type.headers.make(spot.component.header) else {
+    guard let spot = spot else {
       return nil
     }
+
+    if let _ = spot.type.headers.make(spot.component.header) {
+      return nil
+    }
+
     return !spot.component.title.isEmpty ? spot.component.title : nil
   }
 

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,4 +1,4 @@
-import Spots
+@testable import Spots
 import Brick
 #if os(OSX)
 import Foundation
@@ -27,6 +27,14 @@ extension Controller {
     scrollView.setContentOffset(point, animated: false)
     scrollView.layoutSubviews()
     #endif
+  }
+}
+
+struct Helper {
+  static func clearCache(for stateCache: StateCache?) {
+    if FileManager().fileExists(atPath: stateCache!.path) {
+      try! FileManager().removeItem(atPath: stateCache!.path)
+    }
   }
 }
 

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -11,11 +11,11 @@ class CarouselSpotTests: XCTestCase {
   override func setUp() {
     spot = CarouselSpot(component: Component())
     cachedSpot = CarouselSpot(cacheKey: "cached-carousel-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -244,8 +244,6 @@ class CarouselSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)
@@ -254,8 +252,9 @@ class CarouselSpotTests: XCTestCase {
     }
 
     var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
-    Dispatch.delay(for: 0.25) {
-      let cachedSpot = CarouselSpot(cacheKey: self.cachedSpot.stateCache!.key)
+    Dispatch.delay(for: 0.25) { [weak self] in
+      guard let weakSelf = self else { return }
+      let cachedSpot = CarouselSpot(cacheKey: weakSelf.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
       exception?.fulfill()

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -11,11 +11,11 @@ class GridSpotTests: XCTestCase {
   override func setUp() {
     spot = GridSpot(component: Component())
     cachedSpot = GridSpot(cacheKey: "cached-grid-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -130,13 +130,11 @@ class GridSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)
-    cachedSpot.append(item) {
-      self.cachedSpot.cache()
+    cachedSpot.append(item) { [weak self] in
+      self?.cachedSpot.cache()
     }
 
     var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -11,11 +11,11 @@ class RowSpotTests: XCTestCase {
   override func setUp() {
     spot = RowSpot(component: Component())
     cachedSpot = RowSpot(cacheKey: "cached-row-spot")
+    Helper.clearCache(for: cachedSpot.stateCache)
   }
 
   override func tearDown() {
     spot = nil
-    cachedSpot.stateCache?.clear()
     cachedSpot = nil
   }
 
@@ -130,8 +130,6 @@ class RowSpotTests: XCTestCase {
   }
 
   func testSpotCache() {
-    cachedSpot.stateCache?.clear()
-
     let item = Item(title: "test")
 
     XCTAssertEqual(cachedSpot.component.items.count, 0)


### PR DESCRIPTION
This PR refactors the ongoing PR to abstract the delegate and the data source.

Instead of:
```swift
weak var spot: Spotable!
```

We declare it as:
```swift
weak var spot: Spotable?
```