### PR TITLE
Fix layout warnings for carousel

### DIFF
--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -62,7 +62,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     }
   }
 
-
   /// Returns the layout attributes for all of the cells and views in the specified rectangle.
   ///
   /// - parameter rect: The rectangle (specified in the collection view’s coordinate system) containing the target views.

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -50,9 +50,12 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
   /// Invalidates the current layout and triggers a layout update.
   open override func invalidateLayout() {
-    super.invalidateLayout()
+    guard let collectionView = collectionView else {
+      return
+    }
 
     guard let collectionView = collectionView else { return }
+    super.invalidateLayout()
 
     if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {
       collectionView.frame.origin.y = y

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -54,7 +54,12 @@ open class GridableLayout: UICollectionViewFlowLayout {
       return
     }
 
-    guard let collectionView = collectionView else { return }
+    if scrollDirection == .horizontal &&
+      (collectionView.frame.size.height <= contentSize.height ||
+      collectionView.contentOffset.y > 0) {
+      return
+    }
+
     super.invalidateLayout()
 
     if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -21,13 +21,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// The collection view calls -prepareLayout again after layout is invalidated and before requerying the layout information.
   /// Subclasses should always call super if they override.
   open override func prepare() {
-    super.prepare()
-
     guard let delegate = collectionView?.delegate as? Delegate,
       let spot = delegate.spot as? Gridable
       else {
         return
     }
+
+    super.prepare()
 
     if scrollDirection == .horizontal {
       guard let firstItem = spot.items.first else { return }


### PR DESCRIPTION
This will fix layout warnings that can appear for carousel views.
The warnings occur because the container for the items is now smaller
than the desired size as the view gets reduced down by SpotsScrollView.