### PR TITLE
Add missing completion in reload if needed with items

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -392,6 +392,7 @@ public extension Spotable {
 
       if weakSelf.items == items {
         weakSelf.cache()
+        completion?()
         return
       }
 


### PR DESCRIPTION
I found a bug that the completion wasn't called when doing `reloadIfNeeded` on `Spotable` objects if the collections are equal. The completion was missing, this PR fixes that issue :)