### PR TITLE
Feature spotsDidReloadComponents closure

### DIFF
--- a/Sources/Mac/Classes/Controller.swift
+++ b/Sources/Mac/Classes/Controller.swift
@@ -6,6 +6,9 @@ public enum ControllerBackground {
 
 open class Controller: NSViewController, SpotsProtocol {
 
+  /// A closure that is called when the controller is reloaded with components
+  public static var spotsDidReloadComponents: ((Controller) -> Void)?
+
   open static var configure: ((_ container: SpotsScrollView) -> Void)?
   let KVOWindowContext: UnsafeMutableRawPointer? = UnsafeMutableRawPointer(mutating: nil)
 

--- a/Sources/Mac/Extensions/NSTableView+Indexes.swift
+++ b/Sources/Mac/Extensions/NSTableView+Indexes.swift
@@ -54,7 +54,9 @@ extension NSTableView: UserInterface {
 
     for index in reloadSets {
       guard let view = rowView(atRow: index, makeIfNecessary: false) as? SpotConfigurable,
-        let adapter = dataSource as? Listable else { continue }
+        let adapter = dataSource as? Listable else {
+          continue
+      }
 
       var item = adapter.component.items[index]
       view.configure(&item)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -61,6 +61,9 @@ extension SpotsProtocol {
 
       weakSelf.process(changes: changes, components: newComponents, withAnimation: animation) {
         closure?()
+        if let controller = self as? Controller {
+          Controller.spotsDidReloadComponents?(controller)
+        }
       }
     }
   }
@@ -399,6 +402,10 @@ extension SpotsProtocol {
       offsets.enumerated().forEach {
         newSpots[$0.offset].render().contentOffset = $0.element
       }
+
+      if let controller = self as? Controller {
+        Controller.spotsDidReloadComponents?(controller)
+      }
     }
   }
 
@@ -426,6 +433,9 @@ extension SpotsProtocol {
 
       completion?()
       weakSelf.scrollView.layoutSubviews()
+      if let controller = weakSelf as? Controller {
+        Controller.spotsDidReloadComponents?(controller)
+      }
     }
   }
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -409,7 +409,10 @@ extension SpotsProtocol {
    */
   public func reload(_ json: [String : Any], animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
     Dispatch.mainQueue { [weak self] in
-      guard let weakSelf = self else { completion?(); return }
+      guard let weakSelf = self else {
+        completion?()
+        return
+      }
 
       weakSelf.spots = Parser.parse(json)
       weakSelf.cache()

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -8,6 +8,9 @@ import Brick
 import Cache
 
 public protocol SpotsProtocol: class {
+
+  /// A closure that is called when the controller is reloaded with components
+  static var spotsDidReloadComponents: ((_ controller: Controller) -> Void)? { get set }
   /// A StateCache object
   var stateCache: StateCache? { get set }
   /// The internal SpotsScrollView

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -5,6 +5,9 @@ import Cache
 /// A controller powered by Spotable objects
 open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScrollViewDelegate {
 
+  /// A closure that is called when the controller is reloaded with components
+  public static var spotsDidReloadComponents: ((Controller) -> Void)?
+
   /// A notification enum
   ///
   /// - deviceDidRotateNotification: Used when the device is rotated

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -865,4 +865,57 @@ class ControllerTests : XCTestCase {
 
     waitForExpectations(timeout: 5.0, handler: nil)
   }
+
+  func testSpotsDidReloadComponents() {
+    let initialComponents = [
+      Component(
+        kind: "list",
+        items: [
+          Item(title: "Fullname", subtitle: "Job title", kind: "image"),
+          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height" : true]),
+          Item(title: "First name", subtitle: "Input first name",kind: "info"),
+          Item(title: "Last name", subtitle: "Input last name",kind: "info"),
+          Item(title: "Twitter", subtitle: "@twitter",kind: "info"),
+          Item(title: "", subtitle: "Biography", kind: "core", meta: ["dynamic-height" : true])
+        ]
+      )
+    ]
+
+    let newComponents = [
+      Component(
+        kind: "list",
+        items: [
+          Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
+          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height" : true]),
+          Item(title: "First name", subtitle: "Input first name", text: "John", kind: "info"),
+          Item(title: "Last name", subtitle: "Input last name", text: "Hyperseed", kind: "info"),
+          Item(title: "Twitter", subtitle: "@johnhyperseed",kind: "info"),
+          Item(subtitle: "Biography", text: "John Hyperseed is a bot", kind: "core", meta: ["dynamic-height" : true])
+        ]
+      )
+    ]
+
+    var exception: XCTestExpectation? = expectation(description: "Wait for spotsDidReloadComponents to be called")
+
+    Controller.spotsDidReloadComponents = { controller in
+      XCTAssert(true)
+      exception?.fulfill()
+      exception = nil
+    }
+
+    let spots = initialComponents.map { Factory.resolve(component: $0) }
+    controller = Controller(spots: spots)
+    controller.preloadView()
+    controller.viewDidAppear()
+    controller.spots.forEach {
+      #if os(OSX)
+        $0.render().layoutSubtreeIfNeeded()
+      #endif
+      $0.render().layoutSubviews()
+    }
+    controller.reloadIfNeeded(newComponents)
+
+
+    waitForExpectations(timeout: 2.0, handler: nil)
+  }
 }


### PR DESCRIPTION
This PR adds a new static closure that can be used to invoked whenever a `Controller` is reloaded with components.

It is there for convenience if you should desire to build self refreshing components or any other type of view model -> component based logic.

The method is invoked in:
- `reloadIfNeeded` with `[Component]`.
- `reloadIfNeeded` with `JSON`
- `reload` with `JSON`
