### PR TITLE
Improve/mutable spotable objects

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -56,7 +56,7 @@ public extension Spotable {
 
       items.enumerated().forEach {
         indexes.append(numberOfItems + $0.offset)
-        weakSelf.configureItem(at: numberOfItems + $0.offset)
+        weakSelf.configureItem(at: numberOfItems + $0.offset, usesViewSize: true)
       }
 
       if numberOfItems > 0 {
@@ -94,7 +94,7 @@ public extension Spotable {
         if numberOfItems > 0 {
           indexes.append(items.count - 1 - $0.offset)
         }
-        weakSelf.configureItem(at: $0.offset)
+        weakSelf.configureItem(at: $0.offset, usesViewSize: true)
       }
 
       if !indexes.isEmpty {
@@ -133,6 +133,7 @@ public extension Spotable {
       }
 
       if numberOfItems > 0 {
+        weakSelf.configureItem(at: numberOfItems, usesViewSize: true)
         weakSelf.userInterface?.insert(indexes, withAnimation: animation, completion: nil)
       } else {
         weakSelf.userInterface?.reloadDataSource()
@@ -254,7 +255,7 @@ public extension Spotable {
       }
 
       weakSelf.items[index] = item
-      weakSelf.configureItem(at: index)
+      weakSelf.configureItem(at: index, usesViewSize: true)
 
       let newItem = weakSelf.items[index]
 
@@ -316,11 +317,11 @@ public extension Spotable {
 
         if let indexes = indexes {
           indexes.forEach { index  in
-            weakSelf.configureItem(at: index)
+            weakSelf.configureItem(at: index, usesViewSize: true)
           }
         } else {
           for (index, _) in weakSelf.component.items.enumerated() {
-            weakSelf.configureItem(at: index)
+            weakSelf.configureItem(at: index, usesViewSize: true)
           }
         }
 

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -31,10 +31,13 @@ public extension Spotable {
           completion?()
         }
       } else {
-        weakSelf.userInterface?.insert([numberOfItems], withAnimation: animation, completion: nil)
-        weakSelf.updateHeight() {
-          weakSelf.afterUpdate()
-          completion?()
+        Dispatch.mainQueue {
+          weakSelf.configureItem(at: numberOfItems, usesViewSize: true)
+          weakSelf.userInterface?.insert([numberOfItems], withAnimation: animation, completion: nil)
+          weakSelf.updateHeight() {
+            weakSelf.afterUpdate()
+            completion?()
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes the issue on mutable operations where `Item`'s don't appear in the list until you start scrolling. This bug happens when you append an item that doesn't have a size and the view does not specifically set the height in the configure method for the view.

The new behavior introduced in this PR, is that any item that is appended, prepended updated or reloaded will be configured with the flag `usesViewHeight` set to `true`. Internally, Spots will now use the preferred view height as a fallback when configuring the `Item`.