### PR TITLE
Feature/core wrappers

### DIFF
--- a/Sources/Mac/Classes/GridWrapper.swift
+++ b/Sources/Mac/Classes/GridWrapper.swift
@@ -1,0 +1,34 @@
+import Cocoa
+
+class GridWrapper: NSCollectionViewItem {
+
+  static open var flipped: Bool = true
+
+  var isFlipped: Bool = true
+
+  open var coreView: FlippedView = FlippedView()
+  weak var customView: View?
+
+  func configure(with view: View) {
+    if let previousView = self.customView {
+      previousView.removeFromSuperview()
+    }
+
+    coreView.addSubview(view)
+    self.customView = view
+  }
+
+  open override func loadView() {
+    view = coreView
+  }
+
+  override func viewWillLayout() {
+    super.viewWillLayout()
+
+    self.customView?.frame = coreView.bounds
+  }
+
+  override func prepareForReuse() {
+    customView?.removeFromSuperview()
+  }
+}

--- a/Sources/Mac/Classes/ListWrapper.swift
+++ b/Sources/Mac/Classes/ListWrapper.swift
@@ -1,0 +1,35 @@
+import Cocoa
+
+class ListWrapper: NSTableRowView {
+
+  weak var view: View?
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configure(with view: View) {
+    if let previousView = self.view {
+      previousView.removeFromSuperview()
+    }
+
+    view.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
+
+    addSubview(view)
+    self.view = view
+  }
+
+  override func layoutSubtreeIfNeeded() {
+    super.layoutSubtreeIfNeeded()
+
+    self.view?.frame = bounds
+  }
+
+  override func prepareForReuse() {
+    view?.removeFromSuperview()
+  }
+}

--- a/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/DataSource+Mac+Extensions.swift
@@ -43,9 +43,14 @@ extension DataSource: NSCollectionViewDataSource {
       reuseIdentifier = spot.identifier(at: indexPath.item)
     }
 
