### PR TITLE
Improve reload if needed with components

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,7 +16,7 @@ type_body_length:
   - 300
   - 400
 file_length:
-  warning: 650
+  warning: 850
   error: 1200
 cyclomatic_complexity:
   warning: 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_install:
 - travis_wait 35; bin/bootstrap-if-needed
 
 script:
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx clean build
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx -enableCodeCoverage YES test
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build
-- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx clean build | xcpretty
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-Mac" -sdk macosx -enableCodeCoverage YES test | xcpretty
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build | xcpretty
+- set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test | xcpretty
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -505,8 +505,9 @@ extension SpotsProtocol {
     update(spotAtIndex: index, withAnimation: animation, withCompletion: { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
-    }, { [weak self] in
-      $0.items = items })
+    }, {
+      $0.items = items
+    })
   }
 
   /**

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -423,11 +423,11 @@ extension SpotsProtocol {
     }
   }
 
-  /**
-   - parameter json: A JSON dictionary that gets parsed into UI elements
-   - parameter animated: An animation closure that can be used to perform custom animations when reloading
-   - parameter completion: A closure that will be run after reload has been performed on all spots
-   */
+  /// Reload with JSON
+  ///
+  ///- parameter json: A JSON dictionary that gets parsed into UI elements
+  ///- parameter animated: An animation closure that can be used to perform custom animations when reloading
+  ///- parameter completion: A closure that will be run after reload has been performed on all spots
   public func reload(_ json: [String : Any], animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
     Dispatch.mainQueue { [weak self] in
       guard let weakSelf = self else {

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -33,34 +33,49 @@ extension SpotsProtocol {
     }
   }
 
-  public func reloadIfNeeded(_ components: [Component], withAnimation animation: Animation = .automatic, closure: Completion = nil) {
+  /// Reload if needed using JSON
+  ///
+  /// - parameter components: A collection of components that gets parsed into UI elements
+  /// - parameter compare: A closure that is used for comparing a Component collections
+  /// - parameter animated: An animation closure that can be used to perform custom animations when reloading
+  /// - parameter completion: A closure that will be run after reload has been performed on all spots
+  public func reloadIfNeeded(_ components: [Component],
+                             compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
+                             withAnimation animation: Animation = .automatic,
+                             completion: Completion = nil) {
     guard !components.isEmpty else {
-      Dispatch.mainQueue {
-        self.spots.forEach { $0.render().removeFromSuperview() }
-        self.spots = []
-        closure?()
+      Dispatch.mainQueue { [weak self] in
+        self?.spots.forEach { $0.render().removeFromSuperview() }
+        self?.spots = []
+        completion?()
       }
       return
     }
 
     Dispatch.inQueue(queue: .interactive) { [weak self] in
       guard let weakSelf = self else {
-        closure?()
+        completion?()
         return
       }
 
       let oldComponents = weakSelf.spots.map { $0.component }
       let newComponents = components
 
+      guard compare(newComponents, oldComponents) else {
+        weakSelf.cache()
+        Dispatch.mainQueue { completion?() }
+        return
+      }
+
       guard newComponents !== oldComponents else {
-        Dispatch.mainQueue { closure?() }
+        Dispatch.mainQueue { completion?() }
         return
       }
 
       let changes = weakSelf.generateChanges(from: newComponents, and: oldComponents)
 
       weakSelf.process(changes: changes, components: newComponents, withAnimation: animation) {
-        closure?()
+        completion?()
         if let controller = self as? Controller {
           Controller.spotsDidReloadComponents?(controller)
         }
@@ -342,14 +357,13 @@ extension SpotsProtocol {
     }
   }
 
-  /**
-   Reload if needed using JSON
 
-   - parameter json: A JSON dictionary that gets parsed into UI elements
-   - parameter compare: A closure that is used for comparing a Component collections
-   - parameter animated: An animation closure that can be used to perform custom animations when reloading
-   - parameter completion: A closure that will be run after reload has been performed on all spots
-   */
+  ///Reload if needed using JSON
+  ///
+  /// - parameter json: A JSON dictionary that gets parsed into UI elements
+  /// - parameter compare: A closure that is used for comparing a Component collections
+  /// - parameter animated: An animation closure that can be used to perform custom animations when reloading
+  /// - parameter completion: A closure that will be run after reload has been performed on all spots
   public func reloadIfNeeded(_ json: [String : Any],
                              compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              animated: ((_ view: View) -> Void)? = nil,
@@ -453,17 +467,13 @@ extension SpotsProtocol {
     spot.refreshIndexes()
     spot.prepareItems()
 
-    let spotHeight = spot.computedHeight
-
     Dispatch.mainQueue { [weak self] in
       guard let weakSelf = self else { return }
 
       #if !os(OSX)
         if animation != .none {
           let isScrolling = weakSelf.scrollView.isDragging == true || weakSelf.scrollView.isTracking == true
-          if let superview = spot.render().superview,
-            !isScrolling
-          {
+          if let superview = spot.render().superview, !isScrolling {
             spot.render().frame.size.height = superview.frame.height
           }
         }

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -327,8 +327,7 @@ public func == (lhs: Component, rhs: Component) -> Bool {
     lhs.kind == rhs.kind &&
     lhs.span == rhs.span &&
     lhs.header == rhs.header &&
-    (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary) &&
-    lhs.items == rhs.items
+    (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary)
 }
 
 

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -268,38 +268,6 @@ open class CarouselSpot: NSObject, Gridable {
   }
 }
 
-extension CarouselSpot: UICollectionViewDelegateFlowLayout {
-
-  /// Asks the delegate for the spacing between successive rows or columns of a section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose line spacing is needed.
-  /// - returns: The minimum space (measured in points) to apply between successive lines in a section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-    return layout.sectionInset.bottom
-  }
-
-  /// Asks the delegate for the margins to apply to content in the specified section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose insets are needed.
-  ///
-  /// - returns: The margins to apply to items in the section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-    guard layout.scrollDirection == .horizontal else { return layout.sectionInset }
-
-    let left = layout.minimumLineSpacing / 2
-    let right = layout.minimumLineSpacing / 2
-
-    return UIEdgeInsets(top: layout.sectionInset.top,
-                        left: left,
-                        bottom: layout.sectionInset.bottom,
-                        right: right)
-  }
-}
-
 /// A scroll view extension on CarouselSpot to handle scrolling specifically for this object.
 extension Delegate: UIScrollViewDelegate {
 

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -179,35 +179,3 @@ open class GridSpot: NSObject, Gridable {
     collectionView.contentInset.right = component.meta(GridableMeta.Key.contentInsetRight, Default.contentInsetRight)
   }
 }
-
-extension GridSpot: UICollectionViewDelegateFlowLayout {
-
-  /// Asks the delegate for the spacing between successive rows or columns of a section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose line spacing is needed.
-  /// - returns: The minimum space (measured in points) to apply between successive lines in a section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-    return layout.minimumLineSpacing
-  }
-
-  /// Asks the delegate for the margins to apply to content in the specified section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose insets are needed.
-  ///
-  /// - returns: The margins to apply to items in the section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-    guard layout.scrollDirection == .horizontal else { return layout.sectionInset }
-
-    let left = layout.minimumLineSpacing / 2
-    let right = layout.minimumLineSpacing / 2
-
-    return UIEdgeInsets(top: layout.sectionInset.top,
-                        left: left,
-                        bottom: layout.sectionInset.bottom,
-                        right: right)
-  }
-}

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -107,10 +107,8 @@ open class GridableLayout: UICollectionViewFlowLayout {
             itemAttribute.frame.origin.y = headerReferenceSize.height
             itemAttribute.frame.origin.x = offset
             offset += itemAttribute.size.width + minimumInteritemSpacing
-          } else {
-            itemAttribute.frame.origin.y = itemAttribute.frame.origin.y
-            itemAttribute.frame.origin.x = itemAttribute.frame.origin.x
           }
+
           attributes.append(itemAttribute)
         }
       }

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -181,35 +181,3 @@ open class RowSpot: NSObject, Gridable {
     collectionView.delegate = spotDelegate
   }
 }
-
-extension RowSpot: UICollectionViewDelegateFlowLayout {
-
-  /// Asks the delegate for the spacing between successive rows or columns of a section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose line spacing is needed.
-  /// - returns: The minimum space (measured in points) to apply between successive lines in a section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-    return layout.minimumLineSpacing
-  }
-
-  /// Asks the delegate for the margins to apply to content in the specified section.
-  ///
-  /// - parameter collectionView:       The collection view object displaying the flow layout.
-  /// - parameter collectionViewLayout: The layout object requesting the information.
-  /// - parameter section:              The index number of the section whose insets are needed.
-  ///
-  /// - returns: The margins to apply to items in the section.
-  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-    guard layout.scrollDirection == .horizontal else { return layout.sectionInset }
-
-    let left = layout.minimumLineSpacing / 2
-    let right = layout.minimumLineSpacing / 2
-
-    return UIEdgeInsets(top: layout.sectionInset.top,
-                        left: left,
-                        bottom: layout.sectionInset.bottom,
-                        right: right)
-  }
-}

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -61,7 +61,7 @@ open class SpotsScrollView: UIScrollView {
   func didAddSubviewToContainer(_ subview: UIView) {
     subview.autoresizingMask = UIViewAutoresizing()
 
-    guard let index = contentView.subviews.index(of: subview) else { return }
+    guard contentView.subviews.index(of: subview) != nil else { return }
 
     subviewsInLayoutOrder.removeAll()
     for subview in contentView.subviews {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -130,3 +130,45 @@ extension Delegate: UITableViewDelegate {
     return spot.item(at: indexPath)?.size.height ?? 0
   }
 }
+
+extension Delegate: UICollectionViewDelegateFlowLayout {
+
+  /// Asks the delegate for the spacing between successive rows or columns of a section.
+  ///
+  /// - parameter collectionView:       The collection view object displaying the flow layout.
+  /// - parameter collectionViewLayout: The layout object requesting the information.
+  /// - parameter section:              The index number of the section whose line spacing is needed.
+  /// - returns: The minimum space (measured in points) to apply between successive lines in a section.
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    if let layout = collectionView.collectionViewLayout as? GridableLayout {
+      return layout.minimumLineSpacing
+    } else {
+      return 0
+    }
+  }
+
+  /// Asks the delegate for the margins to apply to content in the specified section.
+  ///
+  /// - parameter collectionView:       The collection view object displaying the flow layout.
+  /// - parameter collectionViewLayout: The layout object requesting the information.
+  /// - parameter section:              The index number of the section whose insets are needed.
+  ///
+  /// - returns: The margins to apply to items in the section.
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    if let layout = collectionView.collectionViewLayout as? GridableLayout {
+      guard layout.scrollDirection == .horizontal else {
+        return layout.sectionInset
+      }
+
+      let left = layout.minimumLineSpacing / 2
+      let right = layout.minimumLineSpacing / 2
+
+      return UIEdgeInsets(top: layout.sectionInset.top,
+                          left: left,
+                          bottom: layout.sectionInset.bottom,
+                          right: right)
+    } else {
+      return UIEdgeInsets.zero
+    }
+  }
+}

--- a/SpotsTests/Shared/TestComponent.swift
+++ b/SpotsTests/Shared/TestComponent.swift
@@ -51,10 +51,10 @@ class ComponentTests : XCTestCase {
       kind: json["kind"] as! String,
       span: json["span"] as! Double,
       meta: json["meta"] as! [String : String])
-    XCTAssertFalse(jsonComponent == codeComponent)
+    XCTAssertTrue(jsonComponent == codeComponent)
 
     codeComponent.items.append(Item(title: "item2"))
-    XCTAssertFalse(jsonComponent == codeComponent)
+    XCTAssertTrue(jsonComponent == codeComponent)
   }
 
   func testComponentDictionary() {

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -92,7 +92,7 @@ class RowSpotTests: XCTestCase {
       exception?.fulfill()
       exception = nil
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testInsertItem() {


### PR DESCRIPTION
This PR adds an additional compare label to `reloadIfNeeded` with `[Component]`. This gives you more fine-grained control over when you would consider the components as new and not.