### PR TITLE
Align to top instead of middle

### DIFF
--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -88,6 +88,8 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     if let newAttributes = super.layoutAttributesForElements(in: rect) {
       var offset: CGFloat = sectionInset.left
+      var previousAttribute: UICollectionViewLayoutAttributes?
+
       for attribute in newAttributes {
         guard let itemAttribute = attribute.copy() as? UICollectionViewLayoutAttributes
           else { continue }
@@ -104,10 +106,18 @@ open class GridableLayout: UICollectionViewFlowLayout {
             itemAttribute.frame.origin.y = headerReferenceSize.height
             itemAttribute.frame.origin.x = offset
             offset += itemAttribute.size.width + minimumInteritemSpacing
+          } else {
+            if let previousAttribute = previousAttribute {
+              if itemAttribute.frame.maxY < previousAttribute.frame.maxY {
+                itemAttribute.frame.origin.y = previousAttribute.frame.origin.y
+              }
+            }
           }
 
           attributes.append(itemAttribute)
         }
+
+        previousAttribute = itemAttribute
       }
     }
 


### PR DESCRIPTION
This PR improves the `GridableLayout` on `iOS` and `tvOS`. It will no align to top instead of middle when using it with composition.

The screenshots below illustrates how it works, look at `Repositories`.

### Before
![simulator screen shot jan 10 2017 23 17 28](https://cloud.githubusercontent.com/assets/57446/21827371/9d8f7fb2-d78b-11e6-9b6d-60ab2d099797.png)
### After
![simulator screen shot jan 10 2017 23 18 14](https://cloud.githubusercontent.com/assets/57446/21827380/a4644d86-d78b-11e6-926d-1cc3f58f86af.png)
