### PR TITLE
Fix mutating methods on Listable + improve mutation with proper queuing.

### DIFF
--- a/Examples/Apple News/Podfile.lock
+++ b/Examples/Apple News/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   Transition: 66d86e3ae1b8f0b3d9ba2000c7a45fbc17b066f2

--- a/Examples/Spotify/Podfile.lock
+++ b/Examples/Spotify/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Keychain (1.0.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   Whisper: '08be92623311f8e53201e62e17f6d7b9599a4714'

--- a/Examples/SpotifyMac/Podfile.lock
+++ b/Examples/SpotifyMac/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
     - JWTDecode
     - Keychain
     - Malibu
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -75,7 +75,7 @@ SPEC CHECKSUMS:
   Keychain: b82fa1a6c20666b74014e7549f53bae6c75d617f
   Malibu: d697d750eba061696ddafa097b6cb325ba6037f7
   OhMyAuth: a18f116df4a9fd1ea06cb6b6e3191537645dc04b
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
   When: 3df626af4891607ea7dd3f46a451176c5642c528

--- a/Examples/SpotsCards/Podfile.lock
+++ b/Examples/SpotsCards/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -38,7 +38,7 @@ SPEC CHECKSUMS:
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 

--- a/Examples/SpotsDemo/Podfile.lock
+++ b/Examples/SpotsDemo/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -38,7 +38,7 @@ SPEC CHECKSUMS:
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 

--- a/Examples/SpotsFeed/Podfile.lock
+++ b/Examples/SpotsFeed/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   Fakery: 97b99c23937d2e025d9135c75e2b17351ccd5031
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 

--- a/Examples/SpotsNibDemo/Podfile.lock
+++ b/Examples/SpotsNibDemo/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - CryptoSwift
   - CryptoSwift (0.6.0)
   - Hue (2.0.1)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -29,7 +29,7 @@ SPEC CHECKSUMS:
   Cache: 525a292370641881d7e350f0d451fd276790243a
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 
 PODFILE CHECKSUM: 0f82781f79b3957e854c3d49f6f54f3271306b76

--- a/Examples/tvOS Dashboard/Podfile.lock
+++ b/Examples/tvOS Dashboard/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - CryptoSwift (0.6.0)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
-  - Spots (5.2.0):
+  - Spots (5.3.1):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
@@ -32,7 +32,7 @@ SPEC CHECKSUMS:
   Cache: 525a292370641881d7e350f0d451fd276790243a
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
-  Spots: 9c70f94391c781e43cab4eb9212eaffcbc97c439
+  Spots: f60f1f1ef165766672087bc72d7018915ebd48fe
   Sugar: '079e1375b76c8f0693474417836ef098f507ac50'
   Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -107,7 +107,13 @@ public extension Spotable {
   /// - parameter completion: A completion closure that will be run in the main queue when the size has been updated.
   public func updateHeight(_ completion: Completion = nil) {
     Dispatch.inQueue(queue: .interactive) { [weak self] in
-      guard let weakSelf = self else { Dispatch.mainQueue { completion?(); }; return }
+      guard let weakSelf = self else {
+        Dispatch.mainQueue {
+          completion?()
+        }
+        return
+      }
+
       let spotHeight = weakSelf.computedHeight
       Dispatch.mainQueue { [weak self] in
         self?.render().frame.size.height = spotHeight

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -50,17 +50,22 @@ public extension Spotable {
       guard let weakSelf = self else { completion?(); return }
 
       var indexes = [Int]()
-      let count = weakSelf.component.items.count
+      let itemCount = weakSelf.component.items.count
 
       weakSelf.component.items.append(contentsOf: items)
 
       items.enumerated().forEach {
-        indexes.append(count + $0.offset)
-        weakSelf.configureItem(at: count + $0.offset)
+        indexes.append(itemCount + $0.offset)
+        weakSelf.configureItem(at: itemCount + $0.offset)
       }
 
-      Dispatch.mainQueue { [weak self] in
+      if itemCount > 0 {
         weakSelf.userInterface?.insert(indexes, withAnimation: animation, completion: nil)
+        weakSelf.updateHeight() {
+          completion?()
+        }
+      } else {
+        weakSelf.userInterface?.reloadDataSource()
         weakSelf.updateHeight() {
           completion?()
         }

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -244,7 +244,6 @@ public extension Spotable {
       return
     } else if let cell: SpotConfigurable = userInterface?.view(at: index) {
       cell.configure(&items[index])
-      afterUpdate()
       completion?()
     } else {
       afterUpdate()

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -245,7 +245,7 @@ public extension Spotable {
     } else if let cell: SpotConfigurable = userInterface?.view(at: index) {
       cell.configure(&items[index])
       afterUpdate()
-      updateHeight() { completion?() }
+      completion?()
     } else {
       afterUpdate()
       completion?()

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -50,27 +50,20 @@ public extension Spotable {
       guard let weakSelf = self else { completion?(); return }
 
       var indexes = [Int]()
-      let itemsCount = weakSelf.component.items.count
+      let count = weakSelf.component.items.count
 
-      if weakSelf.component.items.isEmpty {
-        weakSelf.component.items.append(contentsOf: items)
-      } else {
-        for (index, item) in items.enumerated() {
-          weakSelf.component.items.append(item)
-          indexes.append(itemsCount + index)
+      weakSelf.component.items.append(contentsOf: items)
 
-          weakSelf.configureItem(at: itemsCount + index)
-        }
+      items.enumerated().forEach {
+        indexes.append(count + $0.offset)
+        weakSelf.configureItem(at: count + $0.offset)
       }
 
-      if itemsCount > 0 {
+      Dispatch.mainQueue { [weak self] in
         weakSelf.userInterface?.insert(indexes, withAnimation: animation, completion: nil)
-      } else {
-        weakSelf.userInterface?.reloadDataSource()
-      }
-      weakSelf.updateHeight() {
-        weakSelf.afterUpdate()
-        completion?()
+        weakSelf.updateHeight() {
+          completion?()
+        }
       }
     }
   }

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -279,9 +279,7 @@ public extension Spotable {
     }
 
     afterUpdate()
-    updateHeight() {
-      completion?()
-    }
+    completion?()
   }
 
   /// Reload spot with ItemChanges.

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -238,7 +238,9 @@ public extension Spotable {
         userInterface?.reload([index], withAnimation: animation, completion: nil)
       }
       afterUpdate()
-      updateHeight() { completion?() }
+      updateHeight {
+        completion?()
+      }
       return
     } else if let cell: SpotConfigurable = userInterface?.view(at: index) {
       cell.configure(&items[index])

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -276,8 +276,6 @@ public extension Spotable {
         ? userInterface?.reloadSection(0, withAnimation: animation, completion: nil)
         : userInterface?.reloadDataSource()
     }
-
-    afterUpdate()
     completion?()
   }
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -467,10 +467,8 @@ extension SpotsProtocol {
         }
       #endif
 
-      let spot = weakSelf.spot(at: index, ofType: Spotable.self)
-
-      spot?.reload(nil, withAnimation: animation) { [weak self] in
-        spot?.afterUpdate()
+      spot.reload(nil, withAnimation: animation) { [weak self] in
+        spot.afterUpdate()
         completion?()
         self?.scrollView.layoutSubviews()
       }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -460,7 +460,8 @@ extension SpotsProtocol {
 
       #if !os(OSX)
         if animation != .none {
-          if let superview = spot.render().superview {
+          let isScrolling = weakSelf.scrollView.isDragging == true && weakSelf.scrollView.isTracking == true
+          if let superview = spot.render().superview, !isScrolling {
             spot.render().layer.frame.size.height = superview.frame.height
           }
         }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -448,7 +448,6 @@ extension SpotsProtocol {
   public func update(spotAtIndex index: Int = 0, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ spot: Spotable) -> Void) {
     guard let spot = spot(at: index, ofType: Spotable.self) else {
       completion?()
-      scrollView.layoutSubviews()
       return }
     closure(spot)
     spot.refreshIndexes()

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -461,8 +461,10 @@ extension SpotsProtocol {
       #if !os(OSX)
         if animation != .none {
           let isScrolling = weakSelf.scrollView.isDragging == true && weakSelf.scrollView.isTracking == true
-          if let superview = spot.render().superview, !isScrolling {
-            spot.render().layer.frame.size.height = superview.frame.height
+          if let superview = spot.render().superview,
+            !isScrolling
+          {
+            spot.render().frame.size.height = superview.frame.height
           }
         }
       #endif

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -451,7 +451,8 @@ extension SpotsProtocol {
       return }
     closure(spot)
     spot.refreshIndexes()
-    spot.registerAndPrepare()
+    spot.prepareItems()
+
     let spotHeight = spot.computedHeight
 
     Dispatch.mainQueue { [weak self] in

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -460,7 +460,7 @@ extension SpotsProtocol {
 
       #if !os(OSX)
         if animation != .none {
-          let isScrolling = weakSelf.scrollView.isDragging == true && weakSelf.scrollView.isTracking == true
+          let isScrolling = weakSelf.scrollView.isDragging == true || weakSelf.scrollView.isTracking == true
           if let superview = spot.render().superview,
             !isScrolling
           {

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -458,7 +458,11 @@ extension SpotsProtocol {
       guard let weakSelf = self else { return }
 
       #if !os(OSX)
-        if animation != .none { spot.render().layer.frame.size.height = spotHeight }
+        if animation != .none {
+          if let superview = spot.render().superview {
+            spot.render().layer.frame.size.height = superview.frame.height
+          }
+        }
       #endif
 
       let spot = weakSelf.spot(at: index, ofType: Spotable.self)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -448,6 +448,7 @@ extension SpotsProtocol {
   public func update(spotAtIndex index: Int = 0, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ spot: Spotable) -> Void) {
     guard let spot = spot(at: index, ofType: Spotable.self) else {
       completion?()
+      scrollView.layoutSubviews()
       return }
     closure(spot)
     spot.refreshIndexes()

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -486,10 +486,11 @@ extension SpotsProtocol {
       return
     }
 
-    update(spotAtIndex: index, withAnimation: animation, withCompletion: completion, { [weak self] in
-      $0.items = items
+    update(spotAtIndex: index, withAnimation: animation, withCompletion: { [weak self] in
+      completion?()
       self?.scrollView.layoutSubviews()
-      })
+    }, { [weak self] in
+      $0.items = items })
   }
 
   /**

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -24,7 +24,10 @@ open class GridableLayout: UICollectionViewFlowLayout {
     super.prepare()
 
     guard let delegate = collectionView?.delegate as? Delegate,
-     let spot = delegate.spot as? Gridable else { return }
+      let spot = delegate.spot as? Gridable
+      else {
+        return
+    }
 
     if scrollDirection == .horizontal {
       guard let firstItem = spot.items.first else { return }

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -32,4 +32,8 @@ public extension Listable {
     return component.items[0...item.index]
       .reduce(0, { $0 + $1.size.height })
   }
+
+  public func afterUpdate() {
+    updateHeight()
+  }
 }

--- a/Sources/iOS/Extensions/UITableView+Indexes.swift
+++ b/Sources/iOS/Extensions/UITableView+Indexes.swift
@@ -31,9 +31,23 @@ extension UITableView: UserInterface {
   /// - parameter animation: A constant that indicates how the reloading is to be animated
   public func reload(_ indexes: [Int], withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
     let indexPaths = indexes.map { IndexPath(row: $0, section: 0) }
-    if animation == .none { UIView.setAnimationsEnabled(false) }
-    performUpdates { reloadRows(at: indexPaths, with: animation.tableViewAnimation) }
-    if animation == .none { UIView.setAnimationsEnabled(true) }
+
+    if animation == .none {
+      UIView.setAnimationsEnabled(false)
+    }
+
+    if !indexPaths.isEmpty {
+      performUpdates {
+        reloadRows(at: indexPaths, with: animation.tableViewAnimation)
+      }
+    } else {
+      reloadDataSource()
+    }
+
+    if animation == .none {
+      UIView.setAnimationsEnabled(true)
+    }
+
     completion?()
   }
 
@@ -82,6 +96,7 @@ extension UITableView: UserInterface {
   /// - parameter completino: A completion closure that will run when the reload is done.
   public func reloadSection(_ section: Int = 0, withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
     if animation == .none { UIView.setAnimationsEnabled(false) }
+
     performUpdates {
       reloadSections(IndexSet(integer: section), with: animation.tableViewAnimation)
     }

--- a/Sources/iOS/Extensions/UITableView+Indexes.swift
+++ b/Sources/iOS/Extensions/UITableView+Indexes.swift
@@ -95,12 +95,16 @@ extension UITableView: UserInterface {
   /// - parameter animation: A constant that indicates how the reloading is to be animated.
   /// - parameter completino: A completion closure that will run when the reload is done.
   public func reloadSection(_ section: Int = 0, withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
-    if animation == .none { UIView.setAnimationsEnabled(false) }
+    if animation == .none {
+      UIView.setAnimationsEnabled(false)
+    }
 
     performUpdates {
       reloadSections(IndexSet(integer: section), with: animation.tableViewAnimation)
     }
-    if animation == .none { UIView.setAnimationsEnabled(true) }
+    if animation == .none {
+      UIView.setAnimationsEnabled(true)
+    }
     completion?()
   }
 


### PR DESCRIPTION
We had some regression when refactoring `Listable` and `Gridable` into `UserInterface`. This PR fixes `append([Item])` and `updateIfNeeded` to work like it did before the previous refactoring.

Edit:

I ended up adding proper dispatch handling for all `Spotable` objects. So when it needs to perform computation with value types, it will use an interactive thread and when done, it will always dispatch back to the main queue to perform the UI updates.
Before it did perform the update on a different queue and then dispatched back to main when it was time to perform the UI updates. Now it should always be in sync.
This way it should be more responsive for the user as it should never lock the main queue.

I also noticed that some of the mutation didn't use queuing at all, which could cause some odd results when performing spotable mutation in a background thread.

tl;dr

🌮  