### PR TITLE
Fix/vertical scrolling in carousel

### DIFF
--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -242,6 +242,12 @@ extension Delegate: UIScrollViewDelegate {
       return
     }
 
+    /// This will restrict the scroll view to only scroll horizontally.
+    let constrainedYOffset = spot.collectionView.contentSize.height - spot.collectionView.frame.size.height
+    if constrainedYOffset >= 0.0 {
+      spot.collectionView.contentOffset.y = constrainedYOffset
+    }
+
     spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
   }
 

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -111,6 +111,7 @@ open class CarouselSpot: NSObject, Gridable {
     }
 
     collectionView.showsHorizontalScrollIndicator = false
+    collectionView.showsVerticalScrollIndicator = false
     collectionView.alwaysBounceHorizontal = true
     collectionView.clipsToBounds = false
     self.collectionView = collectionView

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -113,6 +113,7 @@ open class CarouselSpot: NSObject, Gridable {
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
     collectionView.alwaysBounceHorizontal = true
+    collectionView.alwaysBounceVertical = false
     collectionView.clipsToBounds = false
 
     self.collectionView = collectionView

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -114,6 +114,7 @@ open class CarouselSpot: NSObject, Gridable {
     collectionView.showsVerticalScrollIndicator = false
     collectionView.alwaysBounceHorizontal = true
     collectionView.clipsToBounds = false
+
     self.collectionView = collectionView
     self.layout = layout
 


### PR DESCRIPTION
This PR restricts scroll views with horizontal scrolling from doing vertical scrolling.

We need this because the frame of the scroll view is mutated by `SpotsScrollView`. If the content size of the scroll view is bigger than the frame, you get internal scrolling. And we cannot resize the content size as that would cause issues for views that use auto layout internally.

So... we end up just hooking into the scrollview and check for it when the user scrolls.