### PR TITLE
Improve/gridable layout

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -79,6 +79,9 @@ extension SpotsProtocol {
         weakSelf.cache()
         Dispatch.mainQueue {
           weakSelf.scrollView.layoutViews()
+          if let controller = self as? Controller {
+            Controller.spotsDidReloadComponents?(controller)
+          }
           completion?()
         }
         return
@@ -453,6 +456,9 @@ extension SpotsProtocol {
       let oldComponents = weakSelf.spots.map { $0.component }
 
       guard compare(newComponents, oldComponents) else {
+        if let controller = self as? Controller {
+          Controller.spotsDidReloadComponents?(controller)
+        }
         weakSelf.cache()
         completion?()
         return

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -166,6 +166,10 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
       self.layout = Layout(layoutDictionary)
     }
 
+    if self.layout == nil {
+      self.span <- map.property("span")
+    }
+
     let width: Double = map.resolve(keyPath: "size.width") ?? 0.0
     let height: Double = map.resolve(keyPath: "size.height") ?? 0.0
     size = CGSize(width: width, height: height)

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -138,4 +138,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     return attributes
   }
+
+  /// Asks the layout object if the new bounds require a layout update.
+  ///
+  /// - parameter newBounds: The new bounds of the collection view.
+  ///
+  /// - returns: Always returns true
+  open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    return true
+  }
 }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -33,7 +33,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     var layoutAttributes = [UICollectionViewLayoutAttributes]()
 
-    for (index, _) in spot.items.enumerated() {
+    for index in 0..<(collectionView?.numberOfItems(inSection: 0) ?? 0) {
       if let attribute = self.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
         layoutAttributes.append(attribute)
       }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -54,7 +54,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     } else {
       contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
       contentSize.height = super.collectionViewContentSize.height
-//      collectionView?.frame.size = super.collectionViewContentSize
     }
   }
 

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -84,8 +84,15 @@ extension UICollectionView: UserInterface {
   public func reload(_ indexes: [Int], withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
     let indexPaths = indexes.map { IndexPath(item: $0, section: 0) }
 
-    UIView.performWithoutAnimation {
-      self.reloadItems(at: indexPaths)
+    switch animation {
+      case .none:
+        UIView.performWithoutAnimation {
+          reloadItems(at: indexPaths)
+          completion?()
+      }
+    default:
+      reloadItems(at: indexPaths)
+      collectionViewLayout.finalizeCollectionViewUpdates()
       completion?()
     }
   }

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -455,6 +455,7 @@ class ControllerTests : XCTestCase {
     let jsonController = Controller([
       "components" : [
         ["kind" : "list",
+         "layout" : ListSpot.layout.dictionary,
          "items" : [
           ["title" : "First item"]
           ]

--- a/SpotsTests/iOS/TestFactory.swift
+++ b/SpotsTests/iOS/TestFactory.swift
@@ -6,9 +6,9 @@ import Brick
 class FactoryTests : XCTestCase {
 
   let json: [String : Any] = [
-    "title" : "title1" as AnyObject,
-    "kind" : "merry-go-round" as AnyObject,
-    "span" : 1 as AnyObject,
+    "title" : "title1",
+    "kind" : "merry-go-round",
+    "span" : 1.0,
     "meta" : ["foo" : "bar"],
     "items" : [["title" : "item1"]]
   ]


### PR DESCRIPTION
This PR improves the implementation of the `GridableLayout`.

Mainly if fixes a crash that can occur because `UICollectionView` returns stale data.

```
*** Assertion failure in -[UICollectionViewData validateLayoutInRect:], /BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit_Sim/UIKit-3600.6.21/UICollectionViewData.m:433
```

I did some research about this and to work around the issue we need to implement `layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes?` and manually handle `layoutAttributes` in `layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]?`.

The layout attributes are now constructed in `prepare`. It is pretty straight forward seeing as we only have one dimension of data (only one section).

```swift
    var layoutAttributes = [UICollectionViewLayoutAttributes]()

    for (index, _) in spot.items.enumerated() {
      if let attribute = self.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
        layoutAttributes.append(attribute)
      }
    }

    self.layoutAttributes = layoutAttributes
```

This PR also fixes a small mapping issue in `Component`. It will now check for `span` and map that to `Layout`.

### References

https://bugzilla.mozilla.org/show_bug.cgi?id=1189985
https://github.com/mozilla-mobile/firefox-ios/pull/864