### PR TITLE
Set inset only once

### DIFF
--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -48,7 +48,6 @@ extension DataSource: UICollectionViewDataSource {
       return UICollectionReusableView()
     }
 
-
     let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
                                                                withReuseIdentifier: identifier,
                                                                for: indexPath)

--- a/Sources/iOS/Extensions/Inset+iOS.swift
+++ b/Sources/iOS/Extensions/Inset+iOS.swift
@@ -11,14 +11,4 @@ extension Inset {
     scrollView.contentInset.bottom = CGFloat(self.bottom)
     scrollView.contentInset.right = CGFloat(self.right)
   }
-
-  /// Configure section insets on flow layouts
-  ///
-  /// - Parameter layout: The flow layout that should be configured.
-  public func configure(layout: FlowLayout) {
-    layout.sectionInset.top = CGFloat(self.top)
-    layout.sectionInset.left = CGFloat(self.left)
-    layout.sectionInset.bottom = CGFloat(self.bottom)
-    layout.sectionInset.right = CGFloat(self.right)
-  }
 }

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -3,7 +3,6 @@ import UIKit
 extension Layout {
 
   public func configure(spot: Gridable) {
-    inset.configure(layout: spot.layout)
     inset.configure(scrollView: spot.view)
 
     spot.layout.minimumInteritemSpacing = CGFloat(itemSpacing)

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -43,7 +43,7 @@ extension DataSource: NSCollectionViewDataSource {
       reuseIdentifier = spot.identifier(at: indexPath.item)
     }
 
-    var item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
+    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
 
     switch item {
     case let item as GridWrapper:

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -106,13 +106,10 @@ extension Delegate: NSTableViewDelegate {
     }
 
     let reuseIdentifier = spot.identifier(at: row)
-    var useWrapper = false
     var craftedView = spot.type.views.make(reuseIdentifier)
-
 
     if craftedView == nil {
       craftedView = Configuration.views.make(reuseIdentifier)
-      useWrapper = true
     }
 
     guard let cachedView = craftedView else {

--- a/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
@@ -57,7 +57,7 @@ extension Gridable {
   public func register() {
     for (identifier, item) in Configuration.views.storage {
       switch item {
-      case .classType(let _):
+      case .classType( _):
         self.collectionView.register(GridWrapper.self, forItemWithIdentifier: identifier)
       case .nib(let nib):
         self.collectionView.register(nib, forItemWithIdentifier: identifier)

--- a/Sources/macOS/Extensions/Inset+macOS.swift
+++ b/Sources/macOS/Extensions/Inset+macOS.swift
@@ -11,14 +11,4 @@ extension Inset {
     scrollView.contentInsets.bottom = CGFloat(self.bottom)
     scrollView.contentInsets.right = CGFloat(self.right)
   }
-
-  /// Configure section insets on flow layouts
-  ///
-  /// - Parameter layout: The flow layout that should be configured.
-  func configure(layout: FlowLayout) {
-    layout.sectionInset.top = CGFloat(self.top)
-    layout.sectionInset.left = CGFloat(self.left)
-    layout.sectionInset.bottom = CGFloat(self.bottom)
-    layout.sectionInset.right = CGFloat(self.right)
-  }
 }

--- a/Sources/macOS/Extensions/Layout+macOS.swift
+++ b/Sources/macOS/Extensions/Layout+macOS.swift
@@ -6,7 +6,6 @@ extension Layout {
     inset.configure(scrollView: spot.view)
 
     if let layout = spot.layout as? FlowLayout {
-      inset.configure(layout: layout)
       layout.minimumInteritemSpacing = CGFloat(itemSpacing)
       layout.minimumLineSpacing = CGFloat(lineSpacing)
     }

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -28,11 +28,6 @@ class LayoutExtensionsTests: XCTestCase {
     XCTAssertEqual(gridSpot.view.contentInsets.left, CGFloat(layout.inset.left))
     XCTAssertEqual(gridSpot.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
     XCTAssertEqual(gridSpot.view.contentInsets.right, CGFloat(layout.inset.right))
-
-    XCTAssertEqual(gridableLayout?.sectionInset.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(gridableLayout?.sectionInset.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(gridableLayout?.sectionInset.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(gridableLayout?.sectionInset.right, CGFloat(layout.inset.right))
   }
 
   func testConfigureListableSpot() {


### PR DESCRIPTION
I don't think we need to care about section inset if we're already using `contentInset` on a scroll view. Otherwise it's being set twice.