### PR TITLE
Fix double page control height calculation

### DIFF
--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -39,10 +39,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
       contentSize.height = firstItem.size.height + headerReferenceSize.height
       contentSize.height += sectionInset.top + sectionInset.bottom
-
-      if let spot = delegate.spot as? CarouselSpot, spot.pageIndicator {
-        contentSize.height += spot.pageControl.frame.height
-      }
     } else {
       contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
     }


### PR DESCRIPTION
@zenangst I had a problem with a carousel where the height in the content size was wrong. Then I've discovered that the height of a page control is already used in calculations https://github.com/hyperoslo/Spots/blob/master/Sources/iOS/Classes/CarouselSpot.swift#L253, so we don't need to do it second time in the `GridableLayout`.