### PR TITLE
Fix field offset

### DIFF
--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -102,7 +102,7 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
   #if os(iOS)
   /// A UIRefresh control.
   /// Note: Only available on iOS.
-  public lazy var refreshControl = UIRefreshControl()
+  public lazy private(set) var refreshControl = UIRefreshControl()
   #endif
 
   // MARK: Initializer


### PR DESCRIPTION
When subclassing from `Spots.Controller`, I get `direct field offset error` on `refreshController`, similar to https://github.com/xmartlabs/XLPagerTabStrip/issues/227

This only happens when using Carthage. 

The workaround is to make `refreshControler` `private(set)` 😇 