### PR TITLE
Resolve views from Configuration.views

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -221,7 +221,13 @@ public extension Spotable {
         ? Self.views.defaultIdentifier
         : item.kind
 
-      guard let (_, view) = Self.views.make(kind) else {
+      let view: View?
+
+      if let (_, resolvedView) = Self.views.make(kind) {
+        view = resolvedView
+      } else if let (_, resolvedView) = Configuration.views.make(kind) {
+        view = resolvedView
+      } else {
         return nil
       }
 


### PR DESCRIPTION
This PR refactors:

```swift
func configure(item: Item, at index: Int, usesViewSize: Bool = false) -> Item? {
```

To also try and resolve views that are located in `Configuration.views`.