-    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
+    var item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
 
     switch item {
+    case let item as GridWrapper:
+      if let (_, resolvedView) = Configuration.views.make(reuseIdentifier), let view = resolvedView {
+        item.configure(with: view)
+        (view as? SpotConfigurable)?.configure(&spot.component.items[indexPath.item])
+      }
     case let item as Composable:
       let spots = spot.compositeSpots.filter { $0.itemIndex == indexPath.item }
       item.contentView.frame.size.width = collectionView.frame.size.width

--- a/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
+++ b/Sources/Mac/Extensions/Delegate+Mac+Extensions.swift
@@ -104,32 +104,53 @@ extension Delegate: NSTableViewDelegate {
     }
 
     let reuseIdentifier = spot.identifier(at: row)
-    guard let cachedView = spot.type.views.make(reuseIdentifier) else { return nil }
+    var useWrapper = false
+    var craftedView = spot.type.views.make(reuseIdentifier)
 
-    var view: View? = nil
+
+    if craftedView == nil {
+      craftedView = Configuration.views.make(reuseIdentifier)
+      useWrapper = true
+    }
+
+    guard let cachedView = craftedView else {
+      return nil
+    }
+
+    var resolvedView: View? = nil
     if let type = cachedView.type {
       switch type {
       case .regular:
-        view = cachedView.view
+        resolvedView = cachedView.view
       case .nib:
-        view = tableView.make(withIdentifier: reuseIdentifier, owner: nil)
+        resolvedView = tableView.make(withIdentifier: reuseIdentifier, owner: nil)
       }
     }
 
-    switch view {
+    switch resolvedView {
     case let view as Composable:
       let spots = spot.compositeSpots.filter { $0.itemIndex == row }
       view.contentView.frame.size.width = tableView.frame.size.width
       view.contentView.frame.size.height = spot.computedHeight
       view.configure(&spot.component.items[row], compositeSpots: spots)
+    case let view as View:
+      let customView = view
+
+      if !(view is NSTableRowView) {
+        let wrapper = ListWrapper()
+        wrapper.configure(with: view)
+        resolvedView = wrapper
+      }
+
+      (customView as? SpotConfigurable)?.configure(&spot.component.items[row])
     case let view as SpotConfigurable:
       view.configure(&spot.component.items[row])
     default: break
     }
 
-    (view as? NSTableRowView)?.identifier = reuseIdentifier
+    (resolvedView as? NSTableRowView)?.identifier = reuseIdentifier
 
-    return view as? NSTableRowView
+    return resolvedView as? NSTableRowView
   }
 
   public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {

--- a/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
+++ b/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
@@ -99,12 +99,14 @@ extension Gridable {
   }
 
   public func identifier(at index: Int) -> String {
-    guard let item = item(at: index), type(of: self).grids.storage[item.kind] != nil
-      else {
-        return type(of: self).grids.defaultIdentifier
-    }
 
-    return item.kind
+    if let item = item(at: index), type(of: self).grids.storage[item.kind] != nil {
+      return item.kind
+    } else if let item = item(at: index), Configuration.views.storage[item.kind] != nil {
+      return item.kind
+    } else {
+      return type(of: self).grids.defaultIdentifier
+    }
   }
 
   /// Prepares a view model item before being used by the UI component

--- a/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
+++ b/Sources/Mac/Extensions/Gridable+Extensions+Mac.swift
@@ -55,6 +55,15 @@ extension Gridable {
   // MARK: - Spotable
 
   public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(let _):
+        self.collectionView.register(GridWrapper.self, forItemWithIdentifier: identifier)
+      case .nib(let nib):
+        self.collectionView.register(nib, forItemWithIdentifier: identifier)
+      }
+    }
+
     for (identifier, item) in type(of: self).grids.storage {
       switch item {
       case .classType(let classType):

--- a/Sources/Shared/Classes/Registry.swift
+++ b/Sources/Shared/Classes/Registry.swift
@@ -13,6 +13,8 @@ public enum RegistryType: String {
 /// A registry that is used internally when resolving kind to the corresponding spot.
 public struct Registry {
 
+  var useCache: Bool = false
+
   public enum Item {
     case classType(View.Type)
     case nib(Nib)
@@ -58,6 +60,10 @@ public struct Registry {
 
   /// A cache that stores instances of created views
   fileprivate var cache: NSCache = NSCache<NSString, View>()
+
+  init(useCache: Bool = true) {
+    self.useCache = useCache
+  }
 
   /**
    Empty the current view cache
@@ -107,7 +113,7 @@ public struct Registry {
       #endif
     }
 
-    if let view = view {
+    if let view = view, useCache {
       let cacheIdentifier: String = "\(registryType.rawValue)-\(identifier)"
       cache.setObject(view, forKey: cacheIdentifier as NSString)
     }

--- a/Sources/Shared/Extensions/SpotConfigurable+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotConfigurable+Extensions.swift
@@ -1,0 +1,4 @@
+public extension SpotConfigurable {
+
+  func prepareForReuse() {}
+}

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -391,12 +391,13 @@ public extension Spotable {
   ///
   /// - returns: A string identifier for the view, defaults to the `defaultIdentifier` on the Spotable object.
   public func identifier(at index: Int) -> String {
-    guard let item = item(at: index), type.views.storage[item.kind] != nil
-      else {
-        return type.views.defaultIdentifier
+    if let item = item(at: index), type.views.storage[item.kind] != nil {
+      return item.kind
+    } else if let item = item(at: index), Configuration.views.storage[item.kind] != nil {
+      return item.kind
+    } else {
+      return type.views.defaultIdentifier
     }
-
-    return item.kind
   }
 
   /// Register and prepare all items in the Spotable object.

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -1,0 +1,23 @@
+import Brick
+
+public struct Configuration {
+
+  public static var views: Registry = Registry(useCache: false)
+
+  /// Register a nib file with identifier on the Spotable object.
+  ///
+  /// - parameter nib:        A Nib file that should be used for identifier
+  /// - parameter identifier: A StringConvertible identifier for the registered nib.
+  public static func register(nib: Nib, identifier: StringConvertible) {
+    self.views.storage[identifier.string] = Registry.Item.nib(nib)
+  }
+
+  /// Register a view with an identifier
+  ///
+  /// - parameter view:       The view type that should be registered with an identifier.
+  /// - parameter identifier: A StringConvertible identifier for the registered view type.
+  public static func register(view: View.Type, identifier: StringConvertible) {
+    self.views.storage[identifier.string] = Registry.Item.classType(view)
+  }
+
+}

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+class GridWrapper: UICollectionViewCell {
+
+  weak var view: View?
+
+  func configure(with view: View) {
+    if let previousView = self.view {
+      previousView.removeFromSuperview()
+    }
+
+    contentView.addSubview(view)
+    self.view = view
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    self.view?.frame = contentView.bounds
+  }
+
+  override func prepareForReuse() {
+    view?.removeFromSuperview()
+  }
+}

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -177,29 +177,6 @@ open class ListSpot: NSObject, Listable {
     }
   }
 
-  // MARK: - Spotable
-
-  /// Register all identifier to UITableView.
-  open func register() {
-    for (identifier, item) in type(of: self).views.storage {
-      switch item {
-      case .classType(let classType):
-        self.tableView.register(classType, forCellReuseIdentifier: identifier)
-      case .nib(let nib):
-        self.tableView.register(nib, forCellReuseIdentifier: identifier)
-      }
-    }
-
-    for (identifier, item) in type(of: self).headers.storage {
-      switch item {
-      case .classType(let classType):
-        self.tableView.register(classType, forHeaderFooterViewReuseIdentifier: identifier)
-      case .nib(let nib):
-        self.tableView.register(nib, forHeaderFooterViewReuseIdentifier: identifier)
-      }
-    }
-  }
-
   /// Register header view with identifier
   ///
   /// - parameter header:     The view type that you want to register.

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+class ListWrapper: UITableViewCell {
+
+  weak var view: View?
+
+  override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    super.init(style: .default, reuseIdentifier: reuseIdentifier)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configure(with view: View) {
+    if let previousView = self.view {
+      previousView.removeFromSuperview()
+    }
+
+    contentView.addSubview(view)
+    self.view = view
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    self.view?.frame = contentView.bounds
+  }
+
+  override func prepareForReuse() {
+    view?.removeFromSuperview()
+  }
+}

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -63,6 +63,22 @@ extension DataSource: UICollectionViewDataSource {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
 
     switch cell {
+    case let cell as GridWrapper:
+      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind),
+        let customView = view {
+        cell.configure(with: customView)
+
+        if let configurableView = customView as? SpotConfigurable {
+          configurableView.configure(&spot.component.items[indexPath.item])
+
+          if spot.component.items[indexPath.item].size.height == 0.0 {
+            spot.component.items[indexPath.item].size = configurableView.preferredViewSize
+          }
+
+        } else {
+          spot.component.items[indexPath.item].size.height = customView.frame.size.height
+        }
+      }
     case let cell as Composable:
       let compositeSpots = spot.compositeSpots.filter({ $0.itemIndex == indexPath.item })
       cell.configure(&spot.component.items[indexPath.item], compositeSpots: compositeSpots)
@@ -115,6 +131,22 @@ extension DataSource: UITableViewDataSource {
       .dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
 
     switch cell {
+    case let cell as ListWrapper:
+      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind),
+        let customView = view {
+        cell.configure(with: customView)
+
+        if let configurableView = customView as? SpotConfigurable {
+          configurableView.configure(&spot.component.items[indexPath.item])
+
+          if spot.component.items[indexPath.item].size.height == 0.0 {
+            spot.component.items[indexPath.item].size = configurableView.preferredViewSize
+          }
+
+        } else {
+          spot.component.items[indexPath.item].size.height = customView.frame.size.height
+        }
+      }
     case let cell as Composable:
       let compositeSpots = spot.compositeSpots.filter({ $0.itemIndex == indexPath.item })
       cell.configure(&spot.component.items[indexPath.item], compositeSpots: compositeSpots)

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -117,6 +117,15 @@ extension Gridable {
 
   /// Register all views in Registry on UICollectionView
   public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(let _):
+        self.collectionView.register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
+      case .nib(let nib):
+        self.collectionView.register(nib, forCellWithReuseIdentifier: identifier)
+      }
+    }
+
     for (identifier, item) in type(of: self).views.storage {
       switch item {
       case .classType(let classType):

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -36,4 +36,38 @@ public extension Listable {
     return component.items[0...item.index]
       .reduce(0, { $0 + $1.size.height })
   }
+
+  /// Register all identifier to UITableView.
+  public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(_):
+        self.tableView.register(ListWrapper.self, forCellReuseIdentifier: identifier)
+      case .nib(let nib):
+        self.tableView.register(nib, forCellReuseIdentifier: identifier)
+      }
+    }
+
+    for (identifier, item) in type(of: self).views.storage {
+      switch item {
+      case .classType(let classType):
+        guard classType.init() is UITableViewCell else {
+          self.tableView.register(ListWrapper.self, forCellReuseIdentifier: identifier)
+          return
+        }
+        self.tableView.register(classType, forCellReuseIdentifier: identifier)
+      case .nib(let nib):
+        self.tableView.register(nib, forCellReuseIdentifier: identifier)
+      }
+    }
+
+    for (identifier, item) in type(of: self).headers.storage {
+      switch item {
+      case .classType(let classType):
+        self.tableView.register(classType, forHeaderFooterViewReuseIdentifier: identifier)
+      case .nib(let nib):
+        self.tableView.register(nib, forHeaderFooterViewReuseIdentifier: identifier)
+      }
+    }
+  }
 }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -151,6 +151,10 @@
 		BD1BFB5A1DA7A9AC00BB55E1 /* ScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BFB591DA7A9AC00BB55E1 /* ScrollDelegate.swift */; };
 		BD1BFB5B1DA7A9AC00BB55E1 /* ScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BFB591DA7A9AC00BB55E1 /* ScrollDelegate.swift */; };
 		BD1BFB5C1DA7A9AC00BB55E1 /* ScrollDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BFB591DA7A9AC00BB55E1 /* ScrollDelegate.swift */; };
+		BD21000C1E39DFB2005AE919 /* ListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21000A1E39DFB2005AE919 /* ListWrapper.swift */; };
+		BD21000D1E39DFB2005AE919 /* ListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21000A1E39DFB2005AE919 /* ListWrapper.swift */; };
+		BD21000E1E39DFB2005AE919 /* GridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21000B1E39DFB2005AE919 /* GridWrapper.swift */; };
+		BD21000F1E39DFB2005AE919 /* GridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21000B1E39DFB2005AE919 /* GridWrapper.swift */; };
 		BD352E5F1CBAD6EC002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E5E1CBAD6EC002CD032 /* Brick.framework */; };
 		BD352E611CBAD6F9002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E601CBAD6F9002CD032 /* Brick.framework */; };
 		BD39001B1DFE8E91007C0411 /* CompositeSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE77F0D1DFDE4CF0012D2B0 /* CompositeSpot.swift */; };
