### PR TITLE
Feature will display view on SpotsProtocol

### DIFF
--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -15,6 +15,19 @@ extension Delegate: NSCollectionViewDelegate {
       spot.delegate?.didSelect(item: item, in: spot)
     }
   }
+
+  /// Notifies the delegate that the specified item is about to be displayed by the collection view.
+  ///
+  /// - parameter collectionView: The collection view that is adding the item.
+  /// - parameter item: The item being added.
+  /// - parameter indexPath: The index path of the item.
+  public func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.willDisplay(item: item, in: spot)
+  }
 }
 
 extension Delegate: NSCollectionViewDelegateFlowLayout {

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -99,7 +99,13 @@ extension Delegate: NSTableViewDelegate {
     return view as? NSTableRowView
   }
 
-  public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {}
+  public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.willDisplay(item: item, in: spot)
+  }
 
   public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
     return nil

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -100,7 +100,7 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {
-    guard let spot = spot, let item = spot.item(at: indexPath) else {
+    guard let spot = spot, let item = spot.item(at: row) else {
       return
     }
 

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -43,9 +43,7 @@ public protocol SpotsDelegate: class {
   /// - parameter spot: An object that conforms to the spotable protocol
   func didSelect(item: Item, in spot: Spotable)
 
-  #if !os(OSX)
   func willDisplay(item: Item, in spot: Spotable)
-  #endif
 }
 
 // MARK: - SpotsDelegate extension

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -42,6 +42,10 @@ public protocol SpotsDelegate: class {
   /// - parameter item: The view model that was tapped
   /// - parameter spot: An object that conforms to the spotable protocol
   func didSelect(item: Item, in spot: Spotable)
+
+  #if !os(OSX)
+  func willDisplay(item: Item, in spot: Spotable)
+  #endif
 }
 
 // MARK: - SpotsDelegate extension
@@ -57,6 +61,8 @@ public extension SpotsDelegate {
   ///
   /// - parameter spots: The collection of new Spotable objects.
   func didChange(spots: [Spotable]) {}
+
+  func willDisplay(item: Item, in spot: Spotable) {}
 }
 
 /// A refresh delegate for handling reloading of a Spot

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -39,10 +39,14 @@ public protocol SpotsDelegate: class {
 
   /// A delegate method that is triggered when ever a cell is tapped by the user
   ///
-  /// - parameter item: The view model that was tapped
-  /// - parameter spot: An object that conforms to the spotable protocol
+  /// - parameter item: The data for the view that is going to be displayed.
+  /// - parameter spot: An object that conforms to the spotable protocol.
   func didSelect(item: Item, in spot: Spotable)
 
+  /// A delegate method that is triggered when ever a view is going to be displayed
+  ///
+  /// - parameter item: The data for the view that is going to be displayed.
+  /// - parameter spot: An object that conforms to the spotable protocol.
   func willDisplay(item: Item, in spot: Spotable)
 }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -24,6 +24,19 @@ extension Delegate: UICollectionViewDelegate {
     spot.delegate?.didSelect(item: item, in: spot)
   }
 
+  /// Tells the delegate that the specified cell is about to be displayed in the collection view.
+  ///
+  /// - parameter collectionView: The collection view object that is adding the cell.
+  /// - parameter cell: The cell object being added.
+  /// - parameter indexPath: The index path of the data item that the cell represents.
+  public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.willDisplay(item: item, in: spot)
+  }
+
   /// Asks the delegate whether the item at the specified index path can be focused.
   ///
   /// - parameter collectionView: The collection view object requesting this information.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -95,6 +95,18 @@ extension Delegate: UITableViewDelegate {
     }
   }
 
+  /// Tells the delegate the table view is about to draw a cell for a particular row.
+  ///
+  /// - Parameters:
+  ///   - tableView: The table-view object informing the delegate of this impending event.
+  ///   - cell: A table-view cell object that tableView is going to use when drawing the row.
+  ///   - indexPath: An index path locating the row in tableView.
+  public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    if let spot = spot, let item = spot.item(at: indexPath) {
+      spot.delegate?.willDisplay(item: item, in: spot)
+    }
+  }
+
   /// Asks the delegate for a view object to display in the header of the specified section of the table view.
   ///
   /// - parameter tableView: The table-view object asking for the view object.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -115,9 +115,11 @@ extension Delegate: UITableViewDelegate {
   ///   - cell: A table-view cell object that tableView is going to use when drawing the row.
   ///   - indexPath: An index path locating the row in tableView.
   public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-    if let spot = spot, let item = spot.item(at: indexPath) {
-      spot.delegate?.willDisplay(item: item, in: spot)
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
     }
+
+    spot.delegate?.willDisplay(item: item, in: spot)
   }
 
   /// Asks the delegate for a view object to display in the header of the specified section of the table view.


### PR DESCRIPTION
This PR features new functionality for `SpotsDelegate`.

It now contains a new optional method:

```swift
func willDisplay(item: Item, in spot: Spotable)
```

It will be invoked in the following methods for collection views and table views.

```swift
/// iOS + tvOS
collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath)

tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath)

/// macOS

collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath)

tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int)
```