### PR TITLE
Call layoutSubviews in updateIfNeeded

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -587,7 +587,6 @@ extension SpotsProtocol {
     }
 
     update(spotAtIndex: index, withAnimation: animation, withCompletion: { [weak self] in
-      self?.scrollView.layoutSubviews()
       completion?()
     }, {
       $0.items = items

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -581,11 +581,13 @@ extension SpotsProtocol {
    */
   public func updateIfNeeded(spotAtIndex index: Int = 0, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     guard let spot = spot(at: index, ofType: Spotable.self), !(spot.items == items) else {
+      scrollView.layoutSubviews()
       completion?()
       return
     }
 
-    update(spotAtIndex: index, withAnimation: animation, withCompletion: {
+    update(spotAtIndex: index, withAnimation: animation, withCompletion: { [weak self] in
+      self?.scrollView.layoutSubviews()
       completion?()
     }, {
       $0.items = items


### PR DESCRIPTION
Found a small issue when updating multiple components in a sequence. It could end up mis-rendering the view hierarchy. Invoking `layoutIfNeeded` corrects this issue.