### PR TITLE
Fix missing headers in `GridableLayout`

### DIFF
--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -69,13 +69,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
       return
     }
 
-    super.invalidateLayout()
-
     if scrollDirection == .horizontal &&
       (collectionView.frame.size.height <= contentSize.height ||
       collectionView.contentOffset.y > 0) {
       return
     }
+
+    super.invalidateLayout()
 
     if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {
       collectionView.frame.origin.y = y
@@ -104,6 +104,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
     }
 
     var attributes = [UICollectionViewLayoutAttributes]()
+    var rect = CGRect(origin: CGPoint.zero, size: contentSize)
+
+    if headerReferenceSize.height > 0.0 {
+      rect.origin = CGPoint(x: -collectionView.bounds.width, y: 0)
+      rect.size.height = contentSize.height
+      rect.size.width = collectionView.bounds.width * 3
+    }
 
     if let newAttributes = self.layoutAttributes {
       var offset: CGFloat = sectionInset.left
@@ -127,7 +134,9 @@ open class GridableLayout: UICollectionViewFlowLayout {
             offset += itemAttribute.size.width + minimumInteritemSpacing
           }
 
-          attributes.append(itemAttribute)
+          if rect.intersects(itemAttribute.frame) {
+            attributes.append(itemAttribute)
+          }
         }
       }
     }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -33,9 +33,15 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     var layoutAttributes = [UICollectionViewLayoutAttributes]()
 
+    if !spot.component.header.isEmpty {
+      if let headerAttribute = super.layoutAttributesForSupplementaryView(ofKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0)) {
+        layoutAttributes.append(headerAttribute)
+      }
+    }
+
     for index in 0..<(collectionView?.numberOfItems(inSection: 0) ?? 0) {
-      if let attribute = self.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
-        layoutAttributes.append(attribute)
+      if let itemAttribute = self.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
+        layoutAttributes.append(itemAttribute)
       }
     }
 

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -69,13 +69,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
       return
     }
 
+    super.invalidateLayout()
+
     if scrollDirection == .horizontal &&
       (collectionView.frame.size.height <= contentSize.height ||
       collectionView.contentOffset.y > 0) {
       return
     }
-
-    super.invalidateLayout()
 
     if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {
       collectionView.frame.origin.y = y
@@ -104,13 +104,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     }
 
     var attributes = [UICollectionViewLayoutAttributes]()
-    var rect = CGRect(origin: CGPoint.zero, size: contentSize)
-
-    if headerReferenceSize.height > 0.0 {
-      rect.origin = CGPoint(x: -collectionView.bounds.width, y: 0)
-      rect.size.height = contentSize.height
-      rect.size.width = collectionView.bounds.width * 3
-    }
 
     if let newAttributes = self.layoutAttributes {
       var offset: CGFloat = sectionInset.left
@@ -134,9 +127,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
             offset += itemAttribute.size.width + minimumInteritemSpacing
           }
 
-          if rect.intersects(itemAttribute.frame) {
-            attributes.append(itemAttribute)
-          }
+          attributes.append(itemAttribute)
         }
       }
     }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -63,13 +63,13 @@ open class GridableLayout: UICollectionViewFlowLayout {
       return
     }
 
+    super.invalidateLayout()
+
     if scrollDirection == .horizontal &&
       (collectionView.frame.size.height <= contentSize.height ||
       collectionView.contentOffset.y > 0) {
       return
     }
-
-    super.invalidateLayout()
 
     if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {
       collectionView.frame.origin.y = y
@@ -98,13 +98,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     }
 
     var attributes = [UICollectionViewLayoutAttributes]()
-    var rect = CGRect(origin: CGPoint.zero, size: contentSize)
-
-    if headerReferenceSize.height > 0.0 {
-      rect.origin = CGPoint(x: -collectionView.bounds.width, y: 0)
-      rect.size.height = contentSize.height
-      rect.size.width = collectionView.bounds.width * 3
-    }
 
     if let newAttributes = self.layoutAttributes {
       var offset: CGFloat = sectionInset.left
@@ -128,9 +121,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
             offset += itemAttribute.size.width + minimumInteritemSpacing
           }
 
-          if rect.intersects(itemAttribute.frame) {
-            attributes.append(itemAttribute)
-          }
+          attributes.append(itemAttribute)
         }
       }
     }


### PR DESCRIPTION
When we moved to manual handling of `UICollectionViewLayoutAttributes`, we forgot to take headers into account. This PR fixes that issue.