### PR TITLE
Refactor spot height calculations

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -114,14 +114,8 @@ public extension Spotable {
         return
       }
 
-      var spotHeight = weakSelf.computedHeight
+      let spotHeight = weakSelf.computedHeight
       Dispatch.mainQueue { [weak self] in
-        #if !os(OSX)
-          if spotHeight > UIScreen.main.bounds.height {
-            let superViewHeight = self?.render().frame.size.height ?? UIScreen.main.bounds.height
-            spotHeight = superViewHeight
-          }
-        #endif
         self?.render().frame.size.height = spotHeight
         completion?()
       }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -21,8 +21,19 @@ public extension Spotable {
     }
 
     var height: CGFloat = 0
-    component.items.forEach {
-      height += $0.size.height
+    #if !os(OSX)
+      let superViewHeight = self.render().superview?.frame.size.height ?? UIScreen.main.bounds.height
+    #endif
+
+    for item in component.items {
+      height += item.size.height
+
+      #if !os(OSX)
+        if height > superViewHeight {
+          height = superViewHeight
+          break
+        }
+      #endif
     }
 
     return height

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -11,7 +11,13 @@ extension Gridable {
 
     layout.prepare()
 
-    return layout.collectionViewContentSize.height + layout.sectionInset.top + layout.sectionInset.bottom
+    var height = layout.collectionViewContentSize.height + layout.sectionInset.top + layout.sectionInset.bottom
+    let superViewHeight = self.render().superview?.frame.size.height ?? UIScreen.main.bounds.height
+    if height > superViewHeight {
+      height = superViewHeight
+    }
+
+    return height
   }
 
   /// Initializes a Gridable container and configures the Spot with the provided component and optional layout properties.


### PR DESCRIPTION
This PR refactors yesterdays CPU spike fix. This solution should be more efficient on larger collections has the `spotHeight` will return an already sanitized value. It also stops counting the spot height when it exceeds either the super view fram height or `UIScreen` height (for iOS).