@@ -212,9 +216,14 @@
 		BD8B1EB21D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
 		BD8B1EB31D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
 		BD8B1EB41D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */; };
+		BD972E041E39EB7C00046F21 /* ListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD972E031E39EB7C00046F21 /* ListWrapper.swift */; };
+		BD972E061E39EB8300046F21 /* GridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD972E051E39EB8300046F21 /* GridWrapper.swift */; };
 		BD978ACD1DD99A4700B8F7AB /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD978ACC1DD99A4700B8F7AB /* Spotable+Mutation.swift */; };
 		BD978ACE1DD99A4700B8F7AB /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD978ACC1DD99A4700B8F7AB /* Spotable+Mutation.swift */; };
 		BD978ACF1DD99A4700B8F7AB /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD978ACC1DD99A4700B8F7AB /* Spotable+Mutation.swift */; };
+		BDA335EA1E39DF54008E03DF /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA335E91E39DF54008E03DF /* Configuration.swift */; };
+		BDA335EB1E39DF54008E03DF /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA335E91E39DF54008E03DF /* Configuration.swift */; };
+		BDA335EC1E39DF54008E03DF /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA335E91E39DF54008E03DF /* Configuration.swift */; };
 		BDA8DAF51DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */; };
 		BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */; };
 		BDA8DAF81DCF423A00A4A8DD /* RowSpotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA8DAF71DCF423A00A4A8DD /* RowSpotCell.swift */; };
