### PR TITLE
Improve/spotable mutation

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -36,6 +36,7 @@ public extension Spotable {
           weakSelf.userInterface?.insert([numberOfItems], withAnimation: animation, completion: nil)
           weakSelf.updateHeight() {
             weakSelf.afterUpdate()
+            weakSelf.render().superview?.layoutSubviews()
             completion?()
           }
         }
@@ -70,6 +71,7 @@ public extension Spotable {
       } else {
         weakSelf.userInterface?.reloadDataSource()
         weakSelf.updateHeight() {
+          weakSelf.render().superview?.layoutSubviews()
           completion?()
         }
       }
@@ -111,6 +113,7 @@ public extension Spotable {
         weakSelf.userInterface?.reloadDataSource()
         weakSelf.afterUpdate()
         weakSelf.sanitize {
+          weakSelf.render().superview?.layoutSubviews()
           completion?()
         }
       }
@@ -147,6 +150,7 @@ public extension Spotable {
       }
       weakSelf.afterUpdate()
       weakSelf.sanitize {
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -169,6 +173,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -201,6 +206,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete(indexPaths, withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -222,6 +228,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -246,6 +253,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete(indexes, withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -277,6 +285,7 @@ public extension Spotable {
           composite.configure(&weakSelf.component.items[index], spots: spots)
           weakSelf.userInterface?.endUpdates()
           weakSelf.updateHeight() {
+            weakSelf.render().superview?.layoutSubviews()
             completion?()
           }
           return
@@ -293,14 +302,17 @@ public extension Spotable {
         }
         weakSelf.afterUpdate()
         weakSelf.updateHeight {
+          weakSelf.render().superview?.layoutSubviews()
           completion?()
         }
         return
       } else if let cell: SpotConfigurable = weakSelf.userInterface?.view(at: index) {
         cell.configure(&weakSelf.items[index])
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       } else {
         weakSelf.afterUpdate()
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -347,6 +359,7 @@ public extension Spotable {
             weakSelf.userInterface?.reloadDataSource()
           }
         }
+        weakSelf.render().superview?.layoutSubviews()
         completion?()
       }
     }
@@ -459,6 +472,7 @@ public extension Spotable {
           return
         }
         weakSelf.afterUpdate()
+        weakSelf.render().superview?.layoutSubviews()
         weakSelf.cache()
       }
     }

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -419,10 +419,6 @@ public extension Spotable {
             if indexes == nil { indexes = [Int]() }
             indexes?.append(index)
           }
-        } else {
-          for (index, _) in items.enumerated() {
-            weakSelf.configureItem(at: index, usesViewSize: true)
-          }
         }
 
         weakSelf.reload(indexes, withAnimation: animation) {

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -146,7 +146,9 @@ public extension Spotable {
         weakSelf.userInterface?.reloadDataSource()
       }
       weakSelf.afterUpdate()
-      weakSelf.sanitize { completion?() }
+      weakSelf.sanitize {
+        completion?()
+      }
     }
   }
 
@@ -198,7 +200,9 @@ public extension Spotable {
 
       weakSelf.userInterface?.delete(indexPaths, withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
-      weakSelf.sanitize { completion?() }
+      weakSelf.sanitize {
+        completion?()
+      }
     }
   }
 

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -257,8 +257,8 @@ public extension Spotable {
     Dispatch.mainQueue { [weak self] in
       guard let weakSelf = self,
         let oldItem = weakSelf.item(at: index) else {
-        completion?()
-        return
+          completion?()
+          return
       }
 
       weakSelf.items[index] = item

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -391,8 +391,11 @@ public extension Spotable {
       }
 
       if weakSelf.items == items {
-        weakSelf.cache()
-        completion?()
+        Dispatch.mainQueue { [weak self] in
+          weakSelf.cache()
+          completion?()
+          weakSelf.render().superview?.layoutSubviews()
+        }
         return
       }
 
@@ -422,8 +425,8 @@ public extension Spotable {
           }
         }
 
-        weakSelf.updateHeight() {
-          weakSelf.reload(indexes, withAnimation: animation) {
+        weakSelf.reload(indexes, withAnimation: animation) {
+          weakSelf.updateHeight() {
             weakSelf.afterUpdate()
             weakSelf.cache()
             completion?()


### PR DESCRIPTION
This PR improves the `Spotable` mutation methods.

First, it fixes a bug where `updateHeight` was run before the items were configured.

Second, it will call `layoutSubviews` on superview if you perform operations directly on the `Spotable` object. This means that you are free to target the UI component that you want to mutate instead of being force to use the proxy methods on `Controller`.