### PR TITLE
Remove/after update on listable

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -103,12 +103,16 @@ public extension Spotable {
       if !indexes.isEmpty {
         weakSelf.userInterface?.insert(indexes, withAnimation: animation) {
           weakSelf.afterUpdate()
-          weakSelf.sanitize { completion?() }
+          weakSelf.sanitize {
+            completion?()
+          }
         }
       } else {
         weakSelf.userInterface?.reloadDataSource()
         weakSelf.afterUpdate()
-        weakSelf.sanitize { completion?() }
+        weakSelf.sanitize {
+          completion?()
+        }
       }
     }
   }

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -32,8 +32,4 @@ public extension Listable {
     return component.items[0...item.index]
       .reduce(0, { $0 + $1.size.height })
   }
-
-  public func afterUpdate() {
-    updateHeight()
-  }
 }


### PR DESCRIPTION
This PR removes redundant code from the `Listable` protocol extension. This was causing issues because it started updating the list height twice as `updateHeight` is a part of `sanitize` on `Spotable`.