### PR TITLE
Compare title when diffing Component

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -324,7 +324,7 @@ extension SpotsProtocol {
 
       for (index, change) in changes.enumerated() {
         switch change {
-        case .identifier, .kind, .span, .header, .meta:
+        case .identifier, .title, .kind, .span, .header, .meta:
           weakSelf.replaceSpot(index, newComponents: newComponents, yOffset: &yOffset)
         case .new:
           weakSelf.newSpot(index, newComponents: newComponents, yOffset: &yOffset)

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -19,7 +19,7 @@ import Brick
 /// - removed:    Indicates that the component was removed
 /// - none:       Indicates that nothing did change
 public enum ComponentDiff {
-  case identifier, kind, span, header, meta, items, new, removed, none
+  case identifier, title, kind, span, header, meta, items, new, removed, none
 }
 
 /// The Component struct is used to configure a Spotable object
@@ -234,6 +234,8 @@ public struct Component: Mappable, Equatable {
     if header != component.header { return .header }
     // Check if meta data for the component changed, this can be up to the developer to decide what course of action to take.
     if !(meta as NSDictionary).isEqual(to: component.meta) { return .meta }
+    // Check if title changed
+    if title != component.title { return .title }
     // Check if the items have changed
     if !(items === component.items) { return .items }
     // Check children


### PR DESCRIPTION
This PR improves the diffing `Component`. Before we didn’t take into account that the component title may change. This issue is now resolved.