### PR TITLE
Properly resolve wrapped views

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -233,7 +233,7 @@ public extension Spotable {
       prepare(kind: kind, view: view as Any, item: &item)
     #else
       let spotableKind = self
-      let fullWidth = self.view.superview?.frame.size.width ?? self.view.frame.size.width
+      let fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
 
       switch spotableKind {
       case let grid as Gridable:

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -52,8 +52,19 @@ extension UICollectionView: UserInterface {
     deselectItem(at: IndexPath(row: index, section: 0), animated: animated)
   }
 
+  /// Resolve view at index
+  ///
+  /// - Parameter index: The item index that should be used to resolve the view.
+  /// - Returns: The view that is resolved at the index casted into the inferred type.
   public func view<T>(at index: Int) -> T? {
-    return cellForItem(at: IndexPath(item: index, section: 0)) as? T
+    let view = cellForItem(at: IndexPath(item: index, section: 0))
+
+    switch view {
+    case let view as GridWrapper:
+      return view.wrappedView as? T
+    default:
+      return view as? T
+    }
   }
 
   public func beginUpdates() {}

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -52,7 +52,7 @@ extension UICollectionView: UserInterface {
     deselectItem(at: IndexPath(row: index, section: 0), animated: animated)
   }
 
-  /// Resolve view at index
+  /// Resolve a view at index
   ///
   /// - Parameter index: The item index that should be used to resolve the view.
   /// - Returns: The view that is resolved at the index casted into the inferred type.

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -52,7 +52,14 @@ extension UITableView: UserInterface {
   }
 
   public func view<T>(at index: Int) -> T? {
-    return cellForRow(at: IndexPath(row: index, section: 0)) as? T
+    let view = cellForRow(at: IndexPath(row: index, section: 0))
+
+    switch view {
+    case let view as ListWrapper:
+      return view.wrappedView as? T
+    default:
+      return view as? T
+    }
   }
 
   public func reloadDataSource() {

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -3,7 +3,14 @@ import Cocoa
 extension NSCollectionView: UserInterface {
 
   public func view<T>(at index: Int) -> T? {
-    return item(at: index) as? T
+    let view = item(at: index)
+
+    switch view {
+    case let view as GridWrapper:
+      return view.wrappedView as? T
+    default:
+      return view as? T
+    }
   }
 
   /**

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -3,7 +3,14 @@ import Cocoa
 extension NSTableView: UserInterface {
 
   public func view<T>(at index: Int) -> T? {
-    return rowView(atRow: index, makeIfNecessary: true) as? T
+    let view = rowView(atRow: index, makeIfNecessary: true)
+
+    switch view {
+    case let view as ListWrapper:
+      return view.wrappedView as? T
+    default:
+      return view as? T
+    }
   }
 
   public func insert(_ indexes: [Int], withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponent.swift */; };
 		BD73973A1D718CDB000AF2DE /* TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58478281C43FF34006EBA49 /* TestFactory.swift */; };
 		BD7397401D718CDB000AF2DE /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
+		BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestSpotable.swift */; };
 		BDA8DAF51DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */; };
 		BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA8DAF41DCF3AED00A4A8DD /* TestRowSpot.swift */; };
 		BDAD84A21E3E701C008289AE /* CarouselComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84801E3E701B008289AE /* CarouselComposite.swift */; };
@@ -1805,6 +1806,7 @@
 				D58478E71C440645006EBA49 /* TestComponent.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
+				BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */,

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -82,3 +82,11 @@ struct Helper {
     }
   }
 #endif