@@ -226,6 +235,9 @@
 		BDB34C241E2F87B2007A1C3B /* Layout+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB34C231E2F87B2007A1C3B /* Layout+iOS.swift */; };
 		BDB34C251E2F87B2007A1C3B /* Layout+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB34C231E2F87B2007A1C3B /* Layout+iOS.swift */; };
 		BDB34C271E2F87DA007A1C3B /* Layout+Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB34C261E2F87DA007A1C3B /* Layout+Mac.swift */; };
+		BDC4B6731E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC4B6721E39E0C80012583F /* SpotConfigurable+Extensions.swift */; };
+		BDC4B6741E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC4B6721E39E0C80012583F /* SpotConfigurable+Extensions.swift */; };
+		BDC4B6751E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC4B6721E39E0C80012583F /* SpotConfigurable+Extensions.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -374,6 +386,8 @@
 		BD129F441D7B2F91009AC164 /* TypeAlias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BD1BFB551DA7A9A300BB55E1 /* ScrollDelegate+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScrollDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BD1BFB591DA7A9AC00BB55E1 /* ScrollDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollDelegate.swift; sourceTree = "<group>"; };
+		BD21000A1E39DFB2005AE919 /* ListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListWrapper.swift; sourceTree = "<group>"; };
+		BD21000B1E39DFB2005AE919 /* GridWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridWrapper.swift; sourceTree = "<group>"; };
 		BD352E5E1CBAD6EC002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/iOS/Brick.framework; sourceTree = "<group>"; };
 		BD352E601CBAD6F9002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/Mac/Brick.framework; sourceTree = "<group>"; };
 		BD412B651DEFF9080064FD12 /* SpotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotView.swift; sourceTree = "<group>"; };
@@ -405,7 +419,10 @@
 		BD7397461D718CDB000AF2DE /* Spots-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD73974A1D718D38000AF2DE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
 		BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrandCentralDispatch.swift; sourceTree = "<group>"; };
+		BD972E031E39EB7C00046F21 /* ListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListWrapper.swift; sourceTree = "<group>"; };
+		BD972E051E39EB8300046F21 /* GridWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridWrapper.swift; sourceTree = "<group>"; };
 		BD978ACC1DD99A4700B8F7AB /* Spotable+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Spotable+Mutation.swift"; sourceTree = "<group>"; };
+		BDA335E91E39DF54008E03DF /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestRowSpot.swift; sourceTree = "<group>"; };
 		BDA8DAF71DCF423A00A4A8DD /* RowSpotCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowSpotCell.swift; sourceTree = "<group>"; };
 		BDA8DAFA1DCF42D800A4A8DD /* RowSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowSpot.swift; sourceTree = "<group>"; };
@@ -415,6 +432,7 @@
 		BDB34C261E2F87DA007A1C3B /* Layout+Mac.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Layout+Mac.swift"; sourceTree = "<group>"; };
 		BDB538321C444D460005E498 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BDC4B6721E39E0C80012583F /* SpotConfigurable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotConfigurable+Extensions.swift"; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
 		BDCFCD451DCA82EC0047E84C /* Listable+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Listable+Extension.swift"; sourceTree = "<group>"; };
 		BDD63FAB1D941A80008E885A /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/tvOS/Tailor.framework; sourceTree = "<group>"; };
@@ -544,6 +562,8 @@
 		BD129DA31D7B2B6C009AC164 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				BD21000A1E39DFB2005AE919 /* ListWrapper.swift */,
