### PR TITLE
Improve/spotable by renaming render

### DIFF
--- a/Sources/Mac/Classes/CarouselSpot.swift
+++ b/Sources/Mac/Classes/CarouselSpot.swift
@@ -3,6 +3,11 @@ import Brick
 
 open class CarouselSpot: NSObject, Gridable {
 
+  /// Return collection view as a scroll view
+  open var view: ScrollView {
+    return scrollView
+  }
+
   public static var layout: Layout = Layout()
 
   /// Child spots
@@ -173,10 +178,6 @@ open class CarouselSpot: NSObject, Gridable {
     collectionView.dataSource = spotDataSource
     collectionView.delegate = spotDelegate
     collectionView.collectionViewLayout = layout
-  }
-
-  open func render() -> ScrollView {
-    return scrollView
   }
 
   open func layout(_ size: CGSize) {

--- a/Sources/Mac/Classes/Controller.swift
+++ b/Sources/Mac/Classes/Controller.swift
@@ -199,7 +199,7 @@ open class Controller: NSViewController, SpotsProtocol {
   public func reloadSpots(spots: [Spotable], closure: (() -> Void)?) {
     for spot in self.spots {
       spot.delegate = nil
-      spot.render().removeFromSuperview()
+      spot.view.removeFromSuperview()
     }
     self.spots = spots
     delegate = nil
@@ -215,13 +215,13 @@ open class Controller: NSViewController, SpotsProtocol {
   public func setupSpots(animated: ((_ view: View) -> Void)? = nil) {
     spots.enumerated().forEach { index, spot in
       setupSpot(at: index, spot: spot)
-      animated?(spot.render())
+      animated?(spot.view)
     }
   }
 
   public func setupSpot(at index: Int, spot: Spotable) {
-    if spot.render().superview == nil {
-      scrollView.spotsContentView.addSubview(spot.render())
+    if spot.view.superview == nil {
+      scrollView.spotsContentView.addSubview(spot.view)
     }
 
     spots[index].component.index = index
@@ -235,7 +235,7 @@ open class Controller: NSViewController, SpotsProtocol {
     spot.setup(CGSize(width: view.frame.width, height: height))
     spot.component.size = CGSize(
       width: view.frame.width,
-      height: ceil(spot.render().frame.height))
+      height: ceil(spot.view.frame.height))
 
     (spot as? Gridable)?.layout(CGSize(width: view.frame.width, height: height))
   }
@@ -256,7 +256,7 @@ open class Controller: NSViewController, SpotsProtocol {
 
   public func deselectAllExcept(selectedSpot: Spotable) {
     for spot in spots {
-      if selectedSpot.render() != spot.render() {
+      if selectedSpot.view != spot.view {
         spot.deselect()
       }
     }

--- a/Sources/Mac/Classes/GridSpot.swift
+++ b/Sources/Mac/Classes/GridSpot.swift
@@ -3,6 +3,11 @@ import Brick
 
 open class GridSpot: NSObject, Gridable {
 
+  /// Return collection view as a scroll view
+  open var view: ScrollView {
+    return scrollView
+  }
+
   public static var layout: Layout = Layout()
 
   /// Child spots
@@ -250,14 +255,6 @@ open class GridSpot: NSObject, Gridable {
     let backgroundView = NSView()
     backgroundView.wantsLayer = true
     collectionView.backgroundView = backgroundView
-  }
-
-  /// Return collection view as a scroll view
-  ///
-  /// - returns: UIScrollView: Returns a UICollectionView as a UIScrollView
-  ///
-  open func render() -> ScrollView {
-    return scrollView
   }
 
   /**

--- a/Sources/Mac/Classes/ListSpot.swift
+++ b/Sources/Mac/Classes/ListSpot.swift
@@ -3,6 +3,11 @@ import Brick
 
 open class ListSpot: NSObject, Listable {
 
+  /// Return collection view as a scroll view
+  open var view: ScrollView {
+    return scrollView
+  }
+
   public static var layout: Layout = Layout(span: 1.0)
 
   /// Child spots
@@ -165,10 +170,6 @@ open class ListSpot: NSObject, Listable {
     delegate?.didSelect(item: item, in: self)
   }
 
-  open func render() -> ScrollView {
-    return scrollView
-  }
-
   open func layout(_ size: CGSize) {
     scrollView.contentInsets.top = component.meta(Key.contentInsetsTop, Default.contentInsetsTop)
     scrollView.contentInsets.left = component.meta(Key.contentInsetsLeft, Default.contentInsetsLeft)
@@ -235,6 +236,6 @@ open class ListSpot: NSObject, Listable {
 
   public func afterUpdate() {
     /// This is to set the proper height after reloading a list when initially it didn't contain any items.
-    layout(render().frame.size)
+    layout(view.frame.size)
   }
 }

--- a/Sources/Mac/Classes/RowSpot.swift
+++ b/Sources/Mac/Classes/RowSpot.swift
@@ -3,6 +3,13 @@ import Brick
 
 open class RowSpot: NSObject, Gridable {
 
+  /// Return collection view as a scroll view
+  ///
+  /// - returns: UIScrollView: Returns a UICollectionView as a UIScrollView
+  open var view: ScrollView {
+    return scrollView
+  }
+
   public static var layout: Layout = Layout(span: 1.0)
 
   /// Child spots
@@ -244,13 +251,6 @@ open class RowSpot: NSObject, Gridable {
     collectionView.dataSource = spotDataSource
     collectionView.delegate = spotDelegate
     collectionView.collectionViewLayout = layout
-  }
-
-  /// Return collection view as a scroll view
-  ///
-  /// - returns: UIScrollView: Returns a UICollectionView as a UIScrollView
-  open func render() -> ScrollView {
-    return scrollView
   }
 
   /**

--- a/Sources/Mac/Extensions/Composable+Mac.swift
+++ b/Sources/Mac/Extensions/Composable+Mac.swift
@@ -23,17 +23,17 @@ public extension Composable {
 
       compositeSpot.spot.component.size = CGSize(
         width: width,
-        height: ceil(compositeSpot.spot.render().frame.size.height))
+        height: ceil(compositeSpot.spot.view.frame.size.height))
 
-      compositeSpot.spot.render().frame.origin.y = height
-      compositeSpot.spot.render().frame.size.width = contentView.frame.size.width
-      compositeSpot.spot.render().frame.size.height = compositeSpot.spot.render().contentSize.height
+      compositeSpot.spot.view.frame.origin.y = height
+      compositeSpot.spot.view.frame.size.width = contentView.frame.size.width
+      compositeSpot.spot.view.frame.size.height = compositeSpot.spot.view.contentSize.height
 
-      height += compositeSpot.spot.render().contentSize.height
+      height += compositeSpot.spot.view.contentSize.height
 
       (compositeSpot.spot as? Gridable)?.layout.invalidateLayout()
 
-      contentView.addSubview(compositeSpot.spot.render())
+      contentView.addSubview(compositeSpot.spot.view)
     }
 
     item.size.height = height

--- a/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
+++ b/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
@@ -33,7 +33,7 @@ extension Gridable {
   /// A computed CGFloat of the total height of all items inside of a component
   public var computedHeight: CGFloat {
     guard usesDynamicHeight else {
-      return self.render().frame.height
+      return self.view.frame.height
     }
 
     return layout.collectionViewContentSize.height

--- a/Sources/Mac/Extensions/Layout+Mac.swift
+++ b/Sources/Mac/Extensions/Layout+Mac.swift
@@ -3,7 +3,7 @@ import Cocoa
 extension Layout {
 
   public func configure(spot: Gridable) {
-    inset.configure(scrollView: spot.render())
+    inset.configure(scrollView: spot.view)
 
     if let layout = spot.layout as? FlowLayout {
       inset.configure(layout: layout)

--- a/Sources/Mac/Extensions/Listable+Extensions+Mac.swift
+++ b/Sources/Mac/Extensions/Listable+Extensions+Mac.swift
@@ -22,7 +22,7 @@ extension Listable {
     let bottom: CGFloat = component.meta("inset-bottom", 0.0)
     let right: CGFloat = component.meta("inset-right", 0.0)
 
-    render().contentInsets = EdgeInsets(top: top, left: left, bottom: bottom, right: right)
+    view.contentInsets = EdgeInsets(top: top, left: left, bottom: bottom, right: right)
   }
 
   public func deselect() {

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -7,6 +7,10 @@ import Brick
 
 open class ViewSpot: NSObject, Spotable, Viewable {
 
+  public var view: View {
+    return scrollView
+  }
+
   public static var layout: Layout = Layout([:])
 
   /// Reload spot with ItemChanges.
@@ -70,10 +74,6 @@ open class ViewSpot: NSObject, Spotable, Viewable {
 
   public func ui<T>(at index: Int) -> T? {
     return nil
-  }
-
-  open func render() -> View {
-    return scrollView
   }
 
   /**

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -13,7 +13,7 @@ public extension Spotable where Self : Gridable {
   ///
   /// - returns: Returns a UICollectionView as a UIScrollView
   ///
-  public func render() -> CollectionView {
+  var view: CollectionView {
     return collectionView
   }
   #else
@@ -21,7 +21,7 @@ public extension Spotable where Self : Gridable {
   ///
   /// - returns: Returns a UICollectionView as a UIScrollView
   ///
-  public func render() -> ScrollView {
+  var view: ScrollView {
     return collectionView
   }
   #endif

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -17,12 +17,12 @@ public extension Spotable {
   /// A computed CGFloat of the total height of all items inside of a component
   public var computedHeight: CGFloat {
     guard usesDynamicHeight else {
-      return self.render().frame.height
+      return self.view.frame.height
     }
 
     var height: CGFloat = 0
     #if !os(OSX)
-      let superViewHeight = self.render().superview?.frame.size.height ?? UIScreen.main.bounds.height
+      let superViewHeight = self.view.superview?.frame.size.height ?? UIScreen.main.bounds.height
     #endif
 
     for item in component.items {
@@ -97,7 +97,7 @@ public extension Spotable {
               }
             }
           #else
-            var spotWidth = render().frame.size.width
+            var spotWidth = view.frame.size.width
 
             if spotWidth == 0.0 {
               spotWidth = UIScreen.main.bounds.width
@@ -153,7 +153,7 @@ public extension Spotable {
 
       let spotHeight = weakSelf.computedHeight
       Dispatch.mainQueue { [weak self] in
-        self?.render().frame.size.height = spotHeight
+        self?.view.frame.size.height = spotHeight
         completion?()
       }
     }
@@ -223,7 +223,7 @@ public extension Spotable {
       prepare(kind: kind, view: view as Any, item: &item)
     #else
       let spotableKind = self
-      fullWidth = render().superview?.frame.size.width ?? render().frame.size.width
+      fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
 
       switch spotableKind {
       case let spotableKind as Gridable:
@@ -276,7 +276,7 @@ public extension Spotable {
   /// - parameter view: The view that is going to be prepared.
   func prepare(view: View) {
     // Set initial size for view
-    view.frame.size.width = render().frame.size.width
+    view.frame.size.width = view.frame.size.width
 
     if let spotConfigurable = view as? SpotConfigurable, view.frame.size.height == 0.0 {
       view.frame.size = spotConfigurable.preferredViewSize
@@ -301,7 +301,7 @@ public extension Spotable {
     var height: CGFloat = 0.0
 
     compositeSpots.filter({ $0.itemIndex == item.index }).forEach {
-      $0.spot.render().removeFromSuperview()
+      $0.spot.view.removeFromSuperview()
 
       if let index = compositeSpots.index(of: $0) {
         compositeSpots.remove(at: index)
@@ -309,7 +309,7 @@ public extension Spotable {
     }
 
     let spots: [Spotable] = Parser.parse(item)
-    let size = render().frame.size
+    let size = view.frame.size
     let width = size.width
 
     spots.forEach { spot in
@@ -320,19 +320,19 @@ public extension Spotable {
       compositeSpot.spot.setup(size)
       compositeSpot.spot.component.size = CGSize(
         width: width,
-        height: ceil(compositeSpot.spot.render().frame.size.height))
+        height: ceil(compositeSpot.spot.view.frame.size.height))
       compositeSpot.spot.layout(size)
-      compositeSpot.spot.render().layoutIfNeeded()
-      compositeSpot.spot.render().frame.origin.y = height
+      compositeSpot.spot.view.layoutIfNeeded()
+      compositeSpot.spot.view.frame.origin.y = height
 
       #if !os(OSX)
         /// Disable scrolling for listable objects
-        compositeSpot.spot.render().isScrollEnabled = !(compositeSpot.spot is Listable)
+        compositeSpot.spot.view.isScrollEnabled = !(compositeSpot.spot is Listable)
       #endif
 
-      compositeSpot.spot.render().frame.size.height = compositeSpot.spot.render().contentSize.height
+      compositeSpot.spot.view.frame.size.height = compositeSpot.spot.view.contentSize.height
 
-      height += compositeSpot.spot.render().frame.size.height
+      height += compositeSpot.spot.view.frame.size.height
 
       compositeSpots.append(compositeSpot)
     }
@@ -354,7 +354,7 @@ public extension Spotable {
       item.size.width  = view.preferredViewSize.width
     }
 
-    if let superview = render().superview, item.size.width == 0.0 {
+    if let superview = self.view.superview, item.size.width == 0.0 {
       item.size.width = superview.frame.width
     }
 
@@ -369,7 +369,7 @@ public extension Spotable {
   ///
   /// - returns: CGSize of the item at index path.
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    return render().frame.size
+    return view.frame.size
   }
 
   /// Get identifier for item at index path

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -36,7 +36,7 @@ public extension Spotable {
           weakSelf.userInterface?.insert([numberOfItems], withAnimation: animation, completion: nil)
           weakSelf.updateHeight {
             weakSelf.afterUpdate()
-            weakSelf.render().superview?.layoutSubviews()
+            weakSelf.view.superview?.layoutSubviews()
             completion?()
           }
         }
@@ -74,7 +74,7 @@ public extension Spotable {
       } else {
         weakSelf.userInterface?.reloadDataSource()
         weakSelf.updateHeight {
-          weakSelf.render().superview?.layoutSubviews()
+          weakSelf.view.superview?.layoutSubviews()
           completion?()
         }
       }
@@ -116,7 +116,7 @@ public extension Spotable {
         weakSelf.userInterface?.reloadDataSource()
         weakSelf.afterUpdate()
         weakSelf.sanitize {
-          weakSelf.render().superview?.layoutSubviews()
+          weakSelf.view.superview?.layoutSubviews()
           completion?()
         }
       }
@@ -153,7 +153,7 @@ public extension Spotable {
       }
       weakSelf.afterUpdate()
       weakSelf.sanitize {
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -176,7 +176,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -209,7 +209,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete(indexPaths, withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -231,7 +231,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -256,7 +256,7 @@ public extension Spotable {
       weakSelf.userInterface?.delete(indexes, withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -285,12 +285,12 @@ public extension Spotable {
                                    compositeSpots: compositeSpots)
         } else {
           for compositeSpot in weakSelf.compositeSpots {
-            compositeSpot.spot.setup(weakSelf.render().frame.size)
+            compositeSpot.spot.setup(weakSelf.view.frame.size)
             compositeSpot.spot.reload([])
           }
         }
 
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         weakSelf.afterUpdate()
         completion?()
         return
@@ -308,17 +308,17 @@ public extension Spotable {
           }
           weakSelf.afterUpdate()
           weakSelf.updateHeight {
-            weakSelf.render().superview?.layoutSubviews()
+            weakSelf.view.superview?.layoutSubviews()
             completion?()
           }
           return
         } else if let cell: SpotConfigurable = weakSelf.userInterface?.view(at: index) {
           cell.configure(&weakSelf.items[index])
-          weakSelf.render().superview?.layoutSubviews()
+          weakSelf.view.superview?.layoutSubviews()
           completion?()
         } else {
           weakSelf.afterUpdate()
-          weakSelf.render().superview?.layoutSubviews()
+          weakSelf.view.superview?.layoutSubviews()
           completion?()
         }
       }
@@ -366,7 +366,7 @@ public extension Spotable {
             weakSelf.userInterface?.reloadDataSource()
           }
         }
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         completion?()
       }
     }
@@ -416,7 +416,7 @@ public extension Spotable {
         Dispatch.mainQueue {
           weakSelf.cache()
           completion?()
-          weakSelf.render().superview?.layoutSubviews()
+          weakSelf.view.superview?.layoutSubviews()
         }
         return
       }
@@ -477,7 +477,7 @@ public extension Spotable {
           return
         }
         weakSelf.afterUpdate()
-        weakSelf.render().superview?.layoutSubviews()
+        weakSelf.view.superview?.layoutSubviews()
         weakSelf.cache()
       }
     }

--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -45,12 +45,12 @@ import Cache
                 #if !os(OSX)
                 (spot as? CarouselSpot)?.layout.yOffset = yOffset
                 #endif
-                yOffset += spot.render().frame.size.height
+                yOffset += spot.view.frame.size.height
               }
 
               #if !os(OSX)
               for case let gridable as CarouselSpot in weakSelf.spots {
-                gridable.layout.yOffset = gridable.render().frame.origin.y
+                gridable.layout.yOffset = gridable.view.frame.origin.y
               }
               #endif
             }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -46,7 +46,7 @@ extension SpotsProtocol {
     guard !components.isEmpty else {
       Dispatch.mainQueue { [weak self] in
         self?.spots.forEach {
-          $0.render().removeFromSuperview()
+          $0.view.removeFromSuperview()
         }
         self?.spots = []
         completion?()
@@ -136,21 +136,21 @@ extension SpotsProtocol {
 
     /// Remove old composite spots from superview and empty container
     for compositeSpot in oldSpot.compositeSpots {
-      compositeSpot.spot.render().removeFromSuperview()
+      compositeSpot.spot.view.removeFromSuperview()
     }
     oldSpot.compositeSpots = []
 
-    spot.render().frame = oldSpot.render().frame
+    spot.view.frame = oldSpot.view.frame
 
-    oldSpot.render().removeFromSuperview()
+    oldSpot.view.removeFromSuperview()
     spots[index] = spot
-    scrollView.spotsContentView.insertSubview(spot.render(), at: index)
+    scrollView.spotsContentView.insertSubview(spot.view, at: index)
     setupSpot(at: index, spot: spot)
 
     #if !os(OSX)
     (spot as? CarouselSpot)?.layout.yOffset = yOffset
     #endif
-    yOffset += spot.render().frame.size.height
+    yOffset += spot.view.frame.size.height
   }
 
   fileprivate func newSpot(_ index: Int, newComponents: [Component], yOffset: inout CGFloat) {
@@ -160,7 +160,7 @@ extension SpotsProtocol {
     #if !os(OSX)
       (spot as? CarouselSpot)?.layout.yOffset = yOffset
     #endif
-    yOffset += spot.render().frame.size.height
+    yOffset += spot.view.frame.size.height
   }
 
   /// Remove Spot at index
@@ -170,7 +170,7 @@ extension SpotsProtocol {
     guard index < spots.count else {
       return
     }
-    spots[index].render().removeFromSuperview()
+    spots[index].view.removeFromSuperview()
   }
 
   /// Set up items for a Spotable object
@@ -187,16 +187,16 @@ extension SpotsProtocol {
     }
 
     let tempSpot = Factory.resolve(component: newComponents[index])
-    tempSpot.render().frame = spot.render().frame
-    tempSpot.setup(tempSpot.render().frame.size)
-    tempSpot.layout(tempSpot.render().frame.size)
-    tempSpot.render().frame.size.height = tempSpot.computedHeight
-    tempSpot.render().layoutIfNeeded()
+    tempSpot.view.frame = spot.view.frame
+    tempSpot.setup(tempSpot.view.frame.size)
+    tempSpot.layout(tempSpot.view.frame.size)
+    tempSpot.view.frame.size.height = tempSpot.computedHeight
+    tempSpot.view.layoutIfNeeded()
     tempSpot.registerAndPrepare()
 
     tempSpot.component.size = CGSize(
       width: view.frame.width,
-      height: ceil(tempSpot.render().frame.height))
+      height: ceil(tempSpot.view.frame.height))
 
     guard let diff = Item.evaluate(tempSpot.items, oldModels: spot.items) else {
       return true
@@ -207,7 +207,7 @@ extension SpotsProtocol {
 
     for index in changes.updatedChildren {
       if index < tempSpot.compositeSpots.count {
-        spot.compositeSpots[index].spot.render().removeFromSuperview()
+        spot.compositeSpots[index].spot.view.removeFromSuperview()
         spot.compositeSpots[index] = tempSpot.compositeSpots[index]
         spot.compositeSpots[index].parentSpot = spot
       }
@@ -259,7 +259,7 @@ extension SpotsProtocol {
       for item in newItems {
         let results = spot.compositeSpots.filter({ $0.itemIndex == item.index })
         for compositeSpot in results {
-          offsets.append(compositeSpot.spot.render().contentOffset)
+          offsets.append(compositeSpot.spot.view.contentOffset)
         }
       }
 
@@ -281,7 +281,7 @@ extension SpotsProtocol {
             continue
           }
 
-          compositeSpot.spot.render().contentOffset = offsets[index]
+          compositeSpot.spot.view.contentOffset = offsets[index]
         }
       }
 
@@ -422,8 +422,8 @@ extension SpotsProtocol {
         }
       }
 
-      for removedSpot in weakSelf.spots where removedSpot.render().superview == nil {
-        if let index = weakSelf.spots.index(where: { removedSpot.render().isEqual($0.render()) }) {
+      for removedSpot in weakSelf.spots where removedSpot.view.superview == nil {
+        if let index = weakSelf.spots.index(where: { removedSpot.view.isEqual($0.view) }) {
           weakSelf.spots.remove(at: index)
         }
       }
@@ -468,7 +468,7 @@ extension SpotsProtocol {
       let oldComposites = weakSelf.spots.flatMap { $0.compositeSpots }
 
       if newComponents.count == oldComponents.count {
-        offsets = weakSelf.spots.map { $0.render().contentOffset }
+        offsets = weakSelf.spots.map { $0.view.contentOffset }
       }
 
       weakSelf.spots = newSpots
@@ -488,13 +488,13 @@ extension SpotsProtocol {
           break
         }
 
-        newComposites[index].spot.render().contentOffset = compositeSpot.spot.render().contentOffset
+        newComposites[index].spot.view.contentOffset = compositeSpot.spot.view.contentOffset
       }
 
       completion?()
 
       offsets.enumerated().forEach {
-        newSpots[$0.offset].render().contentOffset = $0.element
+        newSpots[$0.offset].view.contentOffset = $0.element
       }
 
       if let controller = self as? Controller {
@@ -555,8 +555,8 @@ extension SpotsProtocol {
       #if !os(OSX)
         if animation != .none {
           let isScrolling = weakSelf.scrollView.isDragging == true || weakSelf.scrollView.isTracking == true
-          if let superview = spot.render().superview, !isScrolling {
-            spot.render().frame.size.height = superview.frame.height
+          if let superview = spot.view.superview, !isScrolling {
+            spot.view.frame.size.height = superview.frame.height
           }
         }
       #endif
@@ -565,7 +565,7 @@ extension SpotsProtocol {
         spot.updateHeight {
           spot.afterUpdate()
           completion?()
-          spot.render().layoutIfNeeded()
+          spot.view.layoutIfNeeded()
         }
       }
     }
@@ -754,10 +754,10 @@ extension SpotsProtocol {
     default:
       spot.setup(scrollView.frame.size)
       spot.component.size = CGSize(
-        width: spot.render().frame.size.width,
-        height: ceil(spot.render().frame.size.height))
+        width: spot.view.frame.size.width,
+        height: ceil(spot.view.frame.size.height))
       spot.layout(scrollView.frame.size)
-      spot.render().layoutSubviews()
+      spot.view.layoutSubviews()
     }
   }
 

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -12,7 +12,7 @@ public extension Spotable where Self : Viewable {
   /**
    - returns: UIScrollView: A UIScrollView container for your view
    */
-  func render() -> ScrollView {
+  var view: ScrollView {
     return scrollView
   }
 
@@ -20,7 +20,7 @@ public extension Spotable where Self : Viewable {
    - parameter size: A CGSize to set the size of the view
    */
   func layout(_ size: CGSize) {
-    render().frame.size = size
+    view.frame.size = size
     #if os(iOS)
       scrollView.contentSize = size
     #endif
@@ -53,7 +53,7 @@ public extension Spotable where Self : Viewable {
   func setup(_ size: CGSize) {
     let height = component.items.reduce(0, { $0 + $1.size.height })
     let size = CGSize(width: size.width, height: height)
-    render().frame.size = size
+    view.frame.size = size
     #if os(iOS)
       scrollView.contentSize = size
     #endif

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -40,6 +40,8 @@ public protocol Spotable: class {
   var usesDynamicHeight: Bool { get }
   /// The user interface that will be used to represent the spotable object.
   var userInterface: UserInterface? { get }
+  /// Return a Spotable object as a UIScrollView
+  var view: ScrollView { get }
 
   #if os(OSX)
     /// The current responder for the Spotable object, only available on macOS.
@@ -146,11 +148,6 @@ public protocol Spotable: class {
   /// - parameter animation:  Perform reload animation.
   /// - parameter completion: A completion closure that is executed in the main queue when the view model has been reloaded.
   func reload(_ indexes: [Int]?, withAnimation animation: Animation, completion: Completion)
-
-  /// Return a Spotable object as a UIScrollView
-  ///
-  /// - returns: The UI component that the Spotable object is based on cast as a ScrollView.
-  func render() -> ScrollView
 
   /// Layout using size
   /// - parameter size: A CGSize to set the width of the UI view

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -95,7 +95,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   }
 
   public func configure(spot: Listable) {
-    inset.configure(scrollView: spot.render())
+    inset.configure(scrollView: spot.view)
   }
 
   public static func == (lhs: Layout, rhs: Layout) -> Bool {

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -259,7 +259,7 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
       spot.layout(size)
 
       spot.compositeSpots.forEach {
-        $0.spot.layout(spot.render().frame.size)
+        $0.spot.layout(spot.view.frame.size)
       }
     }
   }
@@ -293,9 +293,9 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
 
     spots.enumerated().forEach { index, spot in
       setupSpot(at: index, spot: spot)
-      animated?(spot.render())
+      animated?(spot.view)
       (spot as? CarouselSpot)?.layout.yOffset = yOffset
-      yOffset += spot.render().frame.size.height
+      yOffset += spot.view.frame.size.height
     }
   }
 
@@ -304,25 +304,25 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
   /// - parameter index: The index of the Spotable object
   /// - parameter spot:  The spotable object that is going to be setup
   open func setupSpot(at index: Int, spot: Spotable) {
-    if spot.render().superview == nil {
-      scrollView.spotsContentView.addSubview(spot.render())
+    if spot.view.superview == nil {
+      scrollView.spotsContentView.addSubview(spot.view)
     }
 
-    guard let superview = spot.render().superview else {
+    guard let superview = spot.view.superview else {
       return
     }
 
-    spot.render().frame.origin.x = 0.0
+    spot.view.frame.origin.x = 0.0
     spot.component.index = index
     spot.setup(superview.frame.size)
     spot.component.size = CGSize(
       width: superview.frame.width,
-      height: ceil(spot.render().frame.height))
+      height: ceil(spot.view.frame.height))
     spot.focusDelegate = self
     spot.registerAndPrepare()
 
     if !spot.items.isEmpty {
-      spot.render().layoutIfNeeded()
+      spot.view.layoutIfNeeded()
     }
   }
 

--- a/Sources/iOS/Extensions/Composable+iOS.swift
+++ b/Sources/iOS/Extensions/Composable+iOS.swift
@@ -27,18 +27,18 @@ public extension Composable where Self : View {
       compositeSpot.spot.setup(size)
       compositeSpot.spot.component.size = CGSize(
         width: width,
-        height: ceil(compositeSpot.spot.render().frame.size.height))
+        height: ceil(compositeSpot.spot.view.frame.size.height))
       compositeSpot.spot.layout(size)
-      compositeSpot.spot.render().layoutIfNeeded()
+      compositeSpot.spot.view.layoutIfNeeded()
 
-      compositeSpot.spot.render().frame.origin.y = height
+      compositeSpot.spot.view.frame.origin.y = height
       /// Disable scrolling for listable objects
-      compositeSpot.spot.render().isScrollEnabled = !(compositeSpot.spot is Listable)
-      compositeSpot.spot.render().frame.size.height = compositeSpot.spot.render().contentSize.height
+      compositeSpot.spot.view.isScrollEnabled = !(compositeSpot.spot is Listable)
+      compositeSpot.spot.view.frame.size.height = compositeSpot.spot.view.contentSize.height
 
-      height += compositeSpot.spot.render().contentSize.height
+      height += compositeSpot.spot.view.contentSize.height
 
-      contentView.addSubview(compositeSpot.spot.render())
+      contentView.addSubview(compositeSpot.spot.view)
     }
 
     item.size.height = height

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -6,13 +6,13 @@ extension Gridable {
   /// A computed CGFloat of the total height of all items inside of a component.
   public var computedHeight: CGFloat {
     guard usesDynamicHeight else {
-      return self.render().frame.height
+      return self.view.frame.height
     }
 
     layout.prepare()
 
     var height = layout.collectionViewContentSize.height + layout.sectionInset.top + layout.sectionInset.bottom
-    let superViewHeight = self.render().superview?.frame.size.height ?? UIScreen.main.bounds.height
+    let superViewHeight = self.view.superview?.frame.size.height ?? UIScreen.main.bounds.height
     if height > superViewHeight {
       height = superViewHeight
     }

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -4,7 +4,7 @@ extension Layout {
 
   public func configure(spot: Gridable) {
     inset.configure(layout: spot.layout)
-    inset.configure(scrollView: spot.render())
+    inset.configure(scrollView: spot.view)
 
     spot.layout.minimumInteritemSpacing = CGFloat(itemSpacing)
     spot.layout.minimumLineSpacing = CGFloat(lineSpacing)

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -8,7 +8,7 @@ public extension Listable {
   ///
   /// - returns: UIScrollView: Returns a UITableView as a UIScrollView
   ///
-  public func render() -> UIScrollView {
+  var view: UIScrollView {
     return tableView
   }
 

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -13,7 +13,7 @@ extension Controller {
     preloadView()
     viewDidAppear()
     spots.forEach {
-      $0.render().layoutSubviews()
+      $0.view.layoutSubviews()
     }
   }
 

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -95,8 +95,8 @@ class CompositionTests: XCTestCase {
     )
 
     let spot = GridSpot(component: component)
-    spot.render().frame.size = CGSize(width: 200, height: 200)
-    spot.render().layoutIfNeeded()
+    spot.view.frame.size = CGSize(width: 200, height: 200)
+    spot.view.layoutIfNeeded()
 
     var composite: Composable?
     var spotConfigurable: SpotConfigurable?
@@ -109,7 +109,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spot.compositeSpots[0].parentSpot!.component == spot.component)
     XCTAssertTrue(spot.compositeSpots[0].spot is Listable)
-    XCTAssertEqual(spot.compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spot.compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[0].spot.items.count))
 
     composite = spot.ui(at: 1)
@@ -119,7 +119,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spot.compositeSpots[1].parentSpot!.component == spot.component)
     XCTAssertTrue(spot.compositeSpots[1].spot is Listable)
-    XCTAssertEqual(spot.compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spot.compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[1].spot.items.count))
 
     composite = spot.ui(at: 2)
@@ -228,7 +228,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -238,7 +238,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
@@ -247,7 +247,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -257,7 +257,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
@@ -358,7 +358,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -368,7 +368,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       XCTAssertNotNil(composite)
@@ -377,7 +377,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
-      XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -387,7 +387,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
@@ -508,7 +508,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -518,7 +518,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       XCTAssertNotNil(composite)
@@ -527,7 +527,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
-      XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -537,7 +537,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
@@ -649,7 +649,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -659,7 +659,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
@@ -668,7 +668,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -678,7 +678,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
@@ -825,7 +825,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot?.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 11)
-      XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -835,7 +835,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       spotConfigurable = spots[1].compositeSpots[0].spot.ui(at: 0)
@@ -846,7 +846,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot?.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 11)
-      XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[1].compositeSpots[1].spot.ui(at: 0)
@@ -856,7 +856,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 11)
-      XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
@@ -968,7 +968,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -978,7 +978,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
@@ -987,7 +987,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[0].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
     spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -997,7 +997,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
-    XCTAssertEqual(spots[1].compositeSpots[1].spot.render().frame.size.height,
+    XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
                    (spotConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
@@ -1061,7 +1061,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[0].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
       spotConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
@@ -1071,7 +1071,7 @@ class CompositionTests: XCTestCase {
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
-      XCTAssertEqual(spots[0].compositeSpots[1].spot.render().frame.size.height,
+      XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
                      ((spotConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
       
       XCTAssertEqual(reloadTimes, 1)

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -17,7 +17,7 @@ class SpotableTests : XCTestCase {
     measure {
       for _ in 0..<5 {
         listSpot.append(items)
-        listSpot.render().layoutSubviews()
+        listSpot.view.layoutSubviews()
       }
     }
 
@@ -41,7 +41,7 @@ class SpotableTests : XCTestCase {
     measure {
       for _ in 0..<5 {
         controller.append(items, spotIndex: 0, withAnimation: .automatic, completion: nil)
-        controller.spots.forEach { $0.render().layoutSubviews() }
+        controller.spots.forEach { $0.view.layoutSubviews() }
       }
     }
 

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -134,7 +134,7 @@ class CarouselSpotTests: XCTestCase {
     XCTAssertEqual(spot.items[2].title, "baz")
     XCTAssertEqual(spot.items.first?.size.width, 120)
     XCTAssertEqual(spot.items.first?.size.height, 180)
-    XCTAssertEqual(spot.render().frame.size.height, 180)
+    XCTAssertEqual(spot.view.frame.size.height, 180)
 
     // Check default value of `paginate`
     XCTAssertFalse(spot.paginate)
@@ -142,7 +142,7 @@ class CarouselSpotTests: XCTestCase {
     // Check that header height gets added to the calculation
     spot.layout.headerReferenceSize.height = 20
     spot.setup(CGSize(width: 100, height: 100))
-    XCTAssertEqual(spot.render().frame.size.height, 200)
+    XCTAssertEqual(spot.view.frame.size.height, 200)
   }
 
   func testCarouselSetupWithPagination() {
@@ -166,7 +166,7 @@ class CarouselSpotTests: XCTestCase {
 
     let component = Component(json)
     let spot = CarouselSpot(component: component)
-    spot.render().layoutIfNeeded()
+    spot.view.layoutIfNeeded()
 
     // Check `span` mapping
     XCTAssertEqual(spot.component.layout!.span, 4.0)
@@ -177,7 +177,7 @@ class CarouselSpotTests: XCTestCase {
     // Check `paginate` mapping
     XCTAssertTrue(spot.paginate)
 
-    let width = spot.render().bounds.width / 4
+    let width = spot.view.bounds.width / 4
 
     // Test that spot height is equal to first item in the list
     XCTAssertEqual(spot.items.count, 4)
@@ -193,12 +193,12 @@ class CarouselSpotTests: XCTestCase {
     XCTAssertEqual(spot.items[2].size.height, 225)
     XCTAssertEqual(spot.items[3].size.width, width)
     XCTAssertEqual(spot.items[3].size.height, 225)
-    XCTAssertEqual(spot.render().frame.size.height, 247)
+    XCTAssertEqual(spot.view.frame.size.height, 247)
 
     // Check that header height gets added to the calculation
     spot.layout.headerReferenceSize.height = 20
     spot.setup(CGSize(width: 100, height: 100))
-    XCTAssertEqual(spot.render().frame.size.height, 311)
+    XCTAssertEqual(spot.view.frame.size.height, 311)
   }
 
   func testAppendItem() {

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -66,9 +66,9 @@ class DataSourceTests: XCTestCase {
         Item(title: "title 1"),
         Item(title: "title 2")
       ]))
-    spot.render().frame.size = CGSize(width: 100, height: 100)
+    spot.view.frame.size = CGSize(width: 100, height: 100)
     spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
-    spot.render().layoutSubviews()
+    spot.view.layoutSubviews()
 
     let header = spot.spotDataSource!.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)
@@ -84,9 +84,9 @@ class DataSourceTests: XCTestCase {
         Item(title: "title 1"),
         Item(title: "title 2")
       ]))
-    spot.render().frame.size = CGSize(width: 100, height: 100)
+    spot.view.frame.size = CGSize(width: 100, height: 100)
     spot.layout.headerReferenceSize = CGSize(width: 100, height: 48)
-    spot.render().layoutSubviews()
+    spot.view.layoutSubviews()
 
     let header = spot.spotDataSource!.collectionView(spot.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -70,8 +70,8 @@ class DelegateTests: XCTestCase {
         Item(title: "title 1"),
         Item(title: "title 2")
       ]))
-    spot.render().frame.size = CGSize(width: 100, height: 100)
-    spot.render().layoutSubviews()
+    spot.view.frame.size = CGSize(width: 100, height: 100)
+    spot.view.layoutSubviews()
 
     var view = spot.spotDelegate?.tableView(spot.tableView, viewForHeaderInSection: 0)
     XCTAssert(view is CustomListHeaderView)

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -122,8 +122,8 @@ class GridSpotTests: XCTestCase {
   func testSpotCollectionDelegate() {
     let items = [Item(title: "Test item")]
     let spot = GridSpot(component: Component(span: 0.0, items: items))
-    spot.render().frame.size = CGSize(width: 100, height: 100)
-    spot.render().layoutSubviews()
+    spot.view.frame.size = CGSize(width: 100, height: 100)
+    spot.view.layoutSubviews()
 
     let cell = spot.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
     XCTAssertEqual(cell?.frame.size, CGSize(width: 88, height: 88))

--- a/SpotsTests/iOS/TestLayoutExtensions.swift
+++ b/SpotsTests/iOS/TestLayoutExtensions.swift
@@ -29,10 +29,10 @@ class LayoutExtensionsTests: XCTestCase {
     XCTAssertEqual(gridSpot.layout.minimumInteritemSpacing, CGFloat(layout.itemSpacing))
     XCTAssertEqual(gridSpot.layout.minimumLineSpacing, CGFloat(layout.lineSpacing))
 
-    XCTAssertEqual(gridSpot.render().contentInset.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(gridSpot.render().contentInset.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(gridSpot.render().contentInset.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(gridSpot.render().contentInset.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(gridSpot.view.contentInset.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(gridSpot.view.contentInset.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(gridSpot.view.contentInset.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(gridSpot.view.contentInset.right, CGFloat(layout.inset.right))
   }
 
   func testConfigureListableSpot() {
@@ -41,9 +41,9 @@ class LayoutExtensionsTests: XCTestCase {
 
     layout.configure(spot: listSpot)
 
-    XCTAssertEqual(listSpot.render().contentInset.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(listSpot.render().contentInset.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(listSpot.render().contentInset.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(listSpot.render().contentInset.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(listSpot.view.contentInset.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(listSpot.view.contentInset.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(listSpot.view.contentInset.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(listSpot.view.contentInset.right, CGFloat(layout.inset.right))
   }
 }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -122,8 +122,8 @@ class RowSpotTests: XCTestCase {
   func testSpotCollectionDelegate() {
     let items = [Item(title: "Test item")]
     let spot = RowSpot(component: Component(span: 1, items: items))
-    spot.render().frame.size = CGSize(width: 100, height: 100)
-    spot.render().layoutSubviews()
+    spot.view.frame.size = CGSize(width: 100, height: 100)
+    spot.view.layoutSubviews()
     
     let cell = spot.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
     XCTAssertEqual(cell?.frame.size, CGSize(width: UIScreen.main.bounds.width, height: 44))

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -24,10 +24,10 @@ class LayoutExtensionsTests: XCTestCase {
     XCTAssertEqual(gridableLayout?.minimumInteritemSpacing, CGFloat(layout.itemSpacing))
     XCTAssertEqual(gridableLayout?.minimumLineSpacing, CGFloat(layout.lineSpacing))
 
-    XCTAssertEqual(gridSpot.render().contentInsets.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(gridSpot.render().contentInsets.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(gridSpot.render().contentInsets.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(gridSpot.render().contentInsets.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(gridSpot.view.contentInsets.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(gridSpot.view.contentInsets.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(gridSpot.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(gridSpot.view.contentInsets.right, CGFloat(layout.inset.right))
 
     XCTAssertEqual(gridableLayout?.sectionInset.top, CGFloat(layout.inset.top))
     XCTAssertEqual(gridableLayout?.sectionInset.left, CGFloat(layout.inset.left))
@@ -41,9 +41,9 @@ class LayoutExtensionsTests: XCTestCase {
 
     layout.configure(spot: listSpot)
 
-    XCTAssertEqual(listSpot.render().contentInsets.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(listSpot.render().contentInsets.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(listSpot.render().contentInsets.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(listSpot.render().contentInsets.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(listSpot.view.contentInsets.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(listSpot.view.contentInsets.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(listSpot.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(listSpot.view.contentInsets.right, CGFloat(layout.inset.right))
   }
 }


### PR DESCRIPTION
This PR renames `render()` to `view`.

It fixes this issue - https://github.com/hyperoslo/Spots/issues/392