### PR TITLE
Improve/init for views

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -221,9 +221,9 @@ public extension Spotable {
 
       let view: View?
 
-      if let (_, resolvedView) = Self.views.make(kind) {
+      if let (_, resolvedView) = Self.views.make(kind, parentFrame: self.view.frame) {
         view = resolvedView
-      } else if let (_, resolvedView) = Configuration.views.make(kind) {
+      } else if let (_, resolvedView) = Configuration.views.make(kind, parentFrame: self.view.frame) {
         view = resolvedView
       } else {
         return nil

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -73,7 +73,7 @@ public struct Registry {
    - parameter identifier: A reusable identifier for the view
    - returns: A tuple with an optional registry type and view
    */
-  func make(_ identifier: String) -> (type: RegistryType?, view: View?)? {
+  func make(_ identifier: String, parentFrame: CGRect = CGRect.zero) -> (type: RegistryType?, view: View?)? {
     guard let item = storage[identifier] else { return nil }
 
     let registryType: RegistryType
@@ -91,7 +91,7 @@ public struct Registry {
         }
       #endif
 
-      view = classType.init()
+      view = classType.init(frame: frame)
     case .nib(let nib):
       registryType = .nib
       let cacheIdentifier: String = "\(registryType.rawValue)-\(identifier)"

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -91,7 +91,7 @@ public struct Registry {
         }
       #endif
 
-      view = classType.init(frame: frame)
+      view = classType.init(frame: parentFrame)
     case .nib(let nib):
       registryType = .nib
       let cacheIdentifier: String = "\(registryType.rawValue)-\(identifier)"


### PR DESCRIPTION
This PR refactors the internal process of initialising views to prepare views. Now it will be initialised with the view of the parent view. This will help solve constraint warnings that might occur if you create a view without setting the frame.