### PR TITLE
Declare estimatedRowHeight for iOS 8

### DIFF
--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -148,12 +148,6 @@ open class ListSpot: NSObject, Listable {
     tableView.delegate = spotDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
 
-    if #available(iOS 9, *) {
-
-    } else {
-      tableView.estimatedRowHeight = 10
-    }
-
     #if os(iOS)
       if let separator = component.meta(Key.separator, type: Bool.self) {
         tableView.separatorStyle = separator
@@ -161,6 +155,12 @@ open class ListSpot: NSObject, Listable {
           : .none
       }
     #endif
+
+    if #available(iOS 9, *) {
+      return
+    } else {
+      tableView.estimatedRowHeight = 10
+    }
   }
 
   // MARK: - Spotable

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -156,6 +156,7 @@ open class ListSpot: NSObject, Listable {
       }
     #endif
 
+    /// On iOS 8 and prior, the second cell always receives the same height as the first cell. Setting estimatedRowHeight magically fixes this issue. The value being set is not relevant.
     if #available(iOS 9, *) {
       return
     } else {

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -148,6 +148,12 @@ open class ListSpot: NSObject, Listable {
     tableView.delegate = spotDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
 
+    if #available(iOS 9, *) {
+
+    } else {
+      tableView.estimatedRowHeight = 10
+    }
+
     #if os(iOS)
       if let separator = component.meta(Key.separator, type: Bool.self) {
         tableView.separatorStyle = separator


### PR DESCRIPTION
On iOS 8.1 and 8.4 (maybe for all iOS 8 versions), we have a problem when the 2nd cell always has the same height as the 1st cell 🐼 

It happens on both simulators and devices

This works around this by explicitly set `estimatedRowHeight` to a "decent" value