### PR TITLE
Improve/reload with components

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -390,7 +390,7 @@ extension SpotsProtocol {
       }
 
       for removedSpot in weakSelf.spots where removedSpot.render().superview == nil {
-        if let index = weakSelf.spots.index(where: { removedSpot.component == $0.component }) {
+        if let index = weakSelf.spots.index(where: { removedSpot.render().isEqual($0.render()) }) {
           weakSelf.spots.remove(at: index)
         }
       }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -534,7 +534,7 @@ extension SpotsProtocol {
       #endif
 
       spot.reload(nil, withAnimation: animation) {
-        spot.updateHeight() { [weak self] in
+        spot.updateHeight() {
           spot.afterUpdate()
           completion?()
           spot.render().layoutIfNeeded()

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -39,6 +39,18 @@ public struct Parser {
     return components
   }
 
+  /// Parse JSON into a collection of Components.
+  ///
+  /// - parameter json: A JSON dictionary of components and items.
+  /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
+  ///
+  /// - returns: A collection of `Component`s
+  public static func parse(_ json: [String : Any]?, key: String = "components") -> [Component] {
+    guard let payload = json else { return [] }
+
+    return Parser.parse(payload)
+  }
+
   /// Parse JSON into a collection of Spotable objects.
   ///
   /// - parameter json: A JSON dictionary of components and items.

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -302,7 +302,7 @@ open class Controller: UIViewController, SpotsProtocol, UIScrollViewDelegate {
     }
 
     spot.render().frame.origin.x = 0.0
-    spots[index].component.index = index
+    spot.component.index = index
     spot.setup(superview.frame.size)
     spot.component.size = CGSize(
       width: superview.frame.width,


### PR DESCRIPTION
This PR fixes a bug where the wrong Spotable object can be removed. This happened because you might have two `Component`'s that are equal in your data. This is fixed by comparing using reference type instead of value type.

So instead of:

```swift
if let index = weakSelf.spots.index(where: { removedSpot.component == $0.component })
```

We compare using `isEqual`

```swift
if let index = weakSelf.spots.index(where: { removedSpot.render().isEqual($0.render()) })
```

The parser also got a bit of love. It can now accept optional payloads.