### PR TITLE
Use section inset to apply component insets

### DIFF
--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -72,7 +72,6 @@ open class GridSpot: NSObject, Gridable {
 
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -72,6 +72,7 @@ open class GridSpot: NSObject, Gridable {
 
     super.init()
     self.userInterface = collectionView
+    self.component.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -120,14 +120,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
     }
   }
 
-  open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-    guard let attribute = super.layoutAttributesForItem(at: indexPath) else {
-      return nil
-    }
-
-    return attribute
-  }
-
   /// Returns the layout attributes for all of the cells and views in the specified rectangle.
   ///
   /// - parameter rect: The rectangle (specified in the collection view’s coordinate system) containing the target views.
@@ -169,7 +161,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
           itemAttribute.size = spot.sizeForItem(at: itemAttribute.indexPath)
 
           if scrollDirection == .horizontal {
-            itemAttribute.frame.origin.y = headerReferenceSize.height + collectionView.contentInset.top
+            itemAttribute.frame.origin.y = headerReferenceSize.height + sectionInset.top
             itemAttribute.frame.origin.x = offset
             offset += itemAttribute.size.width + minimumInteritemSpacing
           }

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -61,8 +61,10 @@ extension Gridable {
       prepareItems()
     }
 
+    component.layout?.configure(spot: self)
     layout.prepare()
     layout.invalidateLayout()
+
     collectionView.frame.size.width = layout.collectionViewContentSize.width
     collectionView.frame.size.height = layout.collectionViewContentSize.height
   }

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -3,7 +3,12 @@ import UIKit
 extension Layout {
 
   public func configure(spot: Gridable) {
-    inset.configure(scrollView: spot.view)
+    spot.layout.sectionInset = UIEdgeInsets(
+      top: CGFloat(inset.top),
+      left: CGFloat(inset.left),
+      bottom: CGFloat(inset.bottom),
+      right: CGFloat(inset.right)
+    )
 
     spot.layout.minimumInteritemSpacing = CGFloat(itemSpacing)
     spot.layout.minimumLineSpacing = CGFloat(lineSpacing)

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -60,9 +60,25 @@ class TestGridableLayout: XCTestCase {
 
     let layoutAttributes = carouselSpot.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
 
+    let expectedFrameA = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left,
+        y: component.layout!.inset.top
+      ),
+      size: itemSize
+    )
+
+    let expectedFrameB = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left + Double(itemSize.width),
+        y: component.layout!.inset.top
+      ),
+      size: itemSize
+    )
+
     XCTAssertEqual(layoutAttributes?.count, 2)
-    XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: component.layout!.inset.top), size: itemSize))
-    XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width), y: component.layout!.inset.top), size: itemSize))
+    XCTAssertEqual(layoutAttributes?[0].frame, expectedFrameA)
+    XCTAssertEqual(layoutAttributes?[1].frame, expectedFrameB)
   }
 
   func testLayoutAttributesForElementInHorizontalLayoutWithItemSpacing() {
@@ -86,5 +102,73 @@ class TestGridableLayout: XCTestCase {
     XCTAssertEqual(layoutAttributes?.count, 2)
     XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: component.layout!.inset.top), size: itemSize))
     XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width) + component.layout!.itemSpacing, y: component.layout!.inset.top), size: itemSize))
+  }
+
+  func testLayoutAttributesForElementInVerticalLayoutWithInsets() {
+    let itemSize = CGSize(width: 25, height: 25)
+    let component = Component(
+      layout: Layout(
+        itemSpacing: 0,
+        inset: Inset(top: 10, left: 30, bottom: 40, right: 20)
+      ),
+      items: [
+        Item(title: "A", size: itemSize),
+        Item(title: "B", size: itemSize),
+        Item(title: "C", size: itemSize),
+        Item(title: "D", size: itemSize)
+      ]
+    )
+
+    let spot = GridSpot(component: component)
+    spot.setup(parentSize)
+    spot.layout(parentSize)
+    spot.view.layoutSubviews()
+
+    let layoutAttributes = spot.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
+
+    let expectedFrameA = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left,
+        y: component.layout!.inset.top
+      ),
+      size: itemSize
+    )
+
+    let expectedFrameB = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left + Double(itemSize.width),
+        y: component.layout!.inset.top
+      ),
+      size: itemSize
+    )
+
+    let expectedFrameC = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left,
+        y: component.layout!.inset.top + Double(itemSize.height)
+      ),
+      size: itemSize
+    )
+
+    let expectedFrameD = CGRect(
+      origin: CGPoint(
+        x: component.layout!.inset.left + Double(itemSize.width),
+        y: component.layout!.inset.top + Double(itemSize.height)
+      ),
+      size: itemSize
+    )
+
+    XCTAssertEqual(layoutAttributes?.count, 4)
+    XCTAssertEqual(layoutAttributes?[0].frame, expectedFrameA)
+    XCTAssertEqual(layoutAttributes?[1].frame, expectedFrameB)
+    XCTAssertEqual(layoutAttributes?[2].frame, expectedFrameC)
+    XCTAssertEqual(layoutAttributes?[3].frame, expectedFrameD)
+
+    let expectedContentSize = CGSize(
+      width: component.layout!.inset.left + component.layout!.inset.right + Double(itemSize.width) * 2,
+      height: component.layout!.inset.top + component.layout!.inset.bottom + Double(itemSize.height) * 2
+    )
+
+    XCTAssertEqual(spot.layout.collectionViewContentSize, expectedContentSize)
   }
 }


### PR DESCRIPTION
This patch makes component inset rendering work, by using `UICollectionViewFlowLayout`’s built-in capability to define section insets, rather than using content inset. This way has a lot more consistency, since other parts of the code (and the system) manipulates content inset.

It also includes a correction of a test (that wasn’t actually taking content insets into account, and thus still succeeding), and removes a redundant method override in the `GridableLayout` class.