+				BD21000B1E39DFB2005AE919 /* GridWrapper.swift */,
 				BD129DA41D7B2B6C009AC164 /* CarouselComposite.swift */,
 				BD129DA51D7B2B6C009AC164 /* CarouselSpot.swift */,
 				BD129DA61D7B2B6C009AC164 /* CarouselSpotCell.swift */,
@@ -578,22 +598,24 @@
 			isa = PBXGroup;
 			children = (
 				BD129E081D7B2CDE009AC164 /* CarouselSpot.swift */,
+				BDDB1A511E09532500DFF834 /* CarouselSpotCell.swift */,
 				BD129E0A1D7B2CDE009AC164 /* CollectionViewLeftLayout.swift */,
 				BD129E111D7B2CDE009AC164 /* Controller.swift */,
 				BDDB1A431E093AED00DFF834 /* GridComposite.swift */,
 				BD129E0B1D7B2CDE009AC164 /* GridSpot.swift */,
+				BDDB1A4D1E0952EF00DFF834 /* GridSpotCell.swift */,
 				BD129E0C1D7B2CDE009AC164 /* GridSpotItem.swift */,
+				BD972E051E39EB8300046F21 /* GridWrapper.swift */,
 				BDDB1A451E093AF400DFF834 /* ListComposite.swift */,
 				BD129E0D1D7B2CDE009AC164 /* ListSpot.swift */,
+				BDDB1A4F1E09530C00DFF834 /* ListSpotCell.swift */,
 				BD129E0E1D7B2CDE009AC164 /* ListSpotItem.swift */,
+				BD972E031E39EB7C00046F21 /* ListWrapper.swift */,
 				BD129E0F1D7B2CDE009AC164 /* NoScrollView.swift */,
 				BDA8DAFD1DCF4CE100A4A8DD /* RowSpot.swift */,
 				BDA8DAFF1DCF4D0A00A4A8DD /* RowSpotItem.swift */,
 				BD129E101D7B2CDE009AC164 /* SpotsContentView.swift */,
 				BD129E121D7B2CDE009AC164 /* SpotsScrollView.swift */,
-				BDDB1A4D1E0952EF00DFF834 /* GridSpotCell.swift */,
-				BDDB1A4F1E09530C00DFF834 /* ListSpotCell.swift */,
-				BDDB1A511E09532500DFF834 /* CarouselSpotCell.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -673,6 +695,7 @@
 				BD129F311D7B2F91009AC164 /* SpotsProtocol+LiveEditing.swift */,
 				BD129F321D7B2F91009AC164 /* SpotsProtocol+Mutation.swift */,
 				BD129F331D7B2F91009AC164 /* Viewable+Extensions.swift */,
+				BDC4B6721E39E0C80012583F /* SpotConfigurable+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -699,6 +722,7 @@
 			isa = PBXGroup;
 			children = (
 				BD129F401D7B2F91009AC164 /* Component.swift */,
+				BDA335E91E39DF54008E03DF /* Configuration.swift */,
 				BD45D9701E2F408100C2D6B2 /* ContentInset.swift */,
 				BD8B1EB11D93D813000C3F53 /* GrandCentralDispatch.swift */,
 				BD129F411D7B2F91009AC164 /* GridableMeta.swift */,
@@ -1225,6 +1249,7 @@
 				BD129F921D7B2F91009AC164 /* StateCache.swift in Sources */,
 				BD129F861D7B2F91009AC164 /* Viewable.swift in Sources */,
 				BDDB1A421E0937BF00DFF834 /* Composable.swift in Sources */,
+				BDC4B6751E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */,
 				BD129DCE1D7B2B6C009AC164 /* Controller.swift in Sources */,
 				BD978ACF1DD99A4700B8F7AB /* Spotable+Mutation.swift in Sources */,
 				BD129DC41D7B2B6C009AC164 /* GridSpotCell.swift in Sources */,
@@ -1245,6 +1270,7 @@
 				BD129D921D7B295F009AC164 /* Controller+UIScrollViewDelegate.swift in Sources */,
 				BD129F7D1D7B2F91009AC164 /* SpotConfigurable.swift in Sources */,
 				BD129F6E1D7B2F91009AC164 /* Componentable.swift in Sources */,
+				BD21000F1E39DFB2005AE919 /* GridWrapper.swift in Sources */,
 				BD129F681D7B2F91009AC164 /* Viewable+Extensions.swift in Sources */,
 				BDCFCD481DCA82EC0047E84C /* Listable+Extension.swift in Sources */,
 				BD129DC61D7B2B6C009AC164 /* ListComposite.swift in Sources */,
@@ -1254,6 +1280,7 @@
 				BDA8DAF91DCF423A00A4A8DD /* RowSpotCell.swift in Sources */,
 				BD129F5F1D7B2F91009AC164 /* SpotsProtocol+Extensions.swift in Sources */,
 				BD45D9731E2F408100C2D6B2 /* ContentInset.swift in Sources */,
+				BD21000D1E39DFB2005AE919 /* ListWrapper.swift in Sources */,
 				BD129DCA1D7B2B6C009AC164 /* ListSpotCell.swift in Sources */,
 				BD129DB81D7B2B6C009AC164 /* CarouselSpotCell.swift in Sources */,
 				BDA8DAFC1DCF42D800A4A8DD /* RowSpot.swift in Sources */,
@@ -1281,6 +1308,7 @@
 				BD129F771D7B2F91009AC164 /* Spotable.swift in Sources */,
 				BD129DC81D7B2B6C009AC164 /* ListSpot.swift in Sources */,
 				BD129F711D7B2F91009AC164 /* Gridable.swift in Sources */,
+				BDA335EC1E39DF54008E03DF /* Configuration.swift in Sources */,
 				BD129DB61D7B2B6C009AC164 /* CarouselSpot.swift in Sources */,
 				BD63B0521DD8D30400C52D73 /* UserInterface.swift in Sources */,
 			);
