### PR TITLE
Call layoutIfNeeded instead of scrollView.layoutSubviews()

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -537,7 +537,7 @@ extension SpotsProtocol {
         spot.updateHeight() { [weak self] in
           spot.afterUpdate()
           completion?()
-          self?.scrollView.layoutSubviews()
+          spot.render().layoutIfNeeded()
         }
       }
     }


### PR DESCRIPTION
This will cause the spot to layout instead of the scrollview.