### PR TITLE
Bug/fix crash

### DIFF
--- a/Examples/Apple News/AppleNews/Controllers/ForYouDetailController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouDetailController.swift
@@ -33,13 +33,14 @@ extension ForYouDetailController {
     guard let navigationController = navigationController, scrollView.isTracking
       else { return }
 
-    if scrollView.contentOffset.y >= (lastContentOffset?.y)! && scrollView.contentOffset.y > 64 {
-      navigationController.setNavigationBarHidden(true, animated: true)
-    } else {
-      navigationController.setNavigationBarHidden(false, animated: true)
+    if let lastContentYOffset = lastContentOffset?.y {
+        if scrollView.contentOffset.y >= lastContentYOffset && scrollView.contentOffset.y > 64 {
+            navigationController.setNavigationBarHidden(true, animated: true)
+        } else {
+            navigationController.setNavigationBarHidden(false, animated: true)
+        }
     }
-
+    
     lastContentOffset = scrollView.contentOffset
   }
-
 }

--- a/Examples/Apple News/AppleNews/Controllers/ForYouDetailController.swift
+++ b/Examples/Apple News/AppleNews/Controllers/ForYouDetailController.swift
@@ -34,11 +34,8 @@ extension ForYouDetailController {
       else { return }
 
     if let lastContentYOffset = lastContentOffset?.y {
-        if scrollView.contentOffset.y >= lastContentYOffset && scrollView.contentOffset.y > 64 {
-            navigationController.setNavigationBarHidden(true, animated: true)
-        } else {
-            navigationController.setNavigationBarHidden(false, animated: true)
-        }
+        let hideNavigationBar = scrollView.contentOffset.y >= lastContentYOffset && scrollView.contentOffset.y > 64
+        navigationController.setNavigationBarHidden(hideNavigationBar, animated: true)
     }
     
     lastContentOffset = scrollView.contentOffset


### PR DESCRIPTION
Was playing with Spots and noticed a crash in Example/Apple News
There is a crash when you go to `ForYouDetailViewController` first time and try to scroll the page. Apparently crash was due to forced unwrapping of nil value.
