### PR TITLE
Refactor reload if needed to update height before calling completion

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -407,11 +407,13 @@ public extension Spotable {
 
         if items.count == oldItems.count {
           for (index, item) in items.enumerated() {
-            guard !(item == oldItems[index]) else { continue }
+            guard !(item == oldItems[index]) else {
+              weakSelf.items[index].size = oldItems[index].size
+              continue
+            }
 
             if indexes == nil { indexes = [Int]() }
             indexes?.append(index)
-            weakSelf.configureItem(at: index, usesViewSize: true)
           }
         } else {
           for (index, _) in items.enumerated() {

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -411,12 +411,20 @@ public extension Spotable {
 
             if indexes == nil { indexes = [Int]() }
             indexes?.append(index)
+            weakSelf.configureItem(at: index, usesViewSize: true)
+          }
+        } else {
+          for (index, _) in items.enumerated() {
+            weakSelf.configureItem(at: index, usesViewSize: true)
           }
         }
 
-        weakSelf.reload(indexes, withAnimation: animation) {
-          weakSelf.cache()
-          completion?()
+        weakSelf.updateHeight() {
+          weakSelf.reload(indexes, withAnimation: animation) {
+            weakSelf.afterUpdate()
+            weakSelf.cache()
+            completion?()
+          }
         }
       }
     }
@@ -444,6 +452,7 @@ public extension Spotable {
         guard let weakSelf = self else {
           return
         }
+        weakSelf.afterUpdate()
         weakSelf.cache()
       }
     }


### PR DESCRIPTION
This PR improves the `reloadIfNeeded` method on `Spotable` computing and setting the height when reloading with `[Item]`.