@@ -1330,6 +1358,7 @@
 				BD129DC91D7B2B6C009AC164 /* ListSpotCell.swift in Sources */,
 				BD45D96E1E2F406600C2D6B2 /* ContentInset+iOS.swift in Sources */,
 				BD129DC51D7B2B6C009AC164 /* ListComposite.swift in Sources */,
+				BDA335EA1E39DF54008E03DF /* Configuration.swift in Sources */,
 				BD978ACD1DD99A4700B8F7AB /* Spotable+Mutation.swift in Sources */,
 				BD129F7B1D7B2F91009AC164 /* SpotConfigurable.swift in Sources */,
 				BD129DB51D7B2B6C009AC164 /* CarouselSpot.swift in Sources */,
@@ -1364,9 +1393,11 @@
 				BDDB1A401E0937BF00DFF834 /* Composable.swift in Sources */,
 				BDA8DAFB1DCF42D800A4A8DD /* RowSpot.swift in Sources */,
 				BD129DC31D7B2B6C009AC164 /* GridSpotCell.swift in Sources */,
+				BD21000E1E39DFB2005AE919 /* GridWrapper.swift in Sources */,
 				BD129F4E1D7B2F91009AC164 /* ViewSpot.swift in Sources */,
 				BD129F5D1D7B2F91009AC164 /* SpotsProtocol+Extensions.swift in Sources */,
 				BD129DC11D7B2B6C009AC164 /* GridSpot.swift in Sources */,
