### PR TITLE
Improve/will display end display

### DIFF
--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -22,11 +22,14 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item being added.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    guard let spot = spot, let item = spot.item(at: indexPath) else {
-      return
+    guard
+      let spot = spot,
+      let data = spot.item(at: indexPath)
+      else {
+        return
     }
 
-    spot.delegate?.willDisplay(item: item, in: spot)
+    spot.delegate?.willDisplay(view: item, item: data, in: spot)
   }
 
   /// Notifies the delegate that the specified item was removed from the collection view.
@@ -35,11 +38,14 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item that was removed.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    guard let spot = spot, let item = spot.item(at: indexPath) else {
-      return
+    guard
+      let spot = spot,
+      let data = spot.item(at: indexPath)
+      else {
+        return
     }
 
-    spot.delegate?.endDisplay(item: item, in: spot)
+    spot.delegate?.endDisplay(view: item, item: data, in: spot)
   }
 }
 
@@ -113,11 +119,15 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {
-    guard let spot = spot, let item = spot.item(at: row) else {
-      return
+    guard
+      let spot = spot,
+      let item = spot.item(at: row),
+      let view = cell as? View
+      else {
+        return
     }
 
-    spot.delegate?.willDisplay(item: item, in: spot)
+    spot.delegate?.willDisplay(view: view, item: item, in: spot)
   }
 
   public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -22,14 +22,16 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item being added.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
+    let view = item
+
     guard
       let spot = spot,
-      let data = spot.item(at: indexPath)
+      let item = spot.item(at: indexPath)
       else {
         return
     }
 
-    spot.delegate?.willDisplay(view: item, item: data, in: spot)
+    spot.delegate?.willDisplay(view: view, item: item, in: spot)
   }
 
   /// Notifies the delegate that the specified item was removed from the collection view.
@@ -38,14 +40,16 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item that was removed.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
+    let view = item
+
     guard
       let spot = spot,
-      let data = spot.item(at: indexPath)
+      let item = spot.item(at: indexPath)
       else {
         return
     }
 
-    spot.delegate?.endDisplay(view: item, item: data, in: spot)
+    spot.delegate?.endDisplay(view: view, item: item, in: spot)
   }
 }
 

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -17,7 +17,6 @@ open class ViewSpot: NSObject, Spotable, Viewable {
     completion?()
   }
 
-
   /// A Registry struct that contains all register components, used for resolving what UI component to use
   open static var headers = Registry()
   open static var views = Registry()

--- a/Sources/Shared/Extensions/Component+Extension.swift
+++ b/Sources/Shared/Extensions/Component+Extension.swift
@@ -12,7 +12,6 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
     return property(name.string)
   }
 
-
   /// Resolve relations with key
   /// - parameter name: The name of the property that you want to map
   ///

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -112,7 +112,6 @@ public extension Spotable {
     #endif
   }
 
-
   /// Update the height of the UI Component
   ///
   /// - parameter completion: A completion closure that will be run in the main queue when the size has been updated.
@@ -255,7 +254,6 @@ public extension Spotable {
     return render().frame.size
   }
 
-
   /// Get identifier for item at index path
   ///
   /// - parameter indexPath: The index path for the item
@@ -268,7 +266,6 @@ public extension Spotable {
       return identifier(at: indexPath.row)
     #endif
   }
-
 
   /// Lookup identifier at index.
   ///
@@ -284,13 +281,11 @@ public extension Spotable {
     return item.kind
   }
 
-
   /// Register and prepare all items in the Spotable object.
   func registerAndPrepare() {
     register()
     prepareItems()
   }
-
 
   /// Update height and refresh indexes for the Spotable object.
   ///
@@ -311,7 +306,6 @@ public extension Spotable {
     }
   }
 
-
   /// Register a composite view for the Spotable component.
   ///
   /// - parameter view: The view type that should be used as the composite view for the Spotable object.
@@ -321,7 +315,6 @@ public extension Spotable {
     }
   }
 
-
   /// Register a nib file with identifier on the Spotable object.
   ///
   /// - parameter nib:        A Nib file that should be used for identifier
@@ -330,7 +323,6 @@ public extension Spotable {
     self.views.storage[identifier.string] = Registry.Item.nib(nib)
   }
 
-
   /// Register a view with an identifier
   ///
   /// - parameter view:       The view type that should be registered with an identifier.
@@ -338,7 +330,6 @@ public extension Spotable {
   public static func register(view: View.Type, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
   }
-
 
   /// Register a default view for the Spotable object.
   ///

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -151,7 +151,6 @@ extension SpotsProtocol {
     yOffset += spot.render().frame.size.height
   }
 
-
   /// Remove Spot at index
   ///
   /// - parameter index: The index of the Spotable object hat you want to remove
@@ -356,7 +355,6 @@ extension SpotsProtocol {
       }
     }
   }
-
 
   ///Reload if needed using JSON
   ///

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -80,7 +80,6 @@ public extension Spotable where Self : Viewable {
       view.frame.size = size
     }
 
