### PR TITLE
Use identifier to find kind instead of if statement

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -217,9 +217,7 @@ public extension Spotable {
 
     #if !os(OSX)
       fullWidth = UIScreen.main.bounds.width
-      kind = item.kind.isEmpty || Self.views.storage[item.kind] == nil
-        ? Self.views.defaultIdentifier
-        : item.kind
+      kind = identifier(at: index)
 
       let view: View?
 


### PR DESCRIPTION
This PR fixes the issue of mapping regular views registered on `Configuration.views`. The issue was that it was using the wrong identifier when looking up the view. Not it uses `identifier(at: index)` which searches both in the current type and falls back to using `Configurator.views`.