### PR TITLE
Internal/refactoring

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -74,6 +74,7 @@ extension SpotsProtocol {
       let changes = weakSelf.generateChanges(from: newComponents, and: oldComponents)
 
       weakSelf.process(changes: changes, components: newComponents, withAnimation: animation) {
+        weakSelf.cache()
         completion?()
         if let controller = self as? Controller {
           Controller.spotsDidReloadComponents?(controller)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -175,7 +175,9 @@ extension SpotsProtocol {
     let newItems = spot.prepare(items: newComponents[index].items)
     let oldItems = spot.items
 
-    guard let diff = Item.evaluate(newItems, oldModels: oldItems) else { return true }
+    guard let diff = Item.evaluate(newItems, oldModels: oldItems) else {
+      return true
+    }
     let changes: (ItemChanges) = Item.processChanges(diff)
 
     if newItems.count == spot.items.count {

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -174,7 +174,7 @@ extension SpotsProtocol {
     let newItems = spot.prepare(items: newComponents[index].items)
     let oldItems = spot.items
 
-    guard let diff = Item.evaluate(newItems, oldModels: oldItems) else { completion?(); return false }
+    guard let diff = Item.evaluate(newItems, oldModels: oldItems) else { return true }
     let changes: (ItemChanges) = Item.processChanges(diff)
 
     if newItems.count == spot.items.count {

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -62,12 +62,6 @@ extension SpotsProtocol {
       let newComponents = components
 
       guard compare(newComponents, oldComponents) else {
-        weakSelf.cache()
-        Dispatch.mainQueue { completion?() }
-        return
-      }
-
-      guard newComponents !== oldComponents else {
         Dispatch.mainQueue { completion?() }
         return
       }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -45,7 +45,9 @@ extension SpotsProtocol {
                              completion: Completion = nil) {
     guard !components.isEmpty else {
       Dispatch.mainQueue { [weak self] in
-        self?.spots.forEach { $0.render().removeFromSuperview() }
+        self?.spots.forEach {
+          $0.render().removeFromSuperview()
+        }
         self?.spots = []
         completion?()
       }
@@ -62,7 +64,10 @@ extension SpotsProtocol {
       let newComponents = components
 
       guard compare(newComponents, oldComponents) else {
-        Dispatch.mainQueue { completion?() }
+        weakSelf.cache()
+        Dispatch.mainQueue {
+          completion?()
+        }
         return
       }
 


### PR DESCRIPTION
This PR improves reloading with components.

- [x] Remove duplicate comparison of collections of components.
- [x] Call `cache` in completion for `reloadIfNeeded` with `[Component]`
- [x] Return true in `setupItemsForSpot` if diff returns nil. This will cause the completion to run once.
- [x] Internal code refactoring to use a better debug-friendly code-style.