### PR TITLE
Fix CPU spike by constraining Spotable height to parent height

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -114,8 +114,14 @@ public extension Spotable {
         return
       }
 
-      let spotHeight = weakSelf.computedHeight
+      var spotHeight = weakSelf.computedHeight
       Dispatch.mainQueue { [weak self] in
+        #if !os(OSX)
+          if spotHeight > UIScreen.main.bounds.height {
+            let superViewHeight = self?.render().frame.size.height ?? UIScreen.main.bounds.height
+            spotHeight = superViewHeight
+          }
+        #endif
         self?.render().frame.size.height = spotHeight
         completion?()
       }


### PR DESCRIPTION
This PR fixes CPU spikes that occur with large collections. This occurred because frame grew and the Spotable object started to initialize all items inside of it. To fix this issue, the Spotable height is no constrained to its parent window. If it doesn't have a parent it is constrained to the screen height. This way it won't initialize more views that is actually needed and the CPU won't spike out of control. 