### PR TITLE
Initial implementation of improved focus for tvOS

### DIFF
--- a/Sources/Shared/Classes/CompositeSpot.swift
+++ b/Sources/Shared/Classes/CompositeSpot.swift
@@ -19,6 +19,8 @@ public struct CompositeSpot: Equatable {
     self.itemIndex = itemIndex
     self.parentSpot = parentSpot
     self.spot = spot
+    #if !os(OSX)
     self.spot.focusDelegate = parentSpot?.focusDelegate
+    #endif
   }
 }

--- a/Sources/Shared/Classes/CompositeSpot.swift
+++ b/Sources/Shared/Classes/CompositeSpot.swift
@@ -16,8 +16,9 @@ public struct CompositeSpot: Equatable {
   var itemIndex: Int
 
   init(spot: Spotable, parentSpot: Spotable? = nil, itemIndex: Int) {
-    self.spot = spot
-    self.parentSpot = parentSpot
     self.itemIndex = itemIndex
+    self.parentSpot = parentSpot
+    self.spot = spot
+    self.spot.focusDelegate = parentSpot?.focusDelegate
   }
 }

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -7,9 +7,6 @@ import Brick
 
 open class ViewSpot: NSObject, Spotable, Viewable {
 
-  /// Child spots
-  public var compositeSpots: [CompositeSpot] = []
-
   /// Reload spot with ItemChanges.
   ///
   /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
@@ -30,8 +27,13 @@ open class ViewSpot: NSObject, Spotable, Viewable {
   open weak var delegate: SpotsDelegate?
   open var component: Component
   open var index = 0
-
   open var configure: ((SpotConfigurable) -> Void)?
+
+  /// A SpotsFocusDelegate object
+  weak public var focusDelegate: SpotsFocusDelegate?
+
+  /// Child spots
+  public var compositeSpots: [CompositeSpot] = []
 
   open lazy var scrollView: ScrollView = ScrollView()
 

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -280,8 +280,9 @@ public extension Spotable {
 
       if weakSelf.items[index].kind == "composite" {
         if let compositeView: Composable? = weakSelf.userInterface?.view(at: index) {
+          let compositeSpots = weakSelf.compositeSpots.filter { $0.itemIndex == item.index }
           compositeView?.configure(&weakSelf.items[index],
-                                   compositeSpots: weakSelf.compositeSpots.filter { $0.itemIndex == item.index })
+                                   compositeSpots: compositeSpots)
         } else {
           for compositeSpot in weakSelf.compositeSpots {
             compositeSpot.spot.setup(weakSelf.render().frame.size)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -82,9 +82,6 @@ extension SpotsProtocol {
             Controller.spotsDidReloadComponents?(controller)
           }
 
-          print("weakSelf.focusedSpot: \(weakSelf.focusedSpot)")
-          print("selectedIndex: \(weakSelf.focusedItemIndex)")
-
           completion?()
         }
       }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -66,6 +66,7 @@ extension SpotsProtocol {
       guard compare(newComponents, oldComponents) else {
         weakSelf.cache()
         Dispatch.mainQueue {
+          weakSelf.scrollView.layoutViews()
           completion?()
         }
         return

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -81,6 +81,10 @@ extension SpotsProtocol {
           if let controller = self as? Controller {
             Controller.spotsDidReloadComponents?(controller)
           }
+
+          print("weakSelf.focusedSpot: \(weakSelf.focusedSpot)")
+          print("selectedIndex: \(weakSelf.focusedItemIndex)")
+
           completion?()
         }
       }

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -17,8 +17,10 @@ public protocol Spotable: class {
   /// Child spots
   var compositeSpots: [CompositeSpot] { get set }
 
-  /// A SpotsFocusDelegate object
-  weak var focusDelegate: SpotsFocusDelegate? { get set }
+  #if !os(OSX)
+    /// A SpotsFocusDelegate object
+    weak var focusDelegate: SpotsFocusDelegate? { get set }
+  #endif
 
   /// A SpotsDelegate object
   weak var delegate: SpotsDelegate? { get set }

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -17,6 +17,9 @@ public protocol Spotable: class {
   /// Child spots
   var compositeSpots: [CompositeSpot] { get set }
 
+  /// A SpotsFocusDelegate object
+  weak var focusDelegate: SpotsFocusDelegate? { get set }
+
   /// A SpotsDelegate object
   weak var delegate: SpotsDelegate? { get set }
 

--- a/Sources/Shared/Protocols/SpotsDelegates.swift
+++ b/Sources/Shared/Protocols/SpotsDelegates.swift
@@ -4,6 +4,11 @@ import Brick
   import UIKit
 #endif
 
+public protocol SpotsFocusDelegate: class {
+  var focusedSpot: Spotable? { get set }
+  var focusedItemIndex: Int? { get set }
+}
+
 /// A generic delegate for Spots
 public protocol SpotsDelegate: class {
 

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -7,7 +7,7 @@
 import Brick
 import Cache
 
-public protocol SpotsProtocol: class, SpotsFocusDelegate {
+public protocol SpotsProtocol: class {
 
   /// A closure that is called when the controller is reloaded with components
   static var spotsDidReloadComponents: ((_ controller: Controller) -> Void)? { get set }

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -7,7 +7,7 @@
 import Brick
 import Cache
 
-public protocol SpotsProtocol: class {
+public protocol SpotsProtocol: class, SpotsFocusDelegate {
 
   /// A closure that is called when the controller is reloaded with components
   static var spotsDidReloadComponents: ((_ controller: Controller) -> Void)? { get set }

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -5,13 +5,16 @@ public protocol UserInterface: class {
 
   #if !os(OSX)
   /// The index of the current selected item
+  @available(iOS 9.0, *)
   var selectedIndex: Int { get }
   /// The index of the current focused item
+  @available(iOS 9.0, *)
   var focusedIndex: Int { get }
 
   /// Focus on item at index
   ///
   /// - parameter index: The index of the item you want to focus.
+  @available(iOS 9.0, *)
   func focusOn(itemAt index: Int)
 
   /// Select item at index

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -3,17 +3,11 @@ import Brick
 /// A protocol used for composition inside Spotable objects
 public protocol UserInterface: class {
 
+  #if !os(OSX)
   /// The index of the current selected item
   var selectedIndex: Int { get }
   /// The index of the current focused item
   var focusedIndex: Int { get }
-
-  /// Find a generic UI component at index
-  ///
-  /// - parameter index: The index of the UI that you are looking for.
-  ///
-  /// - returns: Find UI element with generic type inferred.
-  func view<T>(at index: Int) -> T?
 
   /// Focus on item at index
   ///
@@ -31,6 +25,14 @@ public protocol UserInterface: class {
   /// - parameter index: The index of the item you want to deselect.
   /// - parameter animated: Performs an animation if set to true
   func deselect(itemAt index: Int, animated: Bool)
+  #endif
+
+  /// Find a generic UI component at index
+  ///
+  /// - parameter index: The index of the UI that you are looking for.
+  ///
+  /// - returns: Find UI element with generic type inferred.
+  func view<T>(at index: Int) -> T?
 
   ///  A convenience method for performing inserts on a UserInterface
   ///

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -3,12 +3,34 @@ import Brick
 /// A protocol used for composition inside Spotable objects
 public protocol UserInterface: class {
 
+  /// The index of the current selected item
+  var selectedIndex: Int { get }
+  /// The index of the current focused item
+  var focusedIndex: Int { get }
+
   /// Find a generic UI component at index
   ///
   /// - parameter index: The index of the UI that you are looking for.
   ///
   /// - returns: Find UI element with generic type inferred.
   func view<T>(at index: Int) -> T?
+
+  /// Focus on item at index
+  ///
+  /// - parameter index: The index of the item you want to focus.
+  func focusOn(itemAt index: Int)
+
+  /// Select item at index
+  ///
+  /// - parameter index: The index of the item you want to select.
+  /// - parameter animated: Performs an animation if set to true
+  func select(itemAt index: Int, animated: Bool)
+
+  /// Deselect item at index
+  ///
+  /// - parameter index: The index of the item you want to deselect.
+  /// - parameter animated: Performs an animation if set to true
+  func deselect(itemAt index: Int, animated: Bool)
 
   ///  A convenience method for performing inserts on a UserInterface
   ///

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -4,9 +4,6 @@ import Brick
 /// A CarouselSpot, a collection view based Spotable object that lays out its items in a horizontal order
 open class CarouselSpot: NSObject, Gridable {
 
-  /// Child spots
-  public var compositeSpots: [CompositeSpot] = []
-
   /**
    *  A struct that holds keys that is used when mapping meta data to configuration methods
    */
@@ -38,6 +35,12 @@ open class CarouselSpot: NSObject, Gridable {
     /// Default right section inset
     public static var contentInsetRight: CGFloat = 0.0
   }
+
+  /// Child spots
+  public var compositeSpots: [CompositeSpot] = []
+
+  /// A SpotsFocusDelegate object
+  weak public var focusDelegate: SpotsFocusDelegate?
 
   /// A boolean value that affects the sizing of items when using span, if enabled and the item count is less than the span, the CarouselSpot will even out the space between the items to align them
   open var dynamicSpan = false

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -42,7 +42,14 @@ open class Controller: UIViewController, SpotsProtocol, UIScrollViewDelegate {
   /// A collection of Spotable objects.
   open var spots: [Spotable] {
     didSet {
-      spots.forEach { $0.delegate = delegate }
+      spots.forEach {
+        $0.delegate = delegate
+        $0.focusDelegate = self
+
+        $0.compositeSpots.forEach {
+          $0.spot.focusDelegate = self
+        }
+      }
       delegate?.didChange(spots: spots)
     }
   }
@@ -307,6 +314,7 @@ open class Controller: UIViewController, SpotsProtocol, UIScrollViewDelegate {
     spot.component.size = CGSize(
       width: superview.frame.width,
       height: ceil(spot.render().frame.height))
+    spot.focusDelegate = self
     spot.registerAndPrepare()
 
     if !spot.items.isEmpty {

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -3,7 +3,7 @@ import Brick
 import Cache
 
 /// A controller powered by Spotable objects
-open class Controller: UIViewController, SpotsProtocol, UIScrollViewDelegate {
+open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UIScrollViewDelegate {
 
   open var contentView: View {
     return view

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -9,6 +9,9 @@ open class Controller: UIViewController, SpotsProtocol, UIScrollViewDelegate {
     return view
   }
 
+  public weak var focusedSpot: Spotable?
+  public var focusedItemIndex: Int?
+
   /// A closure that is called when the controller is reloaded with components
   public static var spotsDidReloadComponents: ((Controller) -> Void)?
 

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -4,9 +4,6 @@ import Brick
 /// A GridSpot, a collection view based Spotable object that lays out its items in a vertical order based of the item sizes
 open class GridSpot: NSObject, Gridable {
 
-  /// Child spots
-  public var compositeSpots: [CompositeSpot] = []
-
   /**
    *  Keys for meta data lookup
    */
@@ -47,6 +44,12 @@ open class GridSpot: NSObject, Gridable {
 
   /// A Registry object that holds identifiers and classes for headers used in the GridSpot
   open static var headers = Registry()
+
+  /// A SpotsFocusDelegate object
+  weak public var focusDelegate: SpotsFocusDelegate?
+
+  /// Child spots
+  public var compositeSpots: [CompositeSpot] = []
 
   /// A component struct used as configuration and data source for the GridSpot
   open var component: Component

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -4,9 +4,6 @@ import Brick
 /// A Spotable object that uses UITableView to render its items
 open class ListSpot: NSObject, Listable {
 
-  /// Child spots
-  public var compositeSpots: [CompositeSpot] = []
-
   /// Keys for meta data lookup
   public struct Key {
     /// The meta key for setting the header height
@@ -26,6 +23,12 @@ open class ListSpot: NSObject, Listable {
 
   /// A component struct used as configuration and data source for the ListSpot
   open var component: Component
+
+  /// A SpotsFocusDelegate object
+  weak public var focusDelegate: SpotsFocusDelegate?
+
+  /// Child spots
+  public var compositeSpots: [CompositeSpot] = []
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -4,9 +4,6 @@ import Brick
 /// A RowSpot, a collection view based Spotable object that lays out its items in a vertical order based of the item sizes
 open class RowSpot: NSObject, Gridable {
 
-  /// Child spots
-  public var compositeSpots: [CompositeSpot] = []
-
   /**
    *  Keys for meta data lookup
    */
@@ -47,6 +44,12 @@ open class RowSpot: NSObject, Gridable {
 
   /// A Registry object that holds identifiers and classes for headers used in the RowSpot
   open static var headers = Registry()
+
+  /// A SpotsFocusDelegate object
+  weak public var focusDelegate: SpotsFocusDelegate?
+
+  /// Child spots
+  public var compositeSpots: [CompositeSpot] = []
 
   /// A component struct used as configuration and data source for the RowSpot
   open var component: Component

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -43,7 +43,8 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter cell: The cell object that was removed.
   /// - parameter indexPath: The index path of the data item that the cell represented.
   public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-    guard let spot = spot, let item = spot.item(at: indexPath) else {
+    guard let spot = spot, indexPath.item < spot.items.count,
+      let item = spot.item(at: indexPath) else {
       return
     }
 
@@ -57,7 +58,9 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: YES if the item can receive be focused or NO if it can not.
   public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    guard let spot = spot, let _ = spot.item(at: indexPath) else { return  false }
+    guard let spot = spot, let _ = spot.item(at: indexPath) else {
+      return  false
+    }
     return true
   }
 
@@ -70,8 +73,18 @@ extension Delegate: UICollectionViewDelegate {
   /// - returns: YES if the focus change should occur or NO if it should not.
   @available(iOS 9.0, *)
   public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
-    guard let indexPaths = collectionView.indexPathsForSelectedItems else { return true }
-    return indexPaths.isEmpty
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return true
+    }
+
+    if let spot = spot,
+      spot.items[indexPath.item].kind != "composite",
+      indexPath.item < spot.items.count {
+      spot.focusDelegate?.focusedSpot = spot
+      spot.focusDelegate?.focusedItemIndex = indexPath.item
+    }
+
+    return !indexPath.isEmpty
   }
 }
 
@@ -115,7 +128,9 @@ extension Delegate: UITableViewDelegate {
   /// - parameter tableView: A table-view object informing the delegate about the new row selection.
   /// - parameter indexPath: An index path locating the new selected row in tableView.
   public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
+    #if os(iOS)
+      tableView.deselectRow(at: indexPath, animated: true)
+    #endif
     if let spot = spot, let item = spot.item(at: indexPath) {
       spot.delegate?.didSelect(item: item, in: spot)
     }
@@ -163,6 +178,21 @@ extension Delegate: UITableViewDelegate {
     (view as? Componentable)?.configure(spot.component)
 
     return view
+  }
+
+  public func tableView(_ tableView: UITableView, shouldUpdateFocusIn context: UITableViewFocusUpdateContext) -> Bool {
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return true
+    }
+
+    if let spot = spot,
+      spot.items[indexPath.item].kind != "composite",
+      indexPath.item < spot.items.count {
+      spot.focusDelegate?.focusedSpot = spot
+      spot.focusDelegate?.focusedItemIndex = indexPath.item
+    }
+
+    return true
   }
 
   /// Asks the delegate for the height to use for a row in a specified location.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -180,6 +180,7 @@ extension Delegate: UITableViewDelegate {
     return view
   }
 
+  @available(iOS 9.0, *)
   public func tableView(_ tableView: UITableView, shouldUpdateFocusIn context: UITableViewFocusUpdateContext) -> Bool {
     guard let indexPath = context.nextFocusedIndexPath else {
       return true

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -29,7 +29,7 @@ extension UICollectionView: UserInterface {
   /// - parameter index: The index of the item you want to select.
   /// - parameter animated: Performs an animation if set to true
   public func select(itemAt index: Int, animated: Bool) {
-    guard let delegate = delegate, index < numberOfItems(inSection: 0) else {
+    guard index < numberOfItems(inSection: 0) else {
       return
     }
 
@@ -41,7 +41,7 @@ extension UICollectionView: UserInterface {
   /// - parameter index: The index of the item you want to deselect.
   /// - parameter animated: Performs an animation if set to true
   public func deselect(itemAt index: Int, animated: Bool) {
-    guard let delegate = delegate, index < numberOfItems(inSection: 0) else {
+    guard index < numberOfItems(inSection: 0) else {
       return
     }
 

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -3,10 +3,13 @@ import UIKit
 extension UICollectionView: UserInterface {
 
   /// The index of the current selected item
+  @available(iOS 9.0, *)
   public var selectedIndex: Int {
     return indexPathsForSelectedItems?.first?.item ?? 0
   }
 
+  @available(iOS 9.0, *)
+  /// The index of the current focused item
   public var focusedIndex: Int {
     return delegate?.indexPathForPreferredFocusedView?(in: self)?.item ?? 0
   }
@@ -14,6 +17,7 @@ extension UICollectionView: UserInterface {
   /// Focus on item at index
   ///
   /// - parameter index: The index of the item you want to focus.
+  @available(iOS 9.0, *)
   public func focusOn(itemAt index: Int) {
     guard index < numberOfItems(inSection: 0) else {
       return

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -2,6 +2,52 @@ import UIKit
 
 extension UICollectionView: UserInterface {
 
+  /// The index of the current selected item
+  public var selectedIndex: Int {
+    return indexPathsForSelectedItems?.first?.item ?? 0
+  }
+
+  public var focusedIndex: Int {
+    return delegate?.indexPathForPreferredFocusedView?(in: self)?.item ?? 0
+  }
+
+  /// Focus on item at index
+  ///
+  /// - parameter index: The index of the item you want to focus.
+  public func focusOn(itemAt index: Int) {
+    guard index < numberOfItems(inSection: 0) else {
+      return
+    }
+
+    select(itemAt: index, animated: false)
+    setNeedsFocusUpdate()
+    deselect(itemAt: index, animated: false)
+  }
+
+  /// Select item at index
+  ///
+  /// - parameter index: The index of the item you want to select.
+  /// - parameter animated: Performs an animation if set to true
+  public func select(itemAt index: Int, animated: Bool) {
+    guard let delegate = delegate, index < numberOfItems(inSection: 0) else {
+      return
+    }
+
+    selectItem(at: IndexPath(row: index, section: 0), animated: animated, scrollPosition: [])
+  }
+
+  /// Deselect item at index
+  ///
+  /// - parameter index: The index of the item you want to deselect.
+  /// - parameter animated: Performs an animation if set to true
+  public func deselect(itemAt index: Int, animated: Bool) {
+    guard let delegate = delegate, index < numberOfItems(inSection: 0) else {
+      return
+    }
+
+    deselectItem(at: IndexPath(row: index, section: 0), animated: animated)
+  }
+
   public func view<T>(at index: Int) -> T? {
     return cellForItem(at: IndexPath(item: index, section: 0)) as? T
   }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -6,14 +6,17 @@ extension UITableView: UserInterface {
     return indexPathForSelectedRow?.row ?? 0
   }
 
+  @available(iOS 9.0, *)
   public var focusedIndex: Int {
     updateFocusIfNeeded()
+
     return delegate?.indexPathForPreferredFocusedView?(in: self)?.row ?? 0
   }
 
   /// Focus on item at index
   ///
   /// - parameter index: The index of the item you want to select.
+  @available(iOS 9.0, *)
   public func focusOn(itemAt index: Int) {
     guard index < numberOfRows(inSection: 0) else {
       return

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -29,7 +29,7 @@ extension UITableView: UserInterface {
   /// - parameter index: The index of the item you want to select.
   /// - parameter animated: Performs an animation if set to true
   public func select(itemAt index: Int, animated: Bool = true) {
-    guard let delegate = delegate, index < numberOfRows(inSection: 0) else {
+    guard index < numberOfRows(inSection: 0) else {
       return
     }
 
@@ -41,7 +41,7 @@ extension UITableView: UserInterface {
   /// - parameter index: The index of the item you want to deselect.
   /// - parameter animated: Performs an animation if set to true
   public func deselect(itemAt index: Int, animated: Bool = true) {
-    guard let delegate = delegate, index < numberOfRows(inSection: 0) else {
+    guard index < numberOfRows(inSection: 0) else {
       return
     }
 

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -2,6 +2,52 @@ import UIKit
 
 extension UITableView: UserInterface {
 
+  public var selectedIndex: Int {
+    return indexPathForSelectedRow?.row ?? 0
+  }
+
+  public var focusedIndex: Int {
+    updateFocusIfNeeded()
+    return delegate?.indexPathForPreferredFocusedView?(in: self)?.row ?? 0
+  }
+
+  /// Focus on item at index
+  ///
+  /// - parameter index: The index of the item you want to select.
+  public func focusOn(itemAt index: Int) {
+    guard index < numberOfRows(inSection: 0) else {
+      return
+    }
+
+    select(itemAt: index, animated: true)
+    setNeedsFocusUpdate()
+    deselect(itemAt: index, animated: true)
+  }
+
+  /// Select item at index
+  ///
+  /// - parameter index: The index of the item you want to select.
+  /// - parameter animated: Performs an animation if set to true
+  public func select(itemAt index: Int, animated: Bool = true) {
+    guard let delegate = delegate, index < numberOfRows(inSection: 0) else {
+      return
+    }
+
+    selectRow(at: IndexPath(row: index, section: 0), animated: animated, scrollPosition: .none)
+  }
+
+  /// Deselect item at index
+  ///
+  /// - parameter index: The index of the item you want to deselect.
+  /// - parameter animated: Performs an animation if set to true
+  public func deselect(itemAt index: Int, animated: Bool = true) {
+    guard let delegate = delegate, index < numberOfRows(inSection: 0) else {
+      return
+    }
+
+    deselectRow(at: IndexPath(row: index, section: 0), animated: animated)
+  }
+
   public func view<T>(at index: Int) -> T? {
     return cellForRow(at: IndexPath(row: index, section: 0)) as? T
   }

--- a/Sources/tvOS/Extensions/CollectionAdapter+tvOS.swift
+++ b/Sources/tvOS/Extensions/CollectionAdapter+tvOS.swift
@@ -12,7 +12,6 @@ extension CarouselSpot {
       collectionView.deselectItem(at: indexPath, animated: true)
       return false
     }
-
     return true
   }
 }


### PR DESCRIPTION
This is an initial implementation to try to improve the focus on tvOS.

It features a new protocol called `SpotsFocusDelegate` which `Controller` conforms to.

The intention is that you can get the last focused view on screen. This is a restriction in the API as you can no longer set the `preferredFoucsedView`.

This implementation is not 100% complete but it is a good start.

I also attempted to improve how composites are reloaded. Right now the composite spots get replaced when ever a composite container is changed. There is potential for improvement here. However I ran into a weird crash related to `tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath)`.

The stack trace can be found here.

https://gist.github.com/zenangst/1a7662f81e4abb0071a1bc88493e9fac

This happens when I try to get the prepared items from the temporary spot and add them to the already existing one.

The odd thing is, if you remove the delegate implementation, it reloads just fine.

Anyways, I think this is a good start.