-
     scrollView.addSubview(view)
     component.items.append(item)
   }

--- a/Sources/Shared/Protocols/SpotView.swift
+++ b/Sources/Shared/Protocols/SpotView.swift
@@ -1,0 +1,8 @@
+import Cocoa
+
+public protocol SpotView {
+
+}
+
+extension NSView : SpotView {}
+extension NSCollectionViewItem : SpotView {}

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -47,13 +47,13 @@ public protocol SpotsDelegate: class {
   ///
   /// - parameter item: The data for the view that is going to be displayed.
   /// - parameter spot: An object that conforms to the spotable protocol.
-  func willDisplay(item: Item, in spot: Spotable)
+  func willDisplay(view: SpotView, item: Item, in spot: Spotable)
 
   /// A delegate method that is triggered when ever a view will no longer be displayed.
   ///
   /// - parameter item: The data for the view that is going to be displayed.
   /// - parameter spot: An object that conforms to the spotable protocol.
-  func endDisplay(item: Item, in spot: Spotable)
+  func endDisplay(view: SpotView, item: Item, in spot: Spotable)
 }
 
 // MARK: - SpotsDelegate extension
@@ -70,8 +70,8 @@ public extension SpotsDelegate {
   /// - parameter spots: The collection of new Spotable objects.
   func didChange(spots: [Spotable]) {}
 
-  func willDisplay(item: Item, in spot: Spotable) {}
-  func endDisplay(item: Item, in spot: Spotable) {}
+  func willDisplay(view: SpotView, item: Item, in spot: Spotable) {}
+  func endDisplay(view: SpotView, item: Item, in spot: Spotable) {}
 }
 
 /// A refresh delegate for handling reloading of a Spot

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -209,7 +209,6 @@ public struct Component: Mappable, Equatable {
     return defaultValue
   }
 
-
   /// A generic convenience method for resolving meta attributes
   ///
   /// - parameter key: String
@@ -218,7 +217,6 @@ public struct Component: Mappable, Equatable {
   public func meta<T>(_ key: String, type: T.Type) -> T? {
     return meta[key] as? T
   }
-
 
   ///Compare two components
   ///
@@ -270,7 +268,6 @@ public func == (lhs: [Component], rhs: [Component]) -> Bool {
   return equal
 }
 
-
 /// Compare two collections of Components to see if they are truly equal
 ///
 /// - parameter lhs: Left hand component
@@ -289,7 +286,6 @@ public func === (lhs: [Component], rhs: [Component]) -> Bool {
   return equal
 }
 
-
 /// Check if to collection of components are not equal
 ///
 /// - parameter lhs: Left hand component
@@ -299,7 +295,6 @@ public func === (lhs: [Component], rhs: [Component]) -> Bool {
 public func != (lhs: [Component], rhs: [Component]) -> Bool {
   return !(lhs == rhs)
 }
-
 
 /// Check if to collection of components are truly not equal
 ///
@@ -312,7 +307,6 @@ public func !== (lhs: [Component], rhs: [Component]) -> Bool {
 }
 
 /// Compare view models
-
 
 /// Check if to components are equal
 ///
@@ -329,7 +323,6 @@ public func == (lhs: Component, rhs: Component) -> Bool {
     lhs.header == rhs.header &&
     (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary)
 }
-
 
 /// Check if to components are truly equal
 ///
@@ -352,7 +345,6 @@ public func === (lhs: Component, rhs: Component) -> Bool {
     lhs.items === rhs.items
 }
 
-
 /// Check if to components are not equal
 ///
 /// - parameter lhs: Left hand component
@@ -362,7 +354,6 @@ public func === (lhs: Component, rhs: Component) -> Bool {
 public func != (lhs: Component, rhs: Component) -> Bool {
   return !(lhs == rhs)
 }
-
 
 /// Check if to components are truly not equal
 ///

--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -32,6 +32,8 @@ public typealias Completion = (() -> Void)?
     }
   }
 #else
+  /// A type alias to reference a view passed to delegate method
+  public typealias SpotView = UIView
   /// A type alias to reference a normal platform view
   public typealias View = UIView
   /// A type alias to reference a normal scroll view

--- a/Sources/iOS/Classes/CarouselSpotCell.swift
+++ b/Sources/iOS/Classes/CarouselSpotCell.swift
@@ -26,7 +26,6 @@ public class CarouselSpotCell: UICollectionViewCell, SpotConfigurable {
     return imageView
   }()
 
-
   /// Initializes and returns a newly allocated view object with the specified frame rectangle.
   ///
   /// - parameter frame: The frame rectangle for the view, measured in points.

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -282,7 +282,6 @@ open class Controller: UIViewController, SpotsProtocol, CompositeDelegate, UIScr
     }
   }
 
-
   /// Set up Spotable objects.
   ///
   /// - parameter animated: An optional animation closure that is invoked when setting up the spot.

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -117,7 +117,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     return attributes
   }
 
