### PR TITLE
Registry: Import CoreGraphics [6.0.0]

### DIFF
--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Brick
-
-#if os(OSX)
-import Cocoa
-#endif
+import CoreGraphics
 
 /// A registry that is used internally when resolving kind to the corresponding spot.
 public struct Registry {


### PR DESCRIPTION
Without it, compilation fails due to CGRect not being available. This is a `6.0.0` targeted cherry-pick of  https://github.com/hyperoslo/Spots/pull/453