### PR TITLE
Rebuild subviewsInLayoutOrder based on subviews layout order.

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -30,7 +30,7 @@ open class SpotsScrollView: UIScrollView {
   deinit {
     for subview in subviewsInLayoutOrder {
       if let subview = subview {
-        removeObserved(subview: subview)
+        observeView(view: subview)
       }
     }
   }
@@ -98,7 +98,7 @@ open class SpotsScrollView: UIScrollView {
   ///
   /// - parameter subview: - parameter subview: The subview that will be removed.
   open override func willRemoveSubview(_ subview: UIView) {
-    removeObserved(subview: subview)
+    observeView(view: subview)
     setNeedsLayout()
     layoutSubviews()
   }
@@ -106,16 +106,16 @@ open class SpotsScrollView: UIScrollView {
   /// Remove observers from subview.
   ///
   /// - Parameter subview: The subview that should no longer be observed.
-  private func removeObserved(subview: UIView) {
-    if subview is UIScrollView && subview.superview == contentView {
-      subview.removeObserver(self, forKeyPath: #keyPath(contentSize), context: subviewContext)
-      subview.removeObserver(self, forKeyPath: #keyPath(contentOffset), context: subviewContext)
-    } else if subview.superview == contentView {
-      subview.removeObserver(self, forKeyPath: #keyPath(frame), context: subviewContext)
-      subview.removeObserver(self, forKeyPath: #keyPath(bounds), context: subviewContext)
+  private func observeView(view: UIView) {
+    if view is UIScrollView && view.superview == contentView {
+      view.removeObserver(self, forKeyPath: #keyPath(contentSize), context: subviewContext)
+      view.removeObserver(self, forKeyPath: #keyPath(contentOffset), context: subviewContext)
+    } else if view.superview == contentView {
+      view.removeObserver(self, forKeyPath: #keyPath(frame), context: subviewContext)
+      view.removeObserver(self, forKeyPath: #keyPath(bounds), context: subviewContext)
     }
 
-    if let index = subviewsInLayoutOrder.index(where: { $0 == subview }) {
+    if let index = subviewsInLayoutOrder.index(where: { $0 == view }) {
       subviewsInLayoutOrder.remove(at: index)
     }
   }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -61,7 +61,11 @@ open class SpotsScrollView: UIScrollView {
     subview.autoresizingMask = UIViewAutoresizing()
 
     guard let index = contentView.subviews.index(of: subview) else { return }
-    subviewsInLayoutOrder.insert(subview, at: index)
+
+    subviewsInLayoutOrder.removeAll()
+    for subview in contentView.subviews {
+      subviewsInLayoutOrder.append(subview)
+    }
 
     if subview.superview == contentView && !(subview is UIScrollView) {
       subview.addObserver(self, forKeyPath: #keyPath(frame), options: .old, context: subviewContext)


### PR DESCRIPTION
I found an issue where `subviewsInLayoutOrder` can be out of sync with the actual layout order in the `contentView`. To fix this issue, the layout order is rebuilt based on the `contentView` order when you add new views.

This also moves observers into its own collection so that you cannot add or remove observers twice.