### PR TITLE
Feature remove all on state cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_install:
 - travis_wait 35; bin/bootstrap-if-needed
 
 script:
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx -enableCodeCoverage YES
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx clean build
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx -enableCodeCoverage YES test
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ before_install:
 
 script:
 - set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES
 - set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx -enableCodeCoverage YES
 - set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_install:
 - travis_wait 35; bin/bootstrap-if-needed
 
 script:
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator | xcpretty
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx | xcpretty
-- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
-- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' | xcpretty
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx
+- set -o pipefail && xcodebuild clean build -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
+- set -o pipefail && xcodebuild test -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0'
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -188,6 +188,7 @@ public extension SpotsProtocol {
   }
 
   /// Clear the Spots cache
+  @available(*, deprecated, message: "Use StateCache.removeAll() instead.")
   public static func clearCache() {
     let path = StateCache(key: "").path
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -189,9 +189,8 @@ public extension SpotsProtocol {
 
   /// Clear the Spots cache
   public static func clearCache() {
-    let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
-                                                    FileManager.SearchPathDomainMask.userDomainMask, true)
-    let path = "\(paths.first!)/\(DiskStorage.prefix).\(StateCache.cacheName)"
+    let path = StateCache(key: "").path
+
     do {
       try FileManager.default.removeItem(atPath: path)
     } catch {

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -36,13 +36,7 @@ public struct StateCache {
   public static func removeAll() {
     let path = Cache<JSON>(name: "\(StateCache.cacheName)/\(bundleIdentifer)").path
     do {
-      let files = try FileManager.default.contentsOfDirectory(atPath: path)
-      for file in files {
-        let filePath = path + "/" + file
-        if FileManager.default.fileExists(atPath: filePath) {
-          try FileManager.default.removeItem(atPath: filePath)
-        }
-      }
+      try FileManager.default.removeItem(atPath: path)
     } catch {
       NSLog("🎍 SPOTS: Unable to remove cache.")
     }

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -32,6 +32,22 @@ public struct StateCache {
     return FileManager.default.fileExists(atPath: path)
   }
 
+  /// Remove state cache for all controllers and spotable objects.
+  public static func removeAll() {
+    let path = Cache<JSON>(name: "\(StateCache.cacheName)/\(bundleIdentifer)").path
+    do {
+      let files = try FileManager.default.contentsOfDirectory(atPath: path)
+      for file in files {
+        let filePath = path + "/" + file
+        if FileManager.default.fileExists(atPath: filePath) {
+          try FileManager.default.removeItem(atPath: filePath)
+        }
+      }
+    } catch {
+      NSLog("🎍 SPOTS: Unable to remove cache.")
+    }
+  }
+
   // MARK: - Initialization
 
   /// Initialize a StateCache with a unique cache key

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -53,4 +53,32 @@ class StateCacheTests : XCTestCase {
     let stateCache = StateCache(key: "")
     XCTAssertNotEqual(stateCache.fileName(), "")
   }
+
+  func testRemoveAll() {
+    let cacheOne = StateCache(key: "one")
+    let cacheTwo = StateCache(key: "two")
+    let path = cacheOne.path
+
+    [cacheOne, cacheTwo].forEach { $0.save(["foo" : "bar"]) }
+
+    let exception = self.expectation(description: "Wait for cache")
+    Dispatch.delay(for: 0.5) {
+      do {
+        print(path)
+        let files = try FileManager.default.contentsOfDirectory(atPath: path)
+        XCTAssertEqual(files.count, 2)
+      } catch {}
+
+
+      StateCache.removeAll()
+
+      do {
+        let files = try FileManager.default.contentsOfDirectory(atPath: path)
+        XCTAssertEqual(files.count, 0)
+      } catch {}
+
+      exception.fulfill()
+    }
+    waitForExpectations(timeout: 1.0, handler: nil)
+  }
 }

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -64,7 +64,6 @@ class StateCacheTests : XCTestCase {
     let exception = self.expectation(description: "Wait for cache")
     Dispatch.delay(for: 0.5) {
       do {
-        print(path)
         let files = try FileManager.default.contentsOfDirectory(atPath: path)
         XCTAssertEqual(files.count, 2)
       } catch {}


### PR DESCRIPTION
This PR adds a convenience on `StateCache` to clear out all `Controller` caches. This is useful if you want to clear everything out when a user logs out of your application. Or any other case where you want to clear the state completely.