-
   /// Asks the layout object if the new bounds require a layout update.
   ///
   /// - parameter newBounds: The new bounds of the collection view.

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -26,7 +26,6 @@ open class SpotsScrollView: UIScrollView {
   /// A container view that works as a proxy layer for scroll view
   open var contentView: SpotsContentView = SpotsContentView()
 
-
   /// A deinitiazlier that removes all subviews from contentView
   deinit {
     for subview in observedViews {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -34,7 +34,7 @@ extension Delegate: UICollectionViewDelegate {
       return
     }
 
-    spot.delegate?.willDisplay(item: item, in: spot)
+    spot.delegate?.willDisplay(view: cell, item: item, in: spot)
   }
 
   /// Tells the delegate that the specified cell was removed from the collection view.
@@ -47,7 +47,7 @@ extension Delegate: UICollectionViewDelegate {
       return
     }
 
-    spot.delegate?.endDisplay(item: item, in: spot)
+    spot.delegate?.endDisplay(view: cell, item: item, in: spot)
   }
 
   /// Asks the delegate whether the item at the specified index path can be focused.
@@ -132,7 +132,7 @@ extension Delegate: UITableViewDelegate {
       return
     }
 
-    spot.delegate?.willDisplay(item: item, in: spot)
+    spot.delegate?.willDisplay(view: cell, item: item, in: spot)
   }
 
   /// Tells the delegate that the specified cell was removed from the table.
@@ -145,7 +145,7 @@ extension Delegate: UITableViewDelegate {
       return
     }
 
-    spot.delegate?.endDisplay(item: item, in: spot)
+    spot.delegate?.endDisplay(view: cell, item: item, in: spot)
   }
 
   /// Asks the delegate for a view object to display in the header of the specified section of the table view.

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -35,7 +35,6 @@ extension Gridable {
     layout.minimumInteritemSpacing = itemSpacing
   }
 
-
   /// Asks the data source for the size of an item in a particular location.
   ///
   /// - parameter indexPath: The index path of the

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -55,7 +55,6 @@ extension UICollectionView: UserInterface {
     completion?()
   }
 
-
   /// Process a collection of changes
   ///
   /// - parameter changes:          A tuple with insertions, reloads and delctions

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -64,7 +64,6 @@ extension UITableView: UserInterface {
     completion?()
   }
 
-
   /// Process a collection of changes
   ///
   /// - parameter changes:          A tuple with insertions, reloads and delctions
@@ -107,7 +106,6 @@ extension UITableView: UserInterface {
     }
     completion?()
   }
-
 
   /// Perform updates with closure
   ///

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
 		BD7397401D718CDB000AF2DE /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		BD73974B1D718D38000AF2DE /* CollectionAdapter+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */; };
+		BD7861831DEEDF2B003FF40F /* SpotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7861821DEEDF2B003FF40F /* SpotView.swift */; };
 		BD8B1EB21D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
 		BD8B1EB31D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
 		BD8B1EB41D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
@@ -345,6 +346,7 @@
 		BD73972F1D718CD2000AF2DE /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD7397461D718CDB000AF2DE /* Spots-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
+		BD7861821DEEDF2B003FF40F /* SpotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotView.swift; sourceTree = "<group>"; };
 		BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrandCentralDispatch.swift; sourceTree = "<group>"; };
 		BD978ACC1DD99A4700B8F7AB /* Spotable+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Spotable+Mutation.swift"; sourceTree = "<group>"; };
 		BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestRowSpot.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				BD129F3D1D7B2F91009AC164 /* SpotsProtocol.swift */,
 				BD63B04F1DD8D30400C52D73 /* UserInterface.swift */,
 				BD129F3E1D7B2F91009AC164 /* Viewable.swift */,
+				BD7861821DEEDF2B003FF40F /* SpotView.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1336,6 +1339,7 @@
 				BD129F491D7B2F91009AC164 /* Registry.swift in Sources */,
 				BD129E281D7B2CDE009AC164 /* NoScrollView.swift in Sources */,
 				BD129E331D7B2CDE009AC164 /* NSCollectionView+UserInterface.swift in Sources */,
+				BD7861831DEEDF2B003FF40F /* SpotView.swift in Sources */,
 				BD129E2A1D7B2CDE009AC164 /* Controller.swift in Sources */,
 				BD129F8E1D7B2F91009AC164 /* Parser.swift in Sources */,
 				BD129F4C1D7B2F91009AC164 /* SpotFactory.swift in Sources */,


### PR DESCRIPTION
This PR improves the newly introduced delegate methods for when a view is displayed and when the life cycle end for the view.

The changes is that it will no return the view that is going to be or was displayed in the collection.

```swift
# Before
func willDisplay(item: Item, in spot: Spotable)
func endDisplay(item: Item, in spot: Spotable)

# After
func willDisplay(view: SpotView, item: Item, in spot: Spotable)
func endDisplay(view: SpotView, item: Item, in spot: Spotable)
```