### PR TITLE
Improve layouting after reload

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -196,11 +196,47 @@ extension SpotsProtocol {
     }
 
     if newItems.count == spot.items.count {
-      reload(with: changes, in: spot, newItems: newItems, animation: animation, completion: completion)
+      reload(with: changes, in: spot, newItems: newItems, animation: animation) { [weak self] in
+        if let weakSelf = self, let completion = completion {
+          for spot in weakSelf.spots {
+            spot.setup(weakSelf.scrollView.frame.size)
+            spot.layout(weakSelf.scrollView.frame.size)
+            spot.render().layoutSubviews()
+          }
+
+          weakSelf.scrollView.layoutViews()
+
+          completion()
+        }
+      }
     } else if newItems.count < spot.items.count {
-      reload(with: changes, in: spot, lessItems: newItems, animation: animation, completion: completion)
+      reload(with: changes, in: spot, lessItems: newItems, animation: animation) { [weak self] in
+        if let weakSelf = self, let completion = completion {
+          for spot in weakSelf.spots {
+            spot.setup(weakSelf.scrollView.frame.size)
+            spot.layout(weakSelf.scrollView.frame.size)
+            spot.render().layoutSubviews()
+          }
+
+          weakSelf.scrollView.layoutViews()
+
+          completion()
+        }
+      }
     } else if newItems.count > spot.items.count {
-      reload(with: changes, in: spot, moreItems: newItems, animation: animation, completion: completion)
+      reload(with: changes, in: spot, moreItems: newItems, animation: animation) { [weak self] in
+        if let weakSelf = self, let completion = completion {
+          for spot in weakSelf.spots {
+            spot.setup(weakSelf.scrollView.frame.size)
+            spot.layout(weakSelf.scrollView.frame.size)
+            spot.render().layoutSubviews()
+          }
+
+          weakSelf.scrollView.layoutViews()
+
+          completion()
+        }
+      }
     }
 
     return false

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -411,15 +411,7 @@ extension SpotsProtocol {
       }
 
       if runCompletion {
-        for spot in weakSelf.spots {
-          spot.setup(weakSelf.scrollView.frame.size)
-          spot.layout(weakSelf.scrollView.frame.size)
-          spot.render().layoutSubviews()
-        }
-        #if !os(OSX)
-          weakSelf.scrollView.layoutSubviews()
-        #endif
-
+        weakSelf.setupAndLayoutSpots()
         finalCompletion?()
       }
     }
@@ -724,16 +716,22 @@ extension SpotsProtocol {
     }
   }
 
+  func setupAndLayoutSpot(spot: Spotable) {
+    spot.setup(scrollView.frame.size)
+    spot.component.size = CGSize(
+      width: spot.render().frame.size.width,
+      height: ceil(spot.render().frame.size.height))
+    spot.layout(scrollView.frame.size)
+    spot.render().layoutSubviews()
+  }
+
   fileprivate func setupAndLayoutSpots() {
     for spot in spots {
-      spot.setup(scrollView.frame.size)
-      spot.component.size = CGSize(
-        width: spot.render().frame.size.width,
-        height: ceil(spot.render().frame.size.height))
-      spot.layout(scrollView.frame.size)
-      spot.render().layoutSubviews()
+      setupAndLayoutSpot(spot: spot)
     }
 
-    scrollView.layoutSubviews()
+    #if !os(OSX)
+      scrollView.layoutSubviews()
+    #endif
   }
 }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -198,42 +198,21 @@ extension SpotsProtocol {
     if newItems.count == spot.items.count {
       reload(with: changes, in: spot, newItems: newItems, animation: animation) { [weak self] in
         if let weakSelf = self, let completion = completion {
-          for spot in weakSelf.spots {
-            spot.setup(weakSelf.scrollView.frame.size)
-            spot.layout(weakSelf.scrollView.frame.size)
-            spot.render().layoutSubviews()
-          }
-
-          weakSelf.scrollView.layoutViews()
-
+          weakSelf.setupAndLayoutSpots()
           completion()
         }
       }
     } else if newItems.count < spot.items.count {
       reload(with: changes, in: spot, lessItems: newItems, animation: animation) { [weak self] in
         if let weakSelf = self, let completion = completion {
-          for spot in weakSelf.spots {
-            spot.setup(weakSelf.scrollView.frame.size)
-            spot.layout(weakSelf.scrollView.frame.size)
-            spot.render().layoutSubviews()
-          }
-
-          weakSelf.scrollView.layoutViews()
-
+          weakSelf.setupAndLayoutSpots()
           completion()
         }
       }
     } else if newItems.count > spot.items.count {
       reload(with: changes, in: spot, moreItems: newItems, animation: animation) { [weak self] in
         if let weakSelf = self, let completion = completion {
-          for spot in weakSelf.spots {
-            spot.setup(weakSelf.scrollView.frame.size)
-            spot.layout(weakSelf.scrollView.frame.size)
-            spot.render().layoutSubviews()
-          }
-
-          weakSelf.scrollView.layoutViews()
-
+          weakSelf.setupAndLayoutSpots()
           completion()
         }
       }
@@ -743,5 +722,18 @@ extension SpotsProtocol {
     scrollView.spotsContentView.subviews.forEach {
       $0.removeFromSuperview()
     }
+  }
+
+  fileprivate func setupAndLayoutSpots() {
+    for spot in spots {
+      spot.setup(scrollView.frame.size)
+      spot.component.size = CGSize(
+        width: spot.render().frame.size.width,
+        height: ceil(spot.render().frame.size.height))
+      spot.layout(scrollView.frame.size)
+      spot.render().layoutSubviews()
+    }
+
+    scrollView.layoutSubviews()
   }
 }


### PR DESCRIPTION
This PR fixes some layout issues that can occur if the reloaded Spotable objects are not properly setup and rendered when changing it's properties.

Now every time a Spotable object changes it will try redraw itself accordingly.