### PR TITLE
CarouselSpot: Support placing a page indicator as an overlay

### DIFF
--- a/Sources/Shared/Enums/PageIndicatorPlacement.swift
+++ b/Sources/Shared/Enums/PageIndicatorPlacement.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Enum describing where to place a page indicator in a Spot
+public enum PageIndicatorPlacement: String {
+    /// The page indicator should be placed below the Spot's content
+    case below
+    /// The page indicator should be placed as an overlay, on top of the Spot
+    case overlay
+}

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -43,20 +43,25 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   public var dynamicSpan: Bool = false
   /// Defines if the component uses computed content height or relies on `view.frame.height`.
   public var dynamicHeight: Bool = true
-  /// Declares if the component should display a page indicator.
-  public var pageIndicator: Bool = false
+  /// The placement of any page indicator (`nil` if no indicator should be displayed)
+  public var pageIndicatorPlacement: PageIndicatorPlacement?
 
   /// A dictionary representation of the struct.
   public var dictionary: [String : Any] {
-    return [
+    var dictionary: [String : Any] = [
       Inset.rootKey: inset.dictionary,
       Key.itemSpacing.rawValue: itemSpacing,
       Key.lineSpacing.rawValue: lineSpacing,
       Key.span.rawValue: span,
       Key.dynamicSpan.rawValue: dynamicSpan,
-      Key.dynamicHeight.rawValue: dynamicHeight,
-      Key.pageIndicator.rawValue: pageIndicator
+      Key.dynamicHeight.rawValue: dynamicHeight
     ]
+
+    if let pageIndicatorPlacement = pageIndicatorPlacement {
+      dictionary[Key.pageIndicator.rawValue] = pageIndicatorPlacement.rawValue
+    }
+
+    return dictionary
   }
 
   /// A convenience initializer with default values.
@@ -65,7 +70,6 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     self.dynamicSpan = false
     self.itemSpacing = 0.0
     self.lineSpacing = 0.0
-    self.pageIndicator = false
     self.inset = Inset()
   }
 
@@ -75,18 +79,18 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   ///   - span: The span that should be used for the component.
   ///   - dynamicSpan: Enable or disable dynamic span.
   ///   - dynamicHeight: Enable or disable dynamic height.
-  ///   - pageIndicator: Enable or disable page indicator for component.
+  ///   - pageIndicatorPlacement: Where any page indicator (if any) should be displayed in the component.
   ///   - itemSpacing: Sets minimum item spacing for the component.
   ///   - lineSpacing: Sets minimum lines spacing for items in component.
   ///   - inset: An inset struct used to insert margins for the component.
-  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicator: Bool = false, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = Inset()) {
+  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = Inset()) {
     self.span = span
     self.dynamicSpan = dynamicSpan
     self.dynamicHeight = dynamicHeight
     self.itemSpacing = itemSpacing
     self.lineSpacing = lineSpacing
     self.inset = inset
-    self.pageIndicator = pageIndicator
+    self.pageIndicatorPlacement = pageIndicatorPlacement
   }
 
   /// Initialize with a JSON payload.
@@ -117,7 +121,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     self.dynamicSpan <- map.property(Key.dynamicSpan.rawValue)
     self.dynamicHeight <- map.property(Key.dynamicHeight.rawValue)
     self.span <- map.property(Key.span.rawValue)
-    self.pageIndicator <- map.property(Key.pageIndicator.rawValue)
+    self.pageIndicatorPlacement <- map.enum(Key.pageIndicator.rawValue)
   }
 
   /// Perform mutation with closure.
@@ -150,7 +154,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     lhs.span == rhs.span &&
     lhs.dynamicSpan == rhs.dynamicSpan &&
     lhs.dynamicHeight == rhs.dynamicHeight &&
-    lhs.pageIndicator == rhs.pageIndicator
+    lhs.pageIndicatorPlacement == rhs.pageIndicatorPlacement
   }
 
   /// Compare Layout structs.

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -210,7 +210,6 @@ open class CarouselSpot: NSObject, Gridable {
       case .overlay:
         let verticalAdjustment = CGFloat(2)
         pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
-        break
       }
     }
   }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		52CD427A1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */; };
+		52CD427B1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */; };
+		52CD427C1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */; };
 		BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
 		BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
 		BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
@@ -369,6 +372,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageIndicatorPlacement.swift; sourceTree = "<group>"; };
 		BD01BD0D1DAEA464009C10FF /* TestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestParser.swift; sourceTree = "<group>"; };
 		BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListComposite.swift; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
@@ -782,6 +786,7 @@
 				BDAD85311E3E7032008289AE /* Animation.swift */,
 				BDAD85321E3E7032008289AE /* Paginate.swift */,
 				BDAD85331E3E7032008289AE /* RegistryType.swift */,
