### PR TITLE
Improve/reload with components

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -213,7 +213,10 @@ public extension Spotable {
   /// - parameter animation:  A Animation that is used when performing the mutation (currently not in use).
   /// - parameter completion: A completion closure that is executed in the main queue when the view model has been removed.
   func update(_ item: Item, index: Int, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    guard let oldItem = self.item(at: index) else { completion?(); return }
+    guard let oldItem = self.item(at: index) else {
+      completion?()
+      return
+    }
 
     items[index] = item
     configureItem(at: index)
@@ -348,7 +351,10 @@ public extension Spotable {
   public func reloadIfNeeded(_ json: [String : Any], withAnimation animation: Animation = .automatic) {
     let newComponent = Component(json)
 
-    guard component != newComponent else { cache(); return }
+    guard component != newComponent else {
+      cache()
+      return
+    }
 
     component = newComponent
     reload(nil, withAnimation: animation) { [weak self] in

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -322,7 +322,7 @@ extension SpotsProtocol {
                                                   newComponents: newComponents,
                                                   withAnimation: animation,
                                                   closure: closure)
-        case .none: break
+        case .none: continue
         }
       }
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -44,7 +44,11 @@ extension SpotsProtocol {
     }
 
     Dispatch.inQueue(queue: .interactive) { [weak self] in
-      guard let weakSelf = self else { closure?(); return }
+      guard let weakSelf = self else {
+        closure?()
+        return
+      }
+
       let oldComponents = weakSelf.spots.map { $0.component }
       let newComponents = components
 
@@ -147,7 +151,10 @@ extension SpotsProtocol {
   ///
   /// - returns: A boolean value that determines if the closure should run in `process(changes:)`
   fileprivate func setupItemsForSpot(at index: Int, newComponents: [Component], withAnimation animation: Animation = .automatic, closure: Completion = nil) -> Bool {
-    guard let spot = self.spot(at: index, ofType: Spotable.self) else { return false }
+    guard let spot = self.spot(at: index, ofType: Spotable.self) else {
+      return false
+    }
+
     let newItems = spot.prepare(items: newComponents[index].items)
     let oldItems = spot.items
 

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -24,9 +24,17 @@ public struct Parser {
   ///
   /// - returns: A collection of `Component`s
   public static func parse(_ json: [String : Any], key: String = "components") -> [Component] {
-    guard let components = json[key] as? [[String : Any]] else { return [] }
+    guard let payloads = json[key] as? [[String : Any]] else { return [] }
 
-    return components.map { Component($0) }
+    var components = [Component]()
+
+    for (index, payload) in payloads.enumerated() {
+      var component = Component(payload)
+      component.index = index
+      components.append(component)
+    }
+
+    return components
   }
 
   /// Parse JSON into a collection of Spotable objects.


### PR DESCRIPTION
This PR aims to improve how debug friendly the source code is.

It also fixes a bug in `reloadWithComponents`.
The bug was that we had a `break` in the `forEach` statement instead of a `continue`. So if the first component was unchanged, if would skip all other changes done to the component collection.

It also improve parsing by specifically setting the index base on the payload that the parser receives.