### PR TITLE
Add amount of items to print statement when using live reloading

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -58,7 +58,7 @@ import Cache
               }
               #endif
             }
-            print("🎍 Spots reloaded: \(weakSelf.spots.count)")
+            print("🎍 SPOTS reloaded: \(weakSelf.spots.count) -> items: \(weakSelf.spots.reduce(0, { $0.1.items.count }))")
             weakSelf.liveEditing(stateCache: weakSelf.stateCache)
           }
         } catch _ {


### PR DESCRIPTION
This PR improve how live reloading prints it's debug information. It adds the amount of items that are reloaded in the view.