+				52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1483,6 +1488,7 @@
 				BDAD85C81E3E7032008289AE /* SpotsProtocol.swift in Sources */,
 				BDAD85B31E3E7032008289AE /* Listable.swift in Sources */,
 				BDAD84B71E3E701C008289AE /* GridWrapper.swift in Sources */,
+				52CD427C1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
 				BDAD85891E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BDAD85861E3E7032008289AE /* Listable+Extension.swift in Sources */,
 				BDAD84C71E3E701C008289AE /* SpotsContentView.swift in Sources */,
@@ -1657,6 +1663,7 @@
 				BDAD85871E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BDAD85601E3E7032008289AE /* CompositeSpot.swift in Sources */,
 				BDAD84BC1E3E701C008289AE /* ListSpot.swift in Sources */,
+				52CD427A1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
 				BDAD84DC1E3E701C008289AE /* Listable+Extensions+iOS.swift in Sources */,
 				BDAD85781E3E7032008289AE /* CarouselScrollDelegate+Extensions.swift in Sources */,
 				BDAD85C91E3E7032008289AE /* UserInterface.swift in Sources */,
@@ -1740,6 +1747,7 @@
 				BDAD85221E3E7025008289AE /* Listable+macOS+Extensions.swift in Sources */,
 				BDAD85CD1E3E7032008289AE /* Viewable.swift in Sources */,
 				BDAD85141E3E7025008289AE /* ListSpotCell.swift in Sources */,
+				52CD427B1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
 				BDAD85AC1E3E7032008289AE /* Composable.swift in Sources */,
 				BDAD85DF1E3E7032008289AE /* Inset.swift in Sources */,
 				BDAD85A31E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -158,8 +158,8 @@ class CarouselSpotTests: XCTestCase {
       "layout" : Layout(
         span: 4.0,
         dynamicSpan: false,
-        pageIndicator: true
-        ).dictionary
+        pageIndicatorPlacement: .below
+      ).dictionary
     ]
 
     let component = Component(json)
@@ -190,6 +190,8 @@ class CarouselSpotTests: XCTestCase {
     XCTAssertEqual(spot.items[2].size.height, 88)
     XCTAssertEqual(spot.items[3].size.width, width)
     XCTAssertEqual(spot.items[3].size.height, 88)
+
+    // Assert that height has been added for the page indicator
     XCTAssertEqual(spot.view.frame.size.height, 110)
     XCTAssertEqual(spot.view.contentSize.height, 110)
 
@@ -200,6 +202,44 @@ class CarouselSpotTests: XCTestCase {
     spot.view.layoutSubviews()
     XCTAssertEqual(spot.view.frame.size.height, 130)
     XCTAssertEqual(spot.view.contentSize.height, 130)
+  }
+
+  func testPageIndicatorOverlayPlacement() {
+    let json: [String : Any] = [
+      "items" : [
+        ["title" : "foo", "kind" : "carousel"],
+        ["title" : "bar", "kind" : "carousel"],
+        ["title" : "baz", "kind" : "carousel"],
+        ["title" : "bazar", "kind" : "carousel"]
+      ],
+      "interaction" : Interaction(paginate: .page).dictionary,
+      "layout" : Layout(
+        span: 4.0,
+        dynamicSpan: false,
+        pageIndicatorPlacement: .overlay
+      ).dictionary
+    ]
+
+    let component = Component(json)
+    let spot = CarouselSpot(component: component)
+    let parentSize = CGSize(width: 667, height: 225)
+
+    spot.setup(parentSize)
+    spot.layout(parentSize)
+    spot.prepareItems()
+    spot.view.layoutSubviews()
+
+    // Sanity check, to make sure we have our page indicator in overlay mode
+    XCTAssertEqual(component.layout!.pageIndicatorPlacement, .overlay)
+
+    // Assert item layout (derived from preferred view size)
+    XCTAssertEqual(spot.items[0].size.height, 88)
+    XCTAssertEqual(spot.items[1].size.height, 88)
+    XCTAssertEqual(spot.items[2].size.height, 88)
+    XCTAssertEqual(spot.items[3].size.height, 88)
+
+    // Assert that no height has been added for a page indicator
+    XCTAssertEqual(spot.view.frame.height, 88)
   }
     
   func testPaginatedCarouselSnapping() {
@@ -250,7 +290,7 @@ class CarouselSpotTests: XCTestCase {
       "layout" : Layout(
         span: 0,
         dynamicSpan: false,
-        pageIndicator: true,
+        pageIndicatorPlacement: .below,
         itemSpacing: 0
       ).dictionary
     ]


### PR DESCRIPTION
This change replaces `Layout.pageIndicator` with `.pageIndicatorPlacement`, and introduces a `PageIndicatorPlacement` enum for it. This enables the API user to control whether a page control gets rendered below or on top (on the z axis) a carousel.

This change also makes sure that an added page control gets updated with the current page as the user scrolls through a carousel.

This is a breaking change for Spot’s JSON schema, as “layout.page-indicator” should now be expressed as a string (with either “below” or “overlay” as a value) instead of a Bool.