### PR TITLE
Change type precedence

### DIFF
--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -142,9 +142,9 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     items     <- map.relations("items")
     meta      <- map.property("meta")
 
-    if let span: Int = map.property("span") {
+    if let span: Float = map.property("span") {
       self.span = Double(span)
-    } else if let span: Float = map.property("span") {
+    } else if let span: Int = map.property("span") {
       self.span = Double(span)
     } else {
       self.span <- map.property("span")


### PR DESCRIPTION
With the previous precedence, span could not be properly mapped if it could be resolve into an Int. This PR fixes that issue by trying `Float` before `Int`