+
+class TestView: View, SpotConfigurable {
+  var preferredViewSize: CGSize = CGSize(width: 50, height: 50)
+
+  func configure(_ item: inout Item) {
+
+  }
+}

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -66,12 +66,7 @@ class SpotableTests : XCTestCase {
     spot.layout(parentSize)
     spot.view.layoutIfNeeded()
 
-    #if os(OSX)
-      let genericView: NSCollectionViewItem? = spot.ui(at: 0)
-    #else
-      let genericView: View? = spot.ui(at: 0)
-    #endif
-
+    let genericView: View? = spot.ui(at: 0)
 
     XCTAssertNotNil(genericView)
     XCTAssertFalse(type(of: genericView!) === GridWrapper.self)

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -7,7 +7,7 @@ class SpotableTests : XCTestCase {
 
   func testAppendingMultipleItemsToSpot() {
     let listSpot = ListSpot(component: Component(title: "Component", span: 1.0))
-    listSpot.setup(UIScreen.main.bounds.size)
+    listSpot.setup(CGSize(width: 100, height: 100))
     var items: [Item] = []
 
     for i in 0..<10 {

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -66,11 +66,13 @@ class SpotableTests : XCTestCase {
     spot.layout(parentSize)
     spot.view.layoutIfNeeded()
 
-    let genericView: View? = spot.ui(at: 0)
+    guard let genericView: View = spot.ui(at: 0) else {
+      XCTFail()
+      return
+    }
 
-    XCTAssertNotNil(genericView)
-    XCTAssertFalse(type(of: genericView!) === GridWrapper.self)
-    XCTAssertTrue(type(of: genericView!) === TestView.self)
+    XCTAssertFalse(type(of: genericView) === GridWrapper.self)
+    XCTAssertTrue(type(of: genericView) === TestView.self)
   }
 
   func testResolvingUIFromListableSpot() {
@@ -86,10 +88,12 @@ class SpotableTests : XCTestCase {
     spot.layout(parentSize)
     spot.view.layoutSubviews()
 
-    let genericView: View? = spot.ui(at: 0)
+    guard let genericView: View = spot.ui(at: 0) else {
+      XCTFail()
+      return
+    }
 
-    XCTAssertNotNil(genericView)
-    XCTAssertFalse(type(of: genericView!) === ListWrapper.self)
-    XCTAssertTrue(type(of: genericView!) === TestView.self)
+    XCTAssertFalse(type(of: genericView) === ListWrapper.self)
+    XCTAssertTrue(type(of: genericView) === TestView.self)
   }
 }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -65,9 +65,11 @@ class SpotableTests : XCTestCase {
     spot.setup(parentSize)
     spot.layout(parentSize)
     spot.view.layoutSubviews()
-    let view: View? = spot.ui(at: 0)
 
-    XCTAssertNotNil(view)
-    XCTAssertFalse(view is GridWrapper)
+    let genericView: View? = spot.ui(at: 0)
+
+    XCTAssertNotNil(genericView)
+    XCTAssertFalse(type(of: genericView!) === GridWrapper.self)
+    XCTAssertTrue(type(of: genericView!) === TestView.self)
   }
 }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -52,4 +52,22 @@ class SpotableTests : XCTestCase {
     }
     waitForExpectations(timeout: 1.5, handler: nil)
   }
+
+  func testResolvingUIFromGridableSpot() {
+    let kind = "test-view"
+
+    Configuration.register(view: TestView.self, identifier: kind)
+
+    let parentSize = CGSize(width: 100, height: 100)
+    let component = Component(items: [Item(title: "foo", kind: kind)])
+    let spot = GridSpot(component: component)
+
+    spot.setup(parentSize)
+    spot.layout(parentSize)
+    spot.view.layoutSubviews()
+    let view: View? = spot.ui(at: 0)
+
+    XCTAssertNotNil(view)
+    XCTAssertFalse(view is GridWrapper)
+  }
 }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -72,4 +72,24 @@ class SpotableTests : XCTestCase {
     XCTAssertFalse(type(of: genericView!) === GridWrapper.self)
     XCTAssertTrue(type(of: genericView!) === TestView.self)
   }
+
+  func testResolvingUIFromListableSpot() {
+    let kind = "test-view"
+
+    Configuration.register(view: TestView.self, identifier: kind)
+
+    let parentSize = CGSize(width: 100, height: 100)
+    let component = Component(items: [Item(title: "foo", kind: kind)])
+    let spot = ListSpot(component: component)
+
+    spot.setup(parentSize)
+    spot.layout(parentSize)
+    spot.view.layoutSubviews()
+
+    let genericView: View? = spot.ui(at: 0)
+
+    XCTAssertNotNil(genericView)
+    XCTAssertFalse(type(of: genericView!) === ListWrapper.self)
+    XCTAssertTrue(type(of: genericView!) === TestView.self)
+  }
 }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -61,12 +61,17 @@ class SpotableTests : XCTestCase {
     let parentSize = CGSize(width: 100, height: 100)
     let component = Component(items: [Item(title: "foo", kind: kind)])
     let spot = GridSpot(component: component)
-
+    spot.view.frame.size = parentSize
     spot.setup(parentSize)
     spot.layout(parentSize)
-    spot.view.layoutSubviews()
+    spot.view.layoutIfNeeded()
 
-    let genericView: View? = spot.ui(at: 0)
+    #if os(OSX)
+      let genericView: NSCollectionViewItem? = spot.ui(at: 0)
+    #else
+      let genericView: View? = spot.ui(at: 0)
+    #endif
+
 
     XCTAssertNotNil(genericView)
     XCTAssertFalse(type(of: genericView!) === GridWrapper.self)


### PR DESCRIPTION
With the introduction of using `Configuration.views`, we kind broke `.ui(at index:)`. It broke because the method would always give back a `Wrappable` view which would never match your inferred type.

This PR fixes this by checking if the user interface returns something wrappable. If that turns out to be true, then we try to cast the `.wrappedView` into the inferred type.

With this change, the developer using `Spots` will not have to relate to `Wrappable` at all, which I think is super great!