+				BDC4B6731E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */,
 				BD8B1EB21D93D813000C3F53 /* GrandCentralDispatch.swift in Sources */,
 				BD129F7E1D7B2F91009AC164 /* SpotsDelegates.swift in Sources */,
 				BD45D9631E2EADA600C2D6B2 /* Layout.swift in Sources */,
@@ -1384,6 +1415,7 @@
 				BD129F751D7B2F91009AC164 /* Spotable.swift in Sources */,
 				BD129F901D7B2F91009AC164 /* StateCache.swift in Sources */,
 				BD129D8B1D7B295F009AC164 /* Listable+Extensions+iOS.swift in Sources */,
+				BD21000C1E39DFB2005AE919 /* ListWrapper.swift in Sources */,
 				BD129F6F1D7B2F91009AC164 /* Gridable.swift in Sources */,
 				BD63B0501DD8D30400C52D73 /* UserInterface.swift in Sources */,
 				BD45D96B1E2F403500C2D6B2 /* SectionInset+iOS.swift in Sources */,
@@ -1443,6 +1475,8 @@
 				BD129F7F1D7B2F91009AC164 /* SpotsDelegates.swift in Sources */,
 				BDEFF53D1DD0F18B00FC0537 /* DataSource.swift in Sources */,
 				BD129E291D7B2CDE009AC164 /* SpotsContentView.swift in Sources */,
