### PR TITLE
CarouselSpot: Fix failing test

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -97,7 +97,8 @@ public extension Spotable {
         if layout.span > 0.0 {
           #if os(OSX)
             if let gridable = self as? Gridable,
-              let layout = gridable.layout as? FlowLayout {
+              let layout = gridable.layout as? FlowLayout,
+              let componentLayout = component.layout {
               let newWidth = gridable.collectionView.frame.width / CGFloat(componentLayout.span) - layout.sectionInset.left - layout.sectionInset.right
 
               if newWidth > 0.0 {

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Brick
-import CoreGraphics
+
+#if os(OSX)
+  import Cocoa
+#else
+  import CoreGraphics
+#endif
 
 /// A registry that is used internally when resolving kind to the corresponding spot.
 public struct Registry {

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -169,13 +169,13 @@ class CarouselSpotTests: XCTestCase {
 
     let component = Component(json)
     let spot = CarouselSpot(component: component)
-    spot.view.layoutIfNeeded()
 
     // Check `span` mapping
     XCTAssertEqual(spot.component.layout!.span, 4.0)
 
     spot.setup(CGSize(width: 667, height: 225))
     spot.prepareItems()
+    spot.view.layoutSubviews()
 
     // Check `paginate` mapping
     XCTAssertTrue(spot.collectionView.isPagingEnabled)
@@ -201,7 +201,8 @@ class CarouselSpotTests: XCTestCase {
     // Check that header height gets added to the calculation
     spot.layout.headerReferenceSize.height = 20
     spot.setup(CGSize(width: 100, height: 100))
-    XCTAssertEqual(spot.view.frame.size.height, 130)
+    spot.view.layoutSubviews()
+    XCTAssertEqual(spot.view.frame.size.height, 108)
   }
 
   func testAppendItem() {

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -189,19 +189,19 @@ class CarouselSpotTests: XCTestCase {
     XCTAssertEqual(spot.items[2].title, "baz")
     XCTAssertEqual(spot.items[3].title, "bazar")
     XCTAssertEqual(spot.items[0].size.width, width)
-    XCTAssertEqual(spot.items[0].size.height, 225)
+    XCTAssertEqual(spot.items[0].size.height, 88)
     XCTAssertEqual(spot.items[1].size.width, width)
-    XCTAssertEqual(spot.items[1].size.height, 225)
+    XCTAssertEqual(spot.items[1].size.height, 88)
     XCTAssertEqual(spot.items[2].size.width, width)
-    XCTAssertEqual(spot.items[2].size.height, 225)
+    XCTAssertEqual(spot.items[2].size.height, 88)
     XCTAssertEqual(spot.items[3].size.width, width)
-    XCTAssertEqual(spot.items[3].size.height, 225)
-    XCTAssertEqual(spot.view.frame.size.height, 247)
+    XCTAssertEqual(spot.items[3].size.height, 88)
+    XCTAssertEqual(spot.view.frame.size.height, 88)
 
     // Check that header height gets added to the calculation
     spot.layout.headerReferenceSize.height = 20
     spot.setup(CGSize(width: 100, height: 100))
-    XCTAssertEqual(spot.view.frame.size.height, 311)
+    XCTAssertEqual(spot.view.frame.size.height, 130)
   }
 
   func testAppendItem() {


### PR DESCRIPTION
This patch fixes that `testCarouselSetupWithPagination` was constantly failing on the `6.0.0` branch. Since the `preferredViewSize` of `CarouselSpotCell` is `88` in both dimensions, and no item size has been specified in the model, the correct assertion should be that the item height is `88`, and that the carousel gets resized to that height as well, matching the height of its first item.

Similarly, the assertion for header height is updated to be:
```
header height + line spacing + carousel height
```