### PR TITLE
Revert back to precious implementation of setFallbackViewSize

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -362,27 +362,9 @@ public extension Spotable {
   private func setFallbackViewSize(to item: inout Item, with view: SpotConfigurable) {
     let hasExplicitHeight: Bool = item.size.height == 0.0
 
-    #if os(OSX)
-      if hasExplicitHeight {
-        item.size.height = view.preferredViewSize.height
-      }
-    #else
-      switch self {
-      case let grid as Gridable:
-        if let view = view as? View,
-          grid.layout.scrollDirection == .horizontal {
-          if hasExplicitHeight, grid.component.layout?.span != Optional(0.0) {
-            item.size.height = view.frame.size.height
-          }
-        } else if hasExplicitHeight {
-          item.size.height = view.preferredViewSize.height
-        }
-      default:
-        if hasExplicitHeight {
-          item.size.height = view.preferredViewSize.height
-        }
-      }
-      #endif
+    if hasExplicitHeight {
+      item.size.height = view.preferredViewSize.height
+    }
 
     if item.size.width == 0.0 {
       item.size.width  = view.preferredViewSize.width


### PR DESCRIPTION
This PR reverts a brain-fart that I added in the previous PR.

I can't remember why we would use the `view.frame.size.height`. I guess
I was drunk yesterday.