### PR TITLE
Feature end display cell

### DIFF
--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -28,6 +28,19 @@ extension Delegate: NSCollectionViewDelegate {
 
     spot.delegate?.willDisplay(item: item, in: spot)
   }
+
+  /// Notifies the delegate that the specified item was removed from the collection view.
+  ///
+  /// - parameter collectionView: The collection view that removed the item.
+  /// - parameter item: The item that was removed.
+  /// - parameter indexPath: The index path of the item.
+  public func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.endDisplay(item: item, in: spot)
+  }
 }
 
 extension Delegate: NSCollectionViewDelegateFlowLayout {

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -392,6 +392,7 @@ public extension Spotable {
 
       if weakSelf.items == items {
         weakSelf.cache()
+        completion?()
         return
       }
 

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -48,6 +48,12 @@ public protocol SpotsDelegate: class {
   /// - parameter item: The data for the view that is going to be displayed.
   /// - parameter spot: An object that conforms to the spotable protocol.
   func willDisplay(item: Item, in spot: Spotable)
+
+  /// A delegate method that is triggered when ever a view will no longer be displayed.
+  ///
+  /// - parameter item: The data for the view that is going to be displayed.
+  /// - parameter spot: An object that conforms to the spotable protocol.
+  func endDisplay(item: Item, in spot: Spotable)
 }
 
 // MARK: - SpotsDelegate extension
@@ -65,6 +71,7 @@ public extension SpotsDelegate {
   func didChange(spots: [Spotable]) {}
 
   func willDisplay(item: Item, in spot: Spotable) {}
+  func endDisplay(item: Item, in spot: Spotable) {}
 }
 
 /// A refresh delegate for handling reloading of a Spot

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -32,18 +32,18 @@ extension CompositeDelegate {
 /// A generic delegate for Spots
 public protocol SpotsDelegate: class {
 
-  /// A delegate method that is triggered when spots is changed
+  /// A delegate method that is triggered when spots is changed.
   ///
   /// - parameter spots: New collection of Spotable objects
   func didChange(spots: [Spotable])
 
-  /// A delegate method that is triggered when ever a cell is tapped by the user
+  /// A delegate method that is triggered when ever a cell is tapped by the user.
   ///
   /// - parameter item: The data for the view that is going to be displayed.
   /// - parameter spot: An object that conforms to the spotable protocol.
   func didSelect(item: Item, in spot: Spotable)
 
-  /// A delegate method that is triggered when ever a view is going to be displayed
+  /// A delegate method that is triggered when ever a view is going to be displayed.
   ///
   /// - parameter item: The data for the view that is going to be displayed.
   /// - parameter spot: An object that conforms to the spotable protocol.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -37,6 +37,19 @@ extension Delegate: UICollectionViewDelegate {
     spot.delegate?.willDisplay(item: item, in: spot)
   }
 
+  /// Tells the delegate that the specified cell was removed from the collection view.
+  ///
+  /// - parameter collectionView: The collection view object that removed the cell.
+  /// - parameter cell: The cell object that was removed.
+  /// - parameter indexPath: The index path of the data item that the cell represented.
+  public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.endDisplay(item: item, in: spot)
+  }
+
   /// Asks the delegate whether the item at the specified index path can be focused.
   ///
   /// - parameter collectionView: The collection view object requesting this information.
@@ -120,6 +133,19 @@ extension Delegate: UITableViewDelegate {
     }
 
     spot.delegate?.willDisplay(item: item, in: spot)
+  }
+
+  /// Tells the delegate that the specified cell was removed from the table.
+  ///
+  /// - parameter tableView: The table-view object that removed the view.
+  /// - parameter cell: The cell that was removed.
+  /// - parameter indexPath: The index path of the cell.
+  public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    guard let spot = spot, let item = spot.item(at: indexPath) else {
+      return
+    }
+
+    spot.delegate?.endDisplay(item: item, in: spot)
   }
 
   /// Asks the delegate for a view object to display in the header of the specified section of the table view.


### PR DESCRIPTION
**This is based on https://github.com/hyperoslo/Spots/pull/376 so that should be merge first**

This PR adds one new method to `SpotsDelegate`.

```swift
func endDisplay(item: Item, in spot: Spotable)
```

This method is invoked when a cell is ending its display cycle.

It corresponds to the following methods;

```swift
# iOS & tvOS
func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath)

func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath)

# macOS

func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath)
```

Note that there are no such method for `NSTableView` on macOS. I might be mistaken here but I couldn't find one at least. Please correct me if I'm wrong here.