+				BDA335EB1E39DF54008E03DF /* Configuration.swift in Sources */,
+				BD972E041E39EB7C00046F21 /* ListWrapper.swift in Sources */,
 				BD129F7C1D7B2F91009AC164 /* SpotConfigurable.swift in Sources */,
 				BD129E361D7B2CDE009AC164 /* Viewable+Mac.swift in Sources */,
 				BD129F5B1D7B2F91009AC164 /* Spotable+Extensions.swift in Sources */,
@@ -1475,9 +1509,11 @@
 				BD129F5E1D7B2F91009AC164 /* SpotsProtocol+Extensions.swift in Sources */,
 				BD129E241D7B2CDE009AC164 /* GridSpot.swift in Sources */,
 				BDEFF54B1DD1A64400FC0537 /* DataSource+Mac+Extensions.swift in Sources */,
+				BDC4B6741E39E0C80012583F /* SpotConfigurable+Extensions.swift in Sources */,
 				BD129E351D7B2CDE009AC164 /* NSTableView+UserInterface.swift in Sources */,
 				BD129E2B1D7B2CDE009AC164 /* SpotsScrollView.swift in Sources */,
 				BD45D9641E2EADA600C2D6B2 /* Layout.swift in Sources */,
+				BD972E061E39EB8300046F21 /* GridWrapper.swift in Sources */,
 				BD129F581D7B2F91009AC164 /* Gridable+Extensions.swift in Sources */,
 				BD129F641D7B2F91009AC164 /* SpotsProtocol+Mutation.swift in Sources */,
 				BD129F551D7B2F91009AC164 /* Component+Extension.swift in Sources */,


### PR DESCRIPTION
This PR adds support for `ListWrapper` and `GridWrapper`'s.

What this means is that you can register any view that you want and internally that view will be wrapped in the correct underlaying UI element when it will be displayed on screen.

This is a huge improvement as your views are no longer tied to the foundation class that you are using when building your component.

You can register any view that you want on `Configuration.views`.

#### Example
```swift
Configuration.register(view: TextView.self, identifier: "text-view")
```

This feature is available on `macOS`, `tvOS` and `iOS`.

This PR solves this issue: https://github.com/hyperoslo/Spots/issues/438