### PR TITLE
[DONT MERGE] Feature Hybrid Spot

### DIFF
--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -18,7 +18,7 @@ public class Spot: NSObject, Spotable {
   weak public var delegate: SpotsDelegate?
 
   public var component: Component
-  public var componentKind: Component.Kind
+  public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
   public var configure: ((SpotConfigurable) -> Void)?
   public var spotDelegate: Delegate?
@@ -129,7 +129,10 @@ public class Spot: NSObject, Spotable {
     }
 
     self.component = component
-    self.componentKind = Component.Kind(rawValue: component.kind) ?? .list
+
+    if let componentKind = Component.Kind(rawValue: component.kind) {
+      self.componentKind = componentKind
+    }
 
     super.init()
 

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -114,6 +114,14 @@ public class Spot: NSObject, Spotable {
   }
   #endif
 
+  public var tableView: TableView? {
+    return userInterface as? TableView
+  }
+
+  public var collectionView: CollectionView? {
+    return userInterface as? CollectionView
+  }
+
   public required init(component: Component) {
     var component = component
     if component.kind.isEmpty {

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -12,6 +12,8 @@ public class Spot: NSObject, Spotable {
   public static var views: Registry = Registry()
   public static var defaultKind: String = Component.Kind.list.string
 
+  open static var configure: ((_ view: View) -> Void)?
+
   weak public var focusDelegate: SpotsFocusDelegate?
   weak public var delegate: SpotsDelegate?
 

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -1,0 +1,365 @@
+#if os(OSX)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+public class Spot: NSObject, Spotable {
+
+  /// These are deprecated
+  public static var layout: Layout = Layout()
+  public static var headers: Registry = Registry()
+  public static var views: Registry = Registry()
+  public static var defaultKind: String = Component.Kind.list.string
+
+  weak public var focusDelegate: SpotsFocusDelegate?
+  weak public var delegate: SpotsDelegate?
+
+  public var component: Component
+  public var componentKind: Component.Kind
+  public var compositeSpots: [CompositeSpot] = []
+  public var configure: ((SpotConfigurable) -> Void)?
+  public var spotDelegate: Delegate?
+  public var spotDataSource: DataSource?
+  public var stateCache: StateCache?
+  public var userInterface: UserInterface?
+
+  open lazy var pageControl = UIPageControl()
+  open lazy var backgroundView = UIView()
+
+  #if os(OSX)
+  public var responder: NSResponder {
+    switch self.userInterface {
+    case let tableView as TableView:
+      return tableView
+    case let collectionView as CollectionView:
+      return collectionView
+    default:
+      return scrollView
+    }
+  }
+
+  public var nextResponder: NSResponder? {
+    get {
+      switch self.userInterface {
+      case let tableView as TableView:
+        return tableView.nextResponder
+      case let collectionView as CollectionView:
+        return collectionView.nextResponder
+      default:
+        return scrollView.nextResponder
+      }
+    }
+    set {
+      switch self.userInterface {
+      case let tableView as TableView:
+        tableView.nextResponder = newValue
+      case let collectionView as CollectionView:
+        collectionView.nextResponder = newValue
+      default:
+        scrollView.nextResponder = newValue
+      }
+    }
+  }
+
+  public func deselect() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.deselectAll(nil)
+    case let collectionView as CollectionView:
+      collectionView.deselectAll(nil)
+    default: break
+    }
+  }
+
+  open lazy var scrollView: ScrollView = {
+    let scrollView = ScrollView()
+    scrollView.documentView = NSView()
+    return scrollView
+  }()
+
+  public var view: ScrollView {
+    return scrollView
+  }
+  #else
+  var collectionViewLayout: CollectionLayout?
+
+  public var view: ScrollView {
+    if let userInterface = userInterface as? ScrollView {
+      return userInterface
+    }
+
+    let UIComponent: ScrollView
+
+    switch componentKind {
+    case .carousel, .grid, .row:
+      let collectionViewLayout = CollectionLayout()
+      component.layout?.configure(collectionViewLayout: collectionViewLayout)
+
+      collectionViewLayout.scrollDirection = componentKind == .carousel
+        ? .horizontal : .vertical
+
+      let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+      self.userInterface = collectionView
+      UIComponent = collectionView
+    case .list:
+      let tableView = TableView()
+      self.userInterface = tableView
+      UIComponent = tableView
+    }
+
+    return UIComponent
+  }
+  #endif
+
+  public required init(component: Component) {
+    var component = component
+    if component.kind.isEmpty {
+      component.kind = Spot.defaultKind
+    }
+
+    self.component = component
+    self.componentKind = Component.Kind(rawValue: component.kind) ?? .list
+
+    super.init()
+
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
+    configureUserInterface(with: component,
+                           userInterface: self.view as? UserInterface)
+    configureDataSource()
+    configureDelegate()
+
+    if let componentLayout = component.layout {
+      configure(with: componentLayout)
+    }
+
+    prepareItems()
+  }
+
+  deinit {
+    spotDataSource = nil
+    spotDelegate = nil
+    userInterface = nil
+  }
+
+  public func configure(with layout: Layout) {
+    layout.configure(spot: self)
+  }
+
+  @discardableResult public func configureUserInterface(with component: Component, userInterface: UserInterface? = nil) {
+    userInterface?.register()
+
+    #if os(OSX)
+      switch self.userInterface {
+      case let tableView as TableView:
+        scrollView.contentView.addSubview(tableView)
+      case let collectionView as CollectionView:
+        scrollView.contentView.addSubview(collectionView)
+      default: break
+      }
+    #else
+      if let collectionView = userInterface as? CollectionView {
+        collectionView.backgroundView = backgroundView
+      }
+    #endif
+  }
+
+  func configureDataSource() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.dataSource = spotDataSource
+    case let collectionView as CollectionView:
+      collectionView.dataSource = spotDataSource
+    default: break
+    }
+  }
+
+  func configureDelegate() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.delegate = spotDelegate
+    case let collectionView as CollectionView:
+      collectionView.delegate = spotDelegate
+    default: break
+    }
+  }
+
+  public func setup(_ size: CGSize) {
+    switch self.userInterface {
+    case let collectionView as CollectionView:
+      collectionView.frame.size.width = size.width
+      #if !os(OSX)
+        guard let layout = collectionView.collectionViewLayout as? CollectionLayout else {
+          return
+        }
+
+        switch layout.scrollDirection {
+        case .horizontal:
+          collectionView.frame.size = size
+          prepareItems()
+          configurePageControl()
+
+          if collectionView.contentSize.height > 0 {
+            collectionView.frame.size.height = collectionView.contentSize.height
+          } else {
+            collectionView.frame.size.height = component.items.sorted(by: {
+              $0.size.height > $1.size.height
+            }).first?.size.height ?? 0
+
+            if collectionView.frame.size.height > 0 {
+              collectionView.frame.size.height += layout.sectionInset.top + layout.sectionInset.bottom
+            }
+          }
+
+          if !component.header.isEmpty {
+            let resolve = type(of: self).headers.make(component.header)
+            layout.headerReferenceSize.width = collectionView.frame.size.width
+            layout.headerReferenceSize.height = resolve?.view?.frame.size.height ?? 0.0
+          }
+
+          CarouselSpot.configure?(collectionView, layout)
+
+          collectionView.frame.size.height += layout.headerReferenceSize.height
+
+          if let componentLayout = component.layout {
+            collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
+          }
+
+          if let pageIndicatorPlacement = component.layout?.pageIndicatorPlacement {
+            switch pageIndicatorPlacement {
+            case .below:
+              layout.sectionInset.bottom += pageControl.frame.height
+              pageControl.frame.origin.y = collectionView.frame.height
+            case .overlay:
+              let verticalAdjustment = CGFloat(2)
+              pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
+            }
+          }
+        case .vertical:
+          collectionView.frame.size.width = size.width
+          #if !os(OSX)
+            GridSpot.configure?(collectionView, layout)
+
+            if let resolve = type(of: self).headers.make(component.header),
+              let view = resolve.view as? Componentable,
+              !component.header.isEmpty {
+
+              layout.headerReferenceSize.width = collectionView.frame.size.width
+              layout.headerReferenceSize.height = view.frame.size.height
+
+              if layout.headerReferenceSize.width == 0.0 {
+                layout.headerReferenceSize.width = size.width
+              }
+
+              if layout.headerReferenceSize.height == 0.0 {
+                layout.headerReferenceSize.height = view.preferredHeaderHeight
+              }
+            }
+            collectionView.frame.size.height = layout.contentSize.height
+          #endif
+          layout.prepare()
+
+          component.size = collectionView.frame.size
+        }
+      #endif
+    case let tableView as TableView:
+      var height: CGFloat = 0.0
+      for item in component.items {
+        height += item.size.height
+      }
+
+      tableView.frame.size = size
+      tableView.frame.size.width = size.width - (tableView.contentInset.left)
+      tableView.frame.origin.x = size.width / 2 - tableView.frame.width / 2
+      tableView.contentSize = CGSize(
+        width: tableView.frame.size.width,
+        height: height - tableView.contentInset.top - tableView.contentInset.bottom)
+
+    default: break
+    }
+
+    layout(size)
+  }
+
+  public func layout(_ size: CGSize) {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.frame.size.width = size.width - (tableView.contentInset.left)
+      tableView.frame.origin.x = size.width / 2 - tableView.frame.width / 2
+
+      guard let componentSize = component.size else {
+        return
+      }
+      tableView.frame.size.height = componentSize.height
+    case let collectionView as CollectionView:
+      if compositeSpots.isEmpty {
+        prepareItems()
+      }
+
+      if let collectionViewLayout = collectionView.collectionViewLayout as? GridableLayout {
+        collectionViewLayout.prepare()
+        collectionViewLayout.invalidateLayout()
+
+        collectionView.frame.size.width = collectionViewLayout.contentSize.width
+        collectionView.frame.size.height = collectionViewLayout.contentSize.height
+        collectionView.contentSize.height = collectionView.frame.size.height
+      } else {
+        collectionView.collectionViewLayout.prepare()
+        collectionView.collectionViewLayout.invalidateLayout()
+
+        collectionView.frame.size.width = collectionView.collectionViewLayout.collectionViewContentSize.width
+        collectionView.frame.size.height = collectionView.collectionViewLayout.collectionViewContentSize.height
+      }
+    default: break
+    }
+
+    view.layoutSubviews()
+  }
+
+  private func configurePageControl() {
+    guard let placement = component.layout?.pageIndicatorPlacement else {
+      pageControl.removeFromSuperview()
+      return
+    }
+
+    pageControl.numberOfPages = component.items.count
+    pageControl.frame.origin.x = 0
+    pageControl.frame.size.height = 22
+
+    switch placement {
+    case .below:
+      pageControl.frame.size.width = backgroundView.frame.width
+      pageControl.pageIndicatorTintColor = .lightGray
+      pageControl.currentPageIndicatorTintColor = .gray
+      backgroundView.addSubview(pageControl)
+    case .overlay:
+      pageControl.frame.size.width = view.frame.width
+      pageControl.pageIndicatorTintColor = nil
+      pageControl.currentPageIndicatorTintColor = nil
+      view.addSubview(pageControl)
+    }
+  }
+
+  /// Asks the data source for the size of an item in a particular location.
+  ///
+  /// - parameter indexPath: The index path of the
+  ///
+  /// - returns: Size of the object at index path as CGSize
+  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
+    let width =  item(at: indexPath)?.size.width ?? 0
+    let height = item(at: indexPath)?.size.height ?? 0
+
+    // Never return a negative width
+    guard width > -1 else { return CGSize.zero }
+
+    return CGSize(
+      width: floor(width),
+      height: ceil(height)
+    )
+  }
+  
+  public func register() {
+    
+  }
+}

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -7,7 +7,7 @@
 public class Spot: NSObject, Spotable {
 
   /// These are deprecated
-  public static var layout: Layout = Layout()
+  public static var layout: Layout = Layout(span: 1.0)
   public static var headers: Registry = Registry()
   public static var views: Registry = Registry()
   public static var defaultKind: String = Component.Kind.list.string

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -428,6 +428,12 @@ public class Spot: NSObject, Spotable {
     )
   }
 
+  func registerDefault(view: View.Type) {
+    if Configuration.views.storage[Configuration.views.defaultIdentifier] == nil {
+      Configuration.views.defaultItem = Registry.Item.classType(view)
+    }
+  }
+
   public func register() {
 
   }

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -147,6 +147,19 @@ public class Spot: NSObject, Spotable {
       self.componentKind = componentKind
     }
 
+    if component.layout == nil {
+      switch componentKind {
+      case .carousel:
+        self.component.layout = CarouselSpot.layout
+      case .grid:
+        self.component.layout = GridSpot.layout
+      case .list:
+        self.component.layout = ListSpot.layout
+      case .row:
+        self.component.layout = RowSpot.layout
+      }
+    }
+
     super.init()
 
     self.spotDataSource = DataSource(spot: self)

--- a/Sources/Shared/Classes/Spot.swift
+++ b/Sources/Shared/Classes/Spot.swift
@@ -94,7 +94,7 @@ public class Spot: NSObject, Spotable {
     let UIComponent: ScrollView
 
     switch componentKind {
-    case .carousel, .grid, .row:
+    case .row:
       let collectionViewLayout = CollectionLayout()
       component.layout?.configure(collectionViewLayout: collectionViewLayout)
 
@@ -102,10 +102,23 @@ public class Spot: NSObject, Spotable {
         ? .horizontal : .vertical
 
       let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+      registerDefault(view: RowSpotCell.self)
+      self.userInterface = collectionView
+      UIComponent = collectionView
+    case .carousel, .grid:
+      let collectionViewLayout = CollectionLayout()
+      component.layout?.configure(collectionViewLayout: collectionViewLayout)
+
+      collectionViewLayout.scrollDirection = componentKind == .carousel
+        ? .horizontal : .vertical
+
+      let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+      registerDefault(view: GridSpotCell.self)
       self.userInterface = collectionView
       UIComponent = collectionView
     case .list:
       let tableView = TableView()
+      registerDefault(view: ListSpotCell.self)
       self.userInterface = tableView
       UIComponent = tableView
     }

--- a/Sources/Shared/Classes/SpotFactory.swift
+++ b/Sources/Shared/Classes/SpotFactory.swift
@@ -9,7 +9,8 @@ public struct Factory {
     "list": ListSpot.self,
     "grid": GridSpot.self,
     "row": RowSpot.self,
-    "view": ViewSpot.self
+    "view": ViewSpot.self,
+    "spot": Spot.self
   ]
 
   /// Register a spot for a specfic spot type
@@ -26,7 +27,13 @@ public struct Factory {
   ///
   /// - returns: A spotable object.
   public static func resolve(component: Component) -> Spotable {
-    let spot: Spotable.Type = spots[component.kind] ?? DefaultSpot
+    var resolvedKind = component.kind
+    if component.hybrid {
+      resolvedKind = "spot"
+    }
+
+    let spot: Spotable.Type = spots[resolvedKind] ?? DefaultSpot
+
     return spot.init(component: component)
   }
 }

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -64,60 +64,6 @@ public extension Spotable where Self : Gridable {
     collectionView.frame.size.width = size.width
   }
 
-  /// Process updates and determine if the updates are done.
-  ///
-  /// - parameter updates:    A collection of updates.
-  /// - parameter animation:  A Animation that is used when performing the mutation.
-  /// - parameter completion: A completion closure that is run when the updates are finished.
-  public func process(_ updates: [Int], withAnimation animation: Animation, completion: Completion) {
-    guard !updates.isEmpty else {
-      completion?()
-      return
-    }
-
-    let lastUpdate = updates.last
-    for index in updates {
-      guard let item = self.item(at: index) else {
-        continue
-      }
-
-      update(item, index: index, withAnimation: animation) {
-        if index == lastUpdate {
-          completion?()
-        }
-      }
-    }
-  }
-
-  /// Reload spot with ItemChanges.
-  ///
-  /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
-  /// - parameter animation:        A Animation that is used when performing the mutation.
-  /// - parameter updateDataSource: A closure to update your data source.
-  /// - parameter completion:       A completion closure that runs when your updates are done.
-  public func reloadIfNeeded(_ changes: ItemChanges, withAnimation animation: Animation = .automatic, updateDataSource: () -> Void, completion: Completion) {
-    collectionView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions, childUpdates: changes.updatedChildren), updateDataSource: updateDataSource) { [weak self] in
-      guard let weakSelf = self else {
-        completion?()
-        return
-      }
-
-      if changes.updates.isEmpty {
-        weakSelf.process(changes.updatedChildren, withAnimation: animation) {
-          weakSelf.layout(weakSelf.collectionView.bounds.size)
-          completion?()
-        }
-      } else {
-        weakSelf.process(changes.updates, withAnimation: animation) {
-          weakSelf.process(changes.updatedChildren, withAnimation: animation) {
-            weakSelf.layout(weakSelf.collectionView.bounds.size)
-            completion?()
-          }
-        }
-      }
-    }
-  }
-
   public func configure(with layout: Layout) {
     layout.configure(spot: self)
   }

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -51,7 +51,7 @@ public extension Spotable where Self : Gridable {
       }
       collectionView.frame.size.height = layout.contentSize.height
     #endif
-    layout.prepare()
+    collectionView.collectionViewLayout.prepare()
 
     component.size = collectionView.frame.size
   }

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -50,8 +50,11 @@ public extension Spotable where Self : Gridable {
         }
       }
       collectionView.frame.size.height = layout.contentSize.height
+      collectionView.collectionViewLayout.prepare()
+    #else
+      collectionView.collectionViewLayout?.prepare()
     #endif
-    collectionView.collectionViewLayout.prepare()
+
 
     component.size = collectionView.frame.size
   }

--- a/Sources/Shared/Extensions/Listable+Extension.swift
+++ b/Sources/Shared/Extensions/Listable+Extension.swift
@@ -1,58 +1,5 @@
 extension Listable {
 
-  /**
-   Process updates and determine if the updates are done
-
-   - parameter updates:    A collection of updates
-   - parameter animation:  A Animation that is used when performing the mutation
-   - parameter completion: A completion closure that is run when the updates are finished
-   */
-  public func process(_ updates: [Int], withAnimation animation: Animation = .automatic, completion: Completion) {
-    guard !updates.isEmpty else {
-      updateHeight {
-        completion?()
-      }
-      return
-    }
-
-    let lastUpdate = updates.last
-    for index in updates {
-      guard let item = self.item(at: index) else {
-        completion?()
-        continue
-      }
-
-      update(item, index: index, withAnimation: animation) {
-        if index == lastUpdate {
-          completion?()
-        }
-      }
-    }
-  }
-
-  /// Reload spot with ItemChanges.
-  ///
-  /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
-  /// - parameter animation:        A Animation that is used when performing the mutation.
-  /// - parameter updateDataSource: A closure to update your data source.
-  /// - parameter completion:       A completion closure that runs when your updates are done.
-  public func reloadIfNeeded(_ changes: ItemChanges, withAnimation animation: Animation = .automatic, updateDataSource: () -> Void, completion: Completion) {
-    tableView.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions, childUpdates: changes.updatedChildren), withAnimation: animation, updateDataSource: updateDataSource) { [weak self] in
-      guard let weakSelf = self else {
-        completion?()
-        return
-      }
-
-      if changes.updates.isEmpty {
-        weakSelf.process(changes.updatedChildren, withAnimation: animation, completion: completion)
-      } else {
-        weakSelf.process(changes.updates) {
-          weakSelf.process(changes.updatedChildren, withAnimation: animation, completion: completion)
-        }
-      }
-    }
-  }
-
   public func configure(with layout: Layout) {
     layout.configure(spot: self)
   }

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -96,10 +96,10 @@ public extension Spotable {
       if let layout = component.layout {
         if layout.span > 0.0 {
           #if os(OSX)
-            if let gridable = self as? Gridable,
-              let layout = gridable.layout as? FlowLayout,
+            if let collectionView = userInterface as? CollectionView,
+              let layout = collectionView.collectionViewLayout as? FlowLayout,
               let componentLayout = component.layout {
-              let newWidth = gridable.collectionView.frame.width / CGFloat(componentLayout.span) - layout.sectionInset.left - layout.sectionInset.right
+              let newWidth = collectionView.frame.width / CGFloat(componentLayout.span) - layout.sectionInset.left - layout.sectionInset.right
 
               if newWidth > 0.0 {
                 preparedItems[index].size.width = newWidth

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -411,9 +411,13 @@ public extension Spotable {
       return item.kind
     } else if let item = item(at: index), Configuration.views.storage[item.kind] != nil {
       return item.kind
-    } else {
+    } else if type.views.defaultItem != nil {
       return type.views.defaultIdentifier
+    } else if let _ = item(at: index), Configuration.views.defaultItem != nil {
+      return Configuration.views.defaultIdentifier
     }
+
+    return type.views.defaultIdentifier
   }
 
   /// Register and prepare all items in the Spotable object.

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -372,19 +372,6 @@ public extension Spotable {
     }
   }
 
-  /// Reload spot with ItemChanges.
-  ///
-  /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
-  /// - parameter animation:        A Animation that is used when performing the mutation.
-  /// - parameter updateDataSource: A closure to update your data source.
-  /// - parameter completion:       A completion closure that runs when your updates are done.
-  func reloadIfNeeded(_ changes: ItemChanges, withAnimation animation: Animation = .automatic, updateDataSource: () -> Void, completion: Completion) {
-    reloadIfNeeded(changes,
-                   withAnimation: animation,
-                   updateDataSource: updateDataSource,
-                   completion: completion)
-  }
-
   /// A collection of view models
   var items: [Item] {
     set(items) {
@@ -479,6 +466,60 @@ public extension Spotable {
         weakSelf.afterUpdate()
         weakSelf.view.superview?.layoutSubviews()
         weakSelf.cache()
+      }
+    }
+  }
+
+  /// Reload spot with ItemChanges.
+  ///
+  /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
+  /// - parameter animation:        A Animation that is used when performing the mutation.
+  /// - parameter updateDataSource: A closure to update your data source.
+  /// - parameter completion:       A completion closure that runs when your updates are done.
+  public func reloadIfNeeded(_ changes: ItemChanges, withAnimation animation: Animation = .automatic, updateDataSource: () -> Void, completion: Completion) {
+    userInterface?.process((insertions: changes.insertions, reloads: changes.reloads, deletions: changes.deletions, childUpdates: changes.updatedChildren), withAnimation: animation, updateDataSource: updateDataSource) { [weak self] in
+      guard let weakSelf = self else {
+        completion?()
+        return
+      }
+
+      if changes.updates.isEmpty {
+        weakSelf.process(changes.updatedChildren, withAnimation: animation) {
+          weakSelf.layout(weakSelf.view.bounds.size)
+          completion?()
+        }
+      } else {
+        weakSelf.process(changes.updates, withAnimation: animation) {
+          weakSelf.process(changes.updatedChildren, withAnimation: animation) {
+            weakSelf.layout(weakSelf.view.bounds.size)
+            completion?()
+          }
+        }
+      }
+    }
+  }
+
+  /// Process updates and determine if the updates are done.
+  ///
+  /// - parameter updates:    A collection of updates.
+  /// - parameter animation:  A Animation that is used when performing the mutation.
+  /// - parameter completion: A completion closure that is run when the updates are finished.
+  public func process(_ updates: [Int], withAnimation animation: Animation, completion: Completion) {
+    guard !updates.isEmpty else {
+      completion?()
+      return
+    }
+
+    let lastUpdate = updates.last
+    for index in updates {
+      guard let item = self.item(at: index) else {
+        continue
+      }
+
+      update(item, index: index, withAnimation: animation) {
+        if index == lastUpdate {
+          completion?()
+        }
       }
     }
   }

--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -39,20 +39,6 @@ import Cache
 
             weakSelf.reloadIfNeeded(components) {
               weakSelf.scrollView.contentOffset = offset
-
-              var yOffset: CGFloat = 0.0
-              for spot in weakSelf.spots {
-                #if !os(OSX)
-                (spot as? CarouselSpot)?.layout.yOffset = yOffset
-                #endif
-                yOffset += spot.view.frame.size.height
-              }
-
-              #if !os(OSX)
-              for case let gridable as CarouselSpot in weakSelf.spots {
-                gridable.layout.yOffset = gridable.view.frame.origin.y
-              }
-              #endif
             }
             print("🎍 SPOTS reloaded: \(weakSelf.spots.count) -> items: \(weakSelf.spots.reduce(0, { $0.1.items.count }))")
             weakSelf.liveEditing(stateCache: weakSelf.stateCache)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -146,10 +146,6 @@ extension SpotsProtocol {
     spots[index] = spot
     scrollView.spotsContentView.insertSubview(spot.view, at: index)
     setupSpot(at: index, spot: spot)
-
-    #if !os(OSX)
-      (spot as? CarouselSpot)?.layout.yOffset = yOffset
-    #endif
     yOffset += spot.view.frame.size.height
   }
 
@@ -157,9 +153,6 @@ extension SpotsProtocol {
     let spot = Factory.resolve(component: newComponents[index])
     spots.append(spot)
     setupSpot(at: index, spot: spot)
-    #if !os(OSX)
-      (spot as? CarouselSpot)?.layout.yOffset = yOffset
-    #endif
     yOffset += spot.view.frame.size.height
   }
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -130,7 +130,7 @@ extension SpotsProtocol {
     return changes
   }
 
-  fileprivate func replaceSpot(_ index: Int, newComponents: [Component], yOffset: inout CGFloat) {
+  fileprivate func replaceSpot(_ index: Int, newComponents: [Component]) {
     let spot = Factory.resolve(component: newComponents[index])
     let oldSpot = spots[index]
 
@@ -146,14 +146,12 @@ extension SpotsProtocol {
     spots[index] = spot
     scrollView.spotsContentView.insertSubview(spot.view, at: index)
     setupSpot(at: index, spot: spot)
-    yOffset += spot.view.frame.size.height
   }
 
-  fileprivate func newSpot(_ index: Int, newComponents: [Component], yOffset: inout CGFloat) {
+  fileprivate func newSpot(_ index: Int, newComponents: [Component]) {
     let spot = Factory.resolve(component: newComponents[index])
     spots.append(spot)
     setupSpot(at: index, spot: spot)
-    yOffset += spot.view.frame.size.height
   }
 
   /// Remove Spot at index
@@ -383,7 +381,6 @@ extension SpotsProtocol {
 
       let finalCompletion = completion
 
-      var yOffset: CGFloat = 0.0
       var runCompletion = true
       var completion: Completion = nil
       var lastItemChange: Int?
@@ -397,9 +394,9 @@ extension SpotsProtocol {
       for (index, change) in changes.enumerated() {
         switch change {
         case .identifier, .title, .kind, .layout, .header, .footer, .meta:
-          weakSelf.replaceSpot(index, newComponents: newComponents, yOffset: &yOffset)
+          weakSelf.replaceSpot(index, newComponents: newComponents)
         case .new:
-          weakSelf.newSpot(index, newComponents: newComponents, yOffset: &yOffset)
+          weakSelf.newSpot(index, newComponents: newComponents)
         case .removed:
           weakSelf.removeSpot(at: index)
         case .items:
@@ -733,15 +730,8 @@ extension SpotsProtocol {
   }
 
   func setupAndLayoutSpot(spot: Spotable) {
-
+    print("🎉 \(type(of:spot)) \(spot.view.frame) \(spot.view.contentSize)")
     switch spot {
-    case let spot as Spot:
-      if let collectionViewLayout = spot.collectionViewLayout {
-        collectionViewLayout.prepare()
-        collectionViewLayout.invalidateLayout()
-        spot.view.frame.size.width = collectionViewLayout.collectionViewContentSize.width
-        spot.view.frame.size.height = collectionViewLayout.collectionViewContentSize.height
-      }
     case let spot as Gridable:
       #if !os(OSX)
         guard spot.layout.scrollDirection == .horizontal else {
@@ -759,8 +749,8 @@ extension SpotsProtocol {
         width: spot.view.frame.size.width,
         height: ceil(spot.view.frame.size.height))
       spot.layout(scrollView.frame.size)
-      spot.view.layoutSubviews()
     }
+    spot.view.layoutSubviews()
   }
 
   fileprivate func setupAndLayoutSpots() {

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -730,7 +730,6 @@ extension SpotsProtocol {
   }
 
   func setupAndLayoutSpot(spot: Spotable) {
-    print("🎉 \(type(of:spot)) \(spot.view.frame) \(spot.view.contentSize)")
     switch spot {
     case let spot as Gridable:
       #if !os(OSX)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -742,6 +742,13 @@ extension SpotsProtocol {
   func setupAndLayoutSpot(spot: Spotable) {
 
     switch spot {
+    case let spot as Spot:
+      if let collectionViewLayout = spot.collectionViewLayout {
+        collectionViewLayout.prepare()
+        collectionViewLayout.invalidateLayout()
+        spot.view.frame.size.width = collectionViewLayout.collectionViewContentSize.width
+        spot.view.frame.size.height = collectionViewLayout.collectionViewContentSize.height
+      }
     case let spot as Gridable:
       #if !os(OSX)
         guard spot.layout.scrollDirection == .horizontal else {

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -83,4 +83,6 @@ public protocol UserInterface: class {
   func endUpdates()
   /// A proxy method to call reloadData
   func reloadDataSource()
+
+  func register()
 }

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -44,6 +44,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     case width
     case height
     case footer
+    case hybrid
 
     public var string: String {
       return rawValue.lowercased()
@@ -80,6 +81,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     }
   }
 
+  public var hybrid: Bool = false
   /// Identifier
   public var identifier: String?
   /// The index of the Item when appearing in a list, should be computed and continuously updated by the data source
@@ -155,6 +157,8 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     if !header.isEmpty { JSONComponents[Key.header.string] = header }
     if !footer.isEmpty { JSONComponents[Key.footer.string] = footer }
     if !meta.isEmpty { JSONComponents[Key.meta.string] = meta }
+    
+    JSONComponents[Key.hybrid.string] = hybrid
 
     return JSONComponents
   }
@@ -172,6 +176,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     self.footer    <- map.property("footer")
     self.items     <- map.relations("items")
     self.meta      <- map.property("meta")
+    self.hybrid    <- map.property("hybrid")
 
     if Component.legacyMapping {
       self.layout = Layout(map.property("meta") ?? [:])
@@ -216,7 +221,8 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
               interaction: Interaction? = nil,
               span: Double? = nil,
               items: [Item] = [],
-              meta: [String : Any] = [:]) {
+              meta: [String : Any] = [:],
+              hybrid: Bool = false) {
     self.identifier = identifier
     self.title = title
     self.kind = kind
@@ -226,6 +232,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     self.footer = footer
     self.items = items
     self.meta = meta
+    self.hybrid = hybrid
 
     if let span = span, layout == nil {
       self.layout = Layout(span: span)

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -157,7 +157,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
     if !header.isEmpty { JSONComponents[Key.header.string] = header }
     if !footer.isEmpty { JSONComponents[Key.footer.string] = footer }
     if !meta.isEmpty { JSONComponents[Key.meta.string] = meta }
-    
+
     JSONComponents[Key.hybrid.string] = hybrid
 
     return JSONComponents

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -19,5 +19,4 @@ public struct Configuration {
   public static func register(view: View.Type, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
   }
-
 }

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -294,7 +294,6 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
     spots.enumerated().forEach { index, spot in
       setupSpot(at: index, spot: spot)
       animated?(spot.view)
-      (spot as? CarouselSpot)?.layout.yOffset = yOffset
       yOffset += spot.view.frame.size.height
     }
   }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -5,8 +5,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
   /// The content size for the Gridable object
   public var contentSize = CGSize.zero
-  /// The y offset for the Gridable object
-  open var yOffset: CGFloat?
 
   var footerHeight: CGFloat = 0.0
 
@@ -114,10 +112,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
       collectionView.contentOffset.y > 0) {
       return
     }
-
-    if let y = yOffset, collectionView.isDragging && headerReferenceSize.height > 0.0 {
-      collectionView.frame.origin.y = y
-    }
   }
 
   open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
@@ -177,10 +171,6 @@ open class GridableLayout: UICollectionViewFlowLayout {
           attributes.append(itemAttribute)
         }
       }
-    }
-
-    if let y = yOffset, headerReferenceSize.height > 0.0 {
-      collectionView.frame.origin.y = y
     }
 
     return attributes

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -192,6 +192,8 @@ open class GridableLayout: UICollectionViewFlowLayout {
   ///
   /// - returns: Always returns true
   open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-    return newBounds.size.height >= contentSize.height
+    let shouldInvalidateLayout = newBounds.size.height > contentSize.height || collectionView!.frame.width != newBounds.width
+
+    return shouldInvalidateLayout
   }
 }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -26,7 +26,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// Subclasses should always call super if they override.
   open override func prepare() {
     guard let delegate = collectionView?.delegate as? Delegate,
-      let spot = delegate.spot as? Gridable
+      let spot = delegate.spot
       else {
         return
     }
@@ -96,7 +96,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
         #endif
       }
     case .vertical:
-      contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
+      contentSize.width = spot.view.frame.width - spot.view.contentInset.left - spot.view.contentInset.right
       contentSize.height = super.collectionViewContentSize.height
     }
   }

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -1,0 +1,441 @@
+#if os(OSX)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+import Tailor
+
+public class Spot: NSObject, Spotable {
+
+  /// These are deprecated
+  public static var layout: Layout = Layout(span: 1.0)
+  public static var headers: Registry = Registry()
+  public static var views: Registry = Registry()
+  public static var defaultKind: String = Component.Kind.list.string
+
+  open static var configure: ((_ view: View) -> Void)?
+
+  weak public var focusDelegate: SpotsFocusDelegate?
+  weak public var delegate: SpotsDelegate?
+
+  public var component: Component
+  public var componentKind: Component.Kind = .list
+  public var compositeSpots: [CompositeSpot] = []
+  public var configure: ((SpotConfigurable) -> Void)?
+  public var spotDelegate: Delegate?
+  public var spotDataSource: DataSource?
+  public var stateCache: StateCache?
+  public var userInterface: UserInterface?
+
+  open lazy var pageControl = UIPageControl()
+  open lazy var backgroundView = UIView()
+
+  #if os(OSX)
+  public var responder: NSResponder {
+    switch self.userInterface {
+    case let tableView as TableView:
+      return tableView
+    case let collectionView as CollectionView:
+      return collectionView
+    default:
+      return scrollView
+    }
+  }
+
+  public var nextResponder: NSResponder? {
+    get {
+      switch self.userInterface {
+      case let tableView as TableView:
+        return tableView.nextResponder
+      case let collectionView as CollectionView:
+        return collectionView.nextResponder
+      default:
+        return scrollView.nextResponder
+      }
+    }
+    set {
+      switch self.userInterface {
+      case let tableView as TableView:
+        tableView.nextResponder = newValue
+      case let collectionView as CollectionView:
+        collectionView.nextResponder = newValue
+      default:
+        scrollView.nextResponder = newValue
+      }
+    }
+  }
+
+  public func deselect() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.deselectAll(nil)
+    case let collectionView as CollectionView:
+      collectionView.deselectAll(nil)
+    default: break
+    }
+  }
+
+  open lazy var scrollView: ScrollView = {
+    let scrollView = ScrollView()
+    scrollView.documentView = NSView()
+    return scrollView
+  }()
+
+  public var view: ScrollView {
+    return scrollView
+  }
+  #else
+  var collectionViewLayout: CollectionLayout?
+
+  public var view: ScrollView {
+    if let userInterface = userInterface as? ScrollView {
+      return userInterface
+    }
+
+    let UIComponent: ScrollView
+
+    if componentKind == .list {
+      let tableView = TableView()
+      self.userInterface = tableView
+      UIComponent = tableView
+    } else {
+      let collectionViewLayout = CollectionLayout()
+      component.layout?.configure(collectionViewLayout: collectionViewLayout)
+      let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+      self.userInterface = collectionView
+
+      if componentKind == .carousel {
+        collectionViewLayout.scrollDirection = .horizontal
+      } else {
+        collectionViewLayout.scrollDirection = .vertical
+      }
+
+      UIComponent = collectionView
+    }
+
+    switch componentKind {
+    case .carousel, .grid:
+      registerDefault(view: GridSpotCell.self)
+    case .list:
+      registerDefault(view: ListSpotCell.self)
+    case .row:
+      registerDefault(view: RowSpotCell.self)
+    }
+
+    return UIComponent
+  }
+  #endif
+
+  public var tableView: TableView? {
+    return userInterface as? TableView
+  }
+
+  public var collectionView: CollectionView? {
+    return userInterface as? CollectionView
+  }
+
+  public required init(component: Component) {
+    var component = component
+    if component.kind.isEmpty {
+      component.kind = Spot.defaultKind
+    }
+
+    self.component = component
+
+    if let componentKind = Component.Kind(rawValue: component.kind) {
+      self.componentKind = componentKind
+    }
+
+    if component.layout == nil {
+      switch componentKind {
+      case .carousel:
+        self.component.layout = CarouselSpot.layout
+      case .grid:
+        self.component.layout = GridSpot.layout
+      case .list:
+        self.component.layout = ListSpot.layout
+      case .row:
+        self.component.layout = RowSpot.layout
+      }
+    }
+
+    super.init()
+
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
+
+    configureUserInterface(with: component,
+                           userInterface: self.view as? UserInterface)
+
+    if let componentLayout = component.layout {
+      configure(with: componentLayout)
+    }
+
+    prepareItems()
+  }
+
+  deinit {
+    spotDataSource = nil
+    spotDelegate = nil
+    userInterface = nil
+  }
+
+  public func configure(with layout: Layout) {
+    layout.configure(spot: self)
+  }
+
+  @discardableResult public func configureUserInterface(with component: Component, userInterface: UserInterface? = nil) {
+    userInterface?.register()
+
+    #if os(OSX)
+      if let tableView = self.table {
+        scrollView.contentView.addSubview(tableView)
+      } else if let collectionView = self.collection {
+        scrollView.contentView.addSubview(collectionView)
+      }
+    #else
+      if let collectionView = self.collectionView {
+        collectionView.backgroundView = backgroundView
+      }
+    #endif
+    configureDataSourceAndDelegate()
+  }
+
+  func configureDataSourceAndDelegate() {
+    if let tableView = self.tableView {
+      tableView.dataSource = spotDataSource
+      tableView.delegate = spotDelegate
+    } else if let collectionView = self.collectionView {
+      collectionView.dataSource = spotDataSource
+      collectionView.delegate = spotDelegate
+    }
+  }
+
+  public func setup(_ size: CGSize) {
+    type(of: self).configure?(view)
+
+    if let tableView = self.tableView {
+      setupTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      setupCollectionView(collectionView, with: size)
+    }
+
+    layout(size)
+  }
+
+  public func setupTableView(_ tableView: TableView, with size: CGSize) {
+    var height: CGFloat = 0.0
+    for item in component.items {
+      height += item.size.height
+    }
+
+    tableView.frame.size = size
+    tableView.frame.size.width = size.width - (tableView.contentInset.left)
+    tableView.frame.origin.x = size.width / 2 - tableView.frame.width / 2
+    tableView.contentSize = CGSize(
+      width: tableView.frame.size.width,
+      height: height - tableView.contentInset.top - tableView.contentInset.bottom)
+  }
+
+  public func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    collectionView.frame.size.width = size.width
+    #if !os(OSX)
+      guard let layout = collectionView.collectionViewLayout as? CollectionLayout else {
+        return
+      }
+
+      switch layout.scrollDirection {
+      case .horizontal:
+        setupHorizontalCollectionView(collectionView, with: size)
+      case .vertical:
+        setupVerticalCollectionView(collectionView, with: size)
+      }
+    #endif
+  }
+
+  public func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let layout = collectionView.collectionViewLayout as? GridableLayout else {
+      return
+    }
+
+    collectionView.isScrollEnabled = true
+    prepareItems()
+    configurePageControl()
+
+    if collectionView.contentSize.height > 0 {
+      collectionView.frame.size.height = collectionView.contentSize.height
+    } else {
+      var newCollectionViewHeight: CGFloat = 0.0
+
+      newCollectionViewHeight <- component.items.sorted(by: {
+        $0.size.height > $1.size.height
+      }).first?.size.height
+
+      collectionView.frame.size.height = newCollectionViewHeight
+
+      if collectionView.frame.size.height > 0 {
+        collectionView.frame.size.height += layout.sectionInset.top + layout.sectionInset.bottom
+      }
+    }
+
+    if !component.header.isEmpty,
+      let resolve = Configuration.views.make(component.header),
+      let view = resolve.view {
+      layout.headerReferenceSize.width = collectionView.frame.size.width
+      layout.headerReferenceSize.height = view.frame.size.height
+    }
+
+    CarouselSpot.configure?(collectionView, layout)
+
+    collectionView.frame.size.height += layout.headerReferenceSize.height
+
+    if let componentLayout = component.layout {
+      collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
+    }
+
+    if let pageIndicatorPlacement = component.layout?.pageIndicatorPlacement {
+      switch pageIndicatorPlacement {
+      case .below:
+        layout.sectionInset.bottom += pageControl.frame.height
+        pageControl.frame.origin.y = collectionView.frame.height
+      case .overlay:
+        let verticalAdjustment = CGFloat(2)
+        pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
+      }
+    }
+  }
+
+  public func setupVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let layout = collectionView.collectionViewLayout as? GridableLayout else {
+      return
+    }
+
+    collectionView.isScrollEnabled = false
+    #if !os(OSX)
+      GridSpot.configure?(collectionView, layout)
+
+      if let resolve = Configuration.views.make(component.header),
+        let view = resolve.view as? Componentable,
+        !component.header.isEmpty {
+
+        layout.headerReferenceSize.width = collectionView.frame.size.width
+        layout.headerReferenceSize.height = view.frame.size.height
+
+        if layout.headerReferenceSize.width == 0.0 {
+          layout.headerReferenceSize.width = size.width
+        }
+
+        if layout.headerReferenceSize.height == 0.0 {
+          layout.headerReferenceSize.height = view.preferredHeaderHeight
+        }
+      }
+      layout.prepare()
+      collectionView.frame.size.height = layout.contentSize.height
+    #else
+      layout.prepare()
+    #endif
+    component.size = collectionView.frame.size
+  }
+
+  public func layout(_ size: CGSize) {
+    if let tableView = self.tableView {
+      layoutTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      layoutCollectionView(collectionView, with: size)
+    }
+
+    view.layoutSubviews()
+  }
+
+  func layoutTableView(_ tableView: TableView, with size: CGSize) {
+    tableView.frame.size.width = size.width - (tableView.contentInset.left)
+    tableView.frame.origin.x = size.width / 2 - tableView.frame.width / 2
+  }
+
+  func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let layout = collectionView.collectionViewLayout as? CollectionLayout else {
+      return
+    }
+
+    view.frame.size.width = size.width
+
+    if compositeSpots.isEmpty {
+      prepareItems()
+    }
+
+    switch layout.scrollDirection {
+    case .horizontal:
+      layoutHorizontalCollectionView(collectionView, with: size)
+    case .vertical:
+      layoutVerticalCollectionView(collectionView, with: size)
+    }
+  }
+
+  public func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let collectionViewLayout = collectionView.collectionViewLayout as? GridableLayout else {
+      return
+    }
+
+    collectionViewLayout.prepare()
+    collectionViewLayout.invalidateLayout()
+
+    collectionView.frame.size.width = collectionViewLayout.contentSize.width
+    collectionView.frame.size.height = collectionViewLayout.contentSize.height
+  }
+
+  public func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    collectionView.collectionViewLayout.prepare()
+    collectionView.collectionViewLayout.invalidateLayout()
+
+    collectionView.frame.size.width = collectionView.collectionViewLayout.collectionViewContentSize.width
+    collectionView.frame.size.height = collectionView.collectionViewLayout.collectionViewContentSize.height
+  }
+
+  private func configurePageControl() {
+    guard let placement = component.layout?.pageIndicatorPlacement else {
+      pageControl.removeFromSuperview()
+      return
+    }
+
+    pageControl.numberOfPages = component.items.count
+    pageControl.frame.origin.x = 0
+    pageControl.frame.size.height = 22
+
+    switch placement {
+    case .below:
+      pageControl.frame.size.width = backgroundView.frame.width
+      pageControl.pageIndicatorTintColor = .lightGray
+      pageControl.currentPageIndicatorTintColor = .gray
+      backgroundView.addSubview(pageControl)
+    case .overlay:
+      pageControl.frame.size.width = view.frame.width
+      pageControl.pageIndicatorTintColor = nil
+      pageControl.currentPageIndicatorTintColor = nil
+      view.addSubview(pageControl)
+    }
+  }
+
+  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
+    var width: CGFloat = 0.0
+    var height: CGFloat = 0.0
+
+    width  <- item(at: indexPath)?.size.width
+    height <- item(at: indexPath)?.size.height
+
+    return CGSize(
+      width: floor(width),
+      height: ceil(height)
+    )
+  }
+
+  func registerDefault(view: View.Type) {
+    if Configuration.views.storage[Configuration.views.defaultIdentifier] == nil {
+      Configuration.views.defaultItem = Registry.Item.classType(view)
+    }
+  }
+
+  public func register() {
+
+  }
+}

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -26,7 +26,8 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: A configured supplementary view object.
   public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-    guard let spot = spot as? Gridable, !kind.isEmpty else {
+    guard let spot = spot, !kind.isEmpty,
+      let gridableLayout = collectionView.collectionViewLayout as? GridableLayout else {
       return UICollectionReusableView()
     }
 
@@ -40,10 +41,10 @@ extension DataSource: UICollectionViewDataSource {
       } else {
         identifier = spot.component.header
       }
-      viewHeight = spot.layout.headerReferenceSize.height
+      viewHeight += gridableLayout.headerReferenceSize.height
     case UICollectionElementKindSectionFooter:
       identifier = spot.component.footer
-      viewHeight = spot.layout.footerHeight
+      viewHeight += gridableLayout.footerHeight
     default:
       return UICollectionReusableView()
     }

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -41,10 +41,10 @@ extension DataSource: UICollectionViewDataSource {
       } else {
         identifier = spot.component.header
       }
-      viewHeight += gridableLayout.headerReferenceSize.height
+      viewHeight = gridableLayout.headerReferenceSize.height
     case UICollectionElementKindSectionFooter:
       identifier = spot.component.footer
-      viewHeight += gridableLayout.footerHeight
+      viewHeight = gridableLayout.footerHeight
     default:
       return UICollectionReusableView()
     }

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -9,7 +9,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter indexPath: The index path of the item.
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
-  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
     guard let spot = spot else { return CGSize.zero }
 
     return spot.sizeForItem(at: indexPath)

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -61,8 +61,8 @@ extension Gridable {
       prepareItems()
     }
 
-    layout.prepare()
-    layout.invalidateLayout()
+    collectionView.collectionViewLayout.prepare()
+    collectionView.collectionViewLayout.invalidateLayout()
     collectionView.frame.size.width = layout.collectionViewContentSize.width
     collectionView.frame.size.height = layout.collectionViewContentSize.height
   }

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -8,4 +8,15 @@ extension Layout {
     spot.layout.minimumInteritemSpacing = CGFloat(itemSpacing)
     spot.layout.minimumLineSpacing = CGFloat(lineSpacing)
   }
+
+  public func configure(spot: Spot) {
+    inset.configure(scrollView: spot.view)
+  }
+
+  public func configure(collectionViewLayout: UICollectionViewLayout?) {
+    if let flowLayout = collectionViewLayout as? FlowLayout {
+      flowLayout.minimumInteritemSpacing = CGFloat(itemSpacing)
+      flowLayout.minimumLineSpacing = CGFloat(lineSpacing)
+    }
+  }
 }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -2,6 +2,24 @@ import UIKit
 
 extension UICollectionView: UserInterface {
 
+  public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(_):
+        register(GridHeaderFooterWrapper.self,
+                 forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
+                 withReuseIdentifier: identifier)
+        register(GridHeaderFooterWrapper.self,
+                 forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
+                 withReuseIdentifier: identifier)
+        register(GridWrapper.self,
+                 forCellWithReuseIdentifier: identifier)
+      case .nib(let nib):
+        register(nib, forCellWithReuseIdentifier: identifier)
+      }
+    }
+  }
+
   /// The index of the current selected item
   @available(iOS 9.0, *)
   public var selectedIndex: Int {

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -14,6 +14,8 @@ extension UICollectionView: UserInterface {
                  withReuseIdentifier: identifier)
         register(GridWrapper.self,
                  forCellWithReuseIdentifier: identifier)
+        register(GridWrapper.self,
+                 forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
       case .nib(let nib):
         register(nib, forCellWithReuseIdentifier: identifier)
       }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -7,6 +7,7 @@ extension UITableView: UserInterface {
       switch item {
       case .classType(_):
         register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
+        register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
         register(ListWrapper.self, forCellReuseIdentifier: identifier)
       case .nib(let nib):
         register(nib, forCellReuseIdentifier: identifier)

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -2,6 +2,18 @@ import UIKit
 
 extension UITableView: UserInterface {
 
+  public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(_):
+        register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
+        register(ListWrapper.self, forCellReuseIdentifier: identifier)
+      case .nib(let nib):
+        register(nib, forCellReuseIdentifier: identifier)
+      }
+    }
+  }
+
   public var selectedIndex: Int {
     return indexPathForSelectedRow?.row ?? 0
   }

--- a/Sources/macOS/Classes/GridSpot.swift
+++ b/Sources/macOS/Classes/GridSpot.swift
@@ -253,7 +253,7 @@ open class GridSpot: NSObject, Gridable {
    - parameter size: A CGSize from the GridSpot superview
    */
   open func layout(_ size: CGSize) {
-    layout.prepareForTransition(to: layout)
+    layout.invalidateLayout()
     var layoutInsets = EdgeInsets()
     if let layout = layout as? NSCollectionViewFlowLayout {
       layout.sectionInset.top = component.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8

--- a/Sources/macOS/Classes/GridSpotItem.swift
+++ b/Sources/macOS/Classes/GridSpotItem.swift
@@ -13,7 +13,7 @@ open class GridSpotItem: NSCollectionViewItem, SpotConfigurable {
     }
   }
 
-  open var preferredViewSize = CGSize(width: 0, height: 88)
+  open var preferredViewSize = CGSize(width: 88, height: 88)
   open var customView = FlippedView()
 
   open lazy var customImageView: NSImageView = {

--- a/Sources/macOS/Classes/GridView.swift
+++ b/Sources/macOS/Classes/GridView.swift
@@ -1,0 +1,69 @@
+import Cocoa
+import Brick
+
+open class GridView: View, SpotConfigurable {
+
+  open var preferredViewSize = CGSize(width: 88, height: 88)
+  open var customView = FlippedView()
+
+  open lazy var imageView: NSImageView = {
+    let imageView = NSImageView()
+    imageView.autoresizingMask = .viewWidthSizable
+
+    return imageView
+  }()
+
+  open lazy var titleLabel: NSTextField = {
+    let titleLabel = NSTextField()
+    titleLabel.isEditable = false
+    titleLabel.isSelectable = false
+    titleLabel.isBezeled = false
+    titleLabel.textColor = NSColor.white
+    titleLabel.drawsBackground = false
+
+    return titleLabel
+  }()
+
+  open lazy var subtitleLabel: NSTextField = {
+    let subtitleLabel = NSTextField()
+    subtitleLabel.isEditable = false
+    subtitleLabel.isSelectable = false
+    subtitleLabel.isBezeled = false
+    subtitleLabel.textColor = NSColor.lightGray
+    subtitleLabel.drawsBackground = false
+
+    return subtitleLabel
+  }()
+
+  override init(frame rect: CGRect) {
+    super.init(frame: rect)
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.clear.cgColor
+
+    addSubview(imageView)
+    addSubview(titleLabel)
+    addSubview(subtitleLabel)
+  }
+
+  required public init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  open func configure( _ item: inout Item) {
+    titleLabel.stringValue = item.title
+    titleLabel.frame.origin.x = 8
+    titleLabel.sizeToFit()
+    if !item.subtitle.isEmpty {
+      titleLabel.frame.origin.y = 8
+      titleLabel.font = NSFont.boldSystemFont(ofSize: 14)
+      titleLabel.sizeToFit()
+    } else {
+      titleLabel.frame.origin.y = item.size.height / 2 - titleLabel.frame.size.height / 2
+    }
+
+    subtitleLabel.frame.origin.x = 8
+    subtitleLabel.stringValue = item.subtitle
+    subtitleLabel.sizeToFit()
+    subtitleLabel.frame.origin.y = titleLabel.frame.origin.y + subtitleLabel.frame.height
+  }
+}

--- a/Sources/macOS/Classes/RowSpot.swift
+++ b/Sources/macOS/Classes/RowSpot.swift
@@ -166,6 +166,8 @@ open class RowSpot: NSObject, Gridable {
       self.component.kind = Component.Kind.grid.string
     }
 
+    registerDefault(view: RowSpotItem.self)
+    registerComposite(view: GridComposite.self)
     registerAndPrepare()
     setupCollectionView()
     scrollView.addSubview(titleView)

--- a/Sources/macOS/Classes/RowSpotItem.swift
+++ b/Sources/macOS/Classes/RowSpotItem.swift
@@ -19,7 +19,7 @@ open class RowSpotItem: NSCollectionViewItem, SpotConfigurable {
     }
   }
 
-  open var preferredViewSize = CGSize(width: 0, height: 88)
+  open var preferredViewSize = CGSize(width: 88, height: 88)
   open var customView = FlippedView()
 
   open lazy var customImageView: NSImageView = {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -1,0 +1,509 @@
+import Cocoa
+import Tailor
+
+public class Spot: NSObject, Spotable {
+
+  public enum LayoutType: String {
+    case grid, left, flow
+  }
+
+  public struct Key {
+    public static let titleSeparator = "title-separator"
+    public static let titleFontSize = "title-font-size"
+    public static let titleTopInset = "title-top-inset"
+    public static let titleBottomInset = "title-bottom-inset"
+    public static let titleLeftInset = "title-left-inset"
+    public static let doubleAction = "double-click"
+
+    public static let titleLeftMargin = "title-left-margin"
+    public static let titleTextColor = "title-text-color"
+
+    public static let layout = "layout"
+    public static let gridLayoutMaximumItemWidth = "item-width-max"
+    public static let gridLayoutMaximumItemHeight = "item-height-max"
+    public static let gridLayoutMinimumItemWidth = "item-min-width"
+    public static let gridLayoutMinimumItemHeight = "item-min-height"
+  }
+
+  public struct Default {
+    public static var gridLayoutMaximumItemWidth = 120
+    public static var gridLayoutMaximumItemHeight = 120
+    public static var gridLayoutMinimumItemWidth = 80
+    public static var gridLayoutMinimumItemHeight = 80
+
+    public static var defaultLayout: String = LayoutType.flow.rawValue
+
+    public static var titleSeparator: Bool = true
+    public static var titleFontSize: CGFloat = 18.0
+    public static var titleLeftInset: CGFloat = 0.0
+    public static var titleTopInset: CGFloat = 10.0
+    public static var titleBottomInset: CGFloat = 10.0
+
+    public static var sectionInsetTop: CGFloat = 0.0
+    public static var sectionInsetLeft: CGFloat = 0.0
+    public static var sectionInsetRight: CGFloat = 0.0
+    public static var sectionInsetBottom: CGFloat = 0.0
+  }
+
+  /// These are deprecated
+  public static var layout: Layout = Layout(span: 1.0)
+  public static var headers: Registry = Registry()
+  public static var views: Registry = Registry()
+  public static var defaultKind: String = Component.Kind.list.string
+
+  open static var configure: ((_ view: View) -> Void)?
+
+  weak public var focusDelegate: SpotsFocusDelegate?
+  weak public var delegate: SpotsDelegate?
+
+  public var component: Component
+  public var componentKind: Component.Kind = .list
+  public var compositeSpots: [CompositeSpot] = []
+  public var configure: ((SpotConfigurable) -> Void)?
+  public var spotDelegate: Delegate?
+  public var spotDataSource: DataSource?
+  public var stateCache: StateCache?
+  public var userInterface: UserInterface?
+  open var gradientLayer: CAGradientLayer?
+
+  public var responder: NSResponder {
+    switch self.userInterface {
+    case let tableView as TableView:
+      return tableView
+    case let collectionView as CollectionView:
+      return collectionView
+    default:
+      return scrollView
+    }
+  }
+
+  public var nextResponder: NSResponder? {
+    get {
+      switch self.userInterface {
+      case let tableView as TableView:
+        return tableView.nextResponder
+      case let collectionView as CollectionView:
+        return collectionView.nextResponder
+      default:
+        return scrollView.nextResponder
+      }
+    }
+    set {
+      switch self.userInterface {
+      case let tableView as TableView:
+        tableView.nextResponder = newValue
+      case let collectionView as CollectionView:
+        collectionView.nextResponder = newValue
+      default:
+        scrollView.nextResponder = newValue
+      }
+    }
+  }
+
+  public func deselect() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.deselectAll(nil)
+    case let collectionView as CollectionView:
+      collectionView.deselectAll(nil)
+    default: break
+    }
+  }
+
+  open lazy var scrollView: ScrollView = {
+    let scrollView = ScrollView()
+    scrollView.documentView = NSView()
+    return scrollView
+  }()
+
+  public var view: ScrollView {
+    return scrollView
+  }
+
+  public var tableView: TableView? {
+    return userInterface as? TableView
+  }
+
+  public var collectionView: CollectionView? {
+    return userInterface as? CollectionView
+  }
+
+  open lazy var titleView: NSTextField = {
+    let titleView = NSTextField()
+    titleView.isEditable = false
+    titleView.isSelectable = false
+    titleView.isBezeled = false
+    titleView.textColor = NSColor.gray
+    titleView.drawsBackground = false
+
+    return titleView
+  }()
+
+  open lazy var tableColumn: NSTableColumn = {
+    let column = NSTableColumn(identifier: "tableview-column")
+    column.maxWidth = 250
+    column.width = 250
+    column.minWidth = 150
+
+    return column
+  }()
+
+  lazy var lineView: NSView = {
+    let lineView = NSView()
+    lineView.frame.size.height = 1
+    lineView.wantsLayer = true
+    lineView.layer?.backgroundColor = NSColor.gray.withAlphaComponent(0.2).cgColor
+
+    return lineView
+  }()
+
+  public required init(component: Component) {
+    var component = component
+    if component.kind.isEmpty {
+      component.kind = Spot.defaultKind
+    }
+
+    self.component = component
+
+    if let componentKind = Component.Kind(rawValue: component.kind) {
+      self.componentKind = componentKind
+    }
+
+    if component.layout == nil {
+      switch componentKind {
+      case .carousel:
+        self.component.layout = CarouselSpot.layout
+      case .grid:
+        self.component.layout = GridSpot.layout
+      case .list:
+        self.component.layout = ListSpot.layout
+      case .row:
+        self.component.layout = RowSpot.layout
+      }
+    }
+
+    super.init()
+
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
+
+    configureUserInterface(with: component)
+
+    if let componentLayout = component.layout {
+      configure(with: componentLayout)
+    }
+  }
+
+  deinit {
+    spotDataSource = nil
+    spotDelegate = nil
+    userInterface = nil
+  }
+
+  public func configure(with layout: Layout) {
+    layout.configure(spot: self)
+  }
+
+  @discardableResult public func configureUserInterface(with component: Component) {
+    if componentKind == .list {
+      let tableView = NSTableView(frame: CGRect.zero)
+      tableView.backgroundColor = NSColor.clear
+      tableView.allowsColumnReordering = false
+      tableView.allowsColumnResizing = false
+      tableView.allowsColumnSelection = false
+      tableView.allowsEmptySelection = true
+      tableView.allowsMultipleSelection = false
+      tableView.headerView = nil
+      tableView.selectionHighlightStyle = .none
+      tableView.allowsTypeSelect = true
+      tableView.focusRingType = .none
+
+      userInterface = tableView
+    } else {
+      let collectionView = CollectionView()
+      collectionView.backgroundColors = [NSColor.clear]
+      collectionView.isSelectable = true
+      collectionView.allowsMultipleSelection = false
+      collectionView.allowsEmptySelection = true
+      collectionView.layer = CALayer()
+      collectionView.wantsLayer = true
+      collectionView.collectionViewLayout = Spot.setupLayout(component)
+      userInterface = collectionView
+    }
+
+    switch componentKind {
+    case .list:
+      registerDefault(view: ListSpotItem.self)
+    default:
+      registerDefault(view: GridView.self)
+    }
+
+    userInterface?.register()
+
+    if let tableView = self.tableView {
+      scrollView.contentView.addSubview(tableView)
+    } else if let collectionView = self.collectionView {
+      scrollView.contentView.addSubview(collectionView)
+    }
+    configureDataSourceAndDelegate()
+  }
+
+  func configureDataSourceAndDelegate() {
+    if let tableView = self.tableView {
+      tableView.dataSource = spotDataSource
+      tableView.delegate = spotDelegate
+    } else if let collectionView = self.collectionView {
+      collectionView.dataSource = spotDataSource
+      collectionView.delegate = spotDelegate
+    }
+  }
+
+  fileprivate static func setupLayout(_ component: Component) -> NSCollectionViewLayout {
+    let layout: NSCollectionViewLayout
+
+    switch LayoutType(rawValue: component.meta(Key.layout, Default.defaultLayout)) ?? LayoutType.flow {
+    case .grid:
+      let gridLayout = NSCollectionViewGridLayout()
+
+      gridLayout.maximumItemSize = CGSize(width: component.meta(Key.gridLayoutMaximumItemWidth, Default.gridLayoutMaximumItemWidth),
+                                          height: component.meta(Key.gridLayoutMaximumItemHeight, Default.gridLayoutMaximumItemHeight))
+      gridLayout.minimumItemSize = CGSize(width: component.meta(Key.gridLayoutMinimumItemWidth, Default.gridLayoutMinimumItemWidth),
+                                          height: component.meta(Key.gridLayoutMinimumItemHeight, Default.gridLayoutMinimumItemHeight))
+      layout = gridLayout
+    case .left:
+      let leftLayout = CollectionViewLeftLayout()
+      layout = leftLayout
+    default:
+      let flowLayout = NSCollectionViewFlowLayout()
+      flowLayout.scrollDirection = .vertical
+      layout = flowLayout
+    }
+
+    return layout
+  }
+
+  public func setup(_ size: CGSize) {
+    scrollView.frame.size.width = size.width
+    type(of: self).configure?(view)
+    prepareItems()
+
+    if let tableView = self.tableView {
+      setupTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      setupCollectionView(collectionView, with: size)
+    }
+
+    layout(size)
+  }
+
+  public func setupTableView(_ tableView: TableView, with size: CGSize) {
+    tableView.dataSource = spotDataSource
+    tableView.delegate = spotDelegate
+    tableView.target = self
+    tableView.reloadData()
+    tableView.addTableColumn(tableColumn)
+    tableView.action = #selector(self.action(_:))
+    tableView.doubleAction = #selector(self.doubleAction(_:))
+    tableView.sizeToFit()
+
+    if !component.title.isEmpty {
+      scrollView.addSubview(titleView)
+      if component.meta(Key.titleSeparator, Default.titleSeparator) {
+        scrollView.addSubview(lineView)
+      }
+      configureTitleView()
+    }
+
+    ListSpot.configure?(tableView)
+  }
+
+  public func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    switch componentKind {
+    case .carousel:
+      setupHorizontalCollectionView(collectionView, with: size)
+    default:
+      setupVerticalCollectionView(collectionView, with: size)
+    }
+  }
+
+  public func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    if let layout = component.layout {
+      if layout.span > 0 {
+        component.items.enumerated().forEach {
+          component.items[$0.offset].size.width = size.width / CGFloat(layout.span)
+        }
+      }
+    }
+    CarouselSpot.configure?(collectionView)
+  }
+
+  public func setupVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let collectionViewLayout = collectionView.collectionViewLayout else {
+      return
+    }
+
+    var size = size
+    size.height = collectionViewLayout.collectionViewContentSize.height
+    collectionViewLayout.invalidateLayout()
+    component.size = collectionView.frame.size
+  }
+
+  public func layout(_ size: CGSize) {
+    if let tableView = self.tableView {
+      layoutTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      layoutCollectionView(collectionView, with: size)
+    }
+
+    view.layoutSubviews()
+  }
+
+  func layoutTableView(_ tableView: TableView, with size: CGSize) {
+    if !component.title.isEmpty {
+      configureTitleView()
+    }
+
+    tableView.sizeToFit()
+    scrollView.frame.size.width = size.width
+    scrollView.frame.size.height = tableView.frame.height + scrollView.contentInsets.top + scrollView.contentInsets.bottom
+  }
+
+  func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    if componentKind == .carousel {
+      layoutHorizontalCollectionView(collectionView, with: size)
+    } else {
+      layoutVerticalCollectionView(collectionView, with: size)
+    }
+  }
+
+  public func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    var layoutInsets = EdgeInsets()
+
+    if let layout = collectionView.collectionViewLayout as? NSCollectionViewFlowLayout {
+      layout.sectionInset.top = component.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
+      layoutInsets = layout.sectionInset
+    }
+
+    scrollView.frame.size.height = (component.items.first?.size.height ?? layoutInsets.top) + layoutInsets.top + layoutInsets.bottom
+    collectionView.frame.size.height = scrollView.frame.size.height
+    gradientLayer?.frame.size.height = scrollView.frame.size.height
+
+    if !component.title.isEmpty {
+      configureTitleView(layoutInsets)
+    }
+
+    if let componentLayout = component.layout {
+      if componentLayout.span > 0 {
+        component.items.enumerated().forEach {
+          component.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
+        }
+      } else if componentLayout.span == 1 {
+        scrollView.frame.size.width = size.width - layoutInsets.right
+        scrollView.scrollingEnabled = (component.items.count > 1)
+        scrollView.hasHorizontalScroller = (component.items.count > 1)
+        component.items.enumerated().forEach {
+          component.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
+        }
+        collectionView.collectionViewLayout?.invalidateLayout()
+      }
+    }
+  }
+
+  public func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    guard let collectionViewLayout = collectionView.collectionViewLayout else {
+      return
+    }
+
+    collectionViewLayout.invalidateLayout()
+    var layoutInsets = EdgeInsets()
+    if let layout = collectionViewLayout as? NSCollectionViewFlowLayout {
+      layout.sectionInset.top = component.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
+      layoutInsets = layout.sectionInset
+    }
+
+    var layoutHeight = collectionViewLayout.collectionViewContentSize.height + layoutInsets.top + layoutInsets.bottom
+
+    if component.items.isEmpty {
+      layoutHeight = size.height + layoutInsets.top + layoutInsets.bottom
+    }
+
+    scrollView.frame.size.width = size.width - layoutInsets.right
+    scrollView.frame.size.height = layoutHeight
+    collectionView.frame.size.height = scrollView.frame.size.height - layoutInsets.top + layoutInsets.bottom
+    collectionView.frame.size.width = size.width - layoutInsets.right
+
+    if !component.title.isEmpty {
+      configureTitleView(layoutInsets)
+    }
+  }
+
+  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
+    var width: CGFloat = 0.0
+    var height: CGFloat = 0.0
+
+    width  <- item(at: indexPath)?.size.width
+    height <- item(at: indexPath)?.size.height
+
+    return CGSize(
+      width: floor(width),
+      height: ceil(height)
+    )
+  }
+
+  func registerDefault(view: View.Type) {
+    if Configuration.views.storage[Configuration.views.defaultIdentifier] == nil {
+      Configuration.views.defaultItem = Registry.Item.classType(view)
+    }
+  }
+
+  fileprivate func configureTitleView(_ layoutInsets: EdgeInsets) {
+    guard let collectionView = collectionView else {
+      return
+    }
+
+    titleView.stringValue = component.title
+    titleView.sizeToFit()
+    titleView.font = NSFont.systemFont(ofSize: component.meta(Key.titleFontSize, Default.titleFontSize))
+    titleView.sizeToFit()
+    titleView.frame.size.width = collectionView.frame.width - layoutInsets.right - layoutInsets.left
+    lineView.frame.size.width = scrollView.frame.size.width - (component.meta(Key.titleLeftMargin, titleView.frame.origin.x) * 2)
+    lineView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
+    titleView.frame.origin.x = collectionView.frame.origin.x + component.meta(Key.titleLeftInset, Default.titleLeftInset)
+    titleView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
+    titleView.frame.origin.y = component.meta(Key.titleTopInset, Default.titleTopInset) - component.meta(Key.titleBottomInset, Default.titleBottomInset)
+    lineView.frame.origin.y = titleView.frame.maxY + 5
+    collectionView.frame.size.height = scrollView.frame.size.height + titleView.frame.size.height
+  }
+
+  fileprivate func configureTitleView() {
+    guard let tableView = tableView else {
+      return
+    }
+
+    titleView.stringValue = component.title
+    titleView.font = NSFont.systemFont(ofSize: component.meta(Key.titleFontSize, Default.titleFontSize))
+    titleView.sizeToFit()
+    titleView.isEnabled = false
+    titleView.frame.origin.x = tableView.frame.origin.x + component.meta(Key.titleLeftInset, Default.titleLeftInset)
+    scrollView.contentInsets.top += titleView.frame.size.height * 2
+    titleView.frame.origin.y = titleView.frame.size.height / 2
+
+    lineView.frame.size.width = scrollView.frame.size.width - (component.meta(Key.titleLeftInset, Default.titleLeftInset) * 2)
+    lineView.frame.origin.x = component.meta(Key.titleLeftInset, Default.titleLeftInset)
+    lineView.frame.origin.y = titleView.frame.maxY + 8
+  }
+
+  open func doubleAction(_ sender: Any?) {
+    guard let tableView = tableView, let item = item(at: tableView.clickedRow), component.meta(Key.doubleAction, type: Bool.self) == true else { return }
+    delegate?.spotable(self, itemSelected: item)
+  }
+
+  open func action(_ sender: Any?) {
+    guard let tableView = tableView, let item = item(at: tableView.clickedRow), component.meta(Key.doubleAction, false) == false else { return }
+    delegate?.spotable(self, itemSelected: item)
+  }
+
+  public func register() {
+
+  }
+}

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -132,19 +132,16 @@ extension Delegate: NSTableViewDelegate {
       view.contentView.frame.size.width = tableView.frame.size.width
       view.contentView.frame.size.height = spot.computedHeight
       view.configure(&spot.component.items[row], compositeSpots: spots)
-    case let view as View:
-      let customView = view
+    case let view:
+      if let customView = view {
+        if !(view is NSTableRowView) {
+          let wrapper = ListWrapper()
+          wrapper.configure(with: customView)
+          resolvedView = wrapper
+        }
 
-      if !(view is NSTableRowView) {
-        let wrapper = ListWrapper()
-        wrapper.configure(with: view)
-        resolvedView = wrapper
+        (customView as? SpotConfigurable)?.configure(&spot.component.items[row])
       }
-
-      (customView as? SpotConfigurable)?.configure(&spot.component.items[row])
-    case let view as SpotConfigurable:
-      view.configure(&spot.component.items[row])
-    default: break
     }
 
     (resolvedView as? NSTableRowView)?.identifier = reuseIdentifier

--- a/Sources/macOS/Extensions/Layout+macOS.swift
+++ b/Sources/macOS/Extensions/Layout+macOS.swift
@@ -10,4 +10,8 @@ extension Layout {
       layout.minimumLineSpacing = CGFloat(lineSpacing)
     }
   }
+
+  public func configure(spot: Spot) {
+    inset.configure(scrollView: spot.view)
+  }
 }

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -2,6 +2,17 @@ import Cocoa
 
 extension NSCollectionView: UserInterface {
 
+  public func register() {
+    for (identifier, item) in Configuration.views.storage {
+      switch item {
+      case .classType(_):
+        register(GridWrapper.self, forItemWithIdentifier: identifier)
+      case .nib(let nib):
+        register(nib, forItemWithIdentifier: identifier)
+      }
+    }
+  }
+
   public func view<T>(at index: Int) -> T? {
     let view = item(at: index)
 

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -2,6 +2,8 @@ import Cocoa
 
 extension NSTableView: UserInterface {
 
+  public func register() {}
+
   public func view<T>(at index: Int) -> T? {
     let view = rowView(atRow: index, makeIfNecessary: true)
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
+		BD1B2C3A1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
+		BD1B2C3B1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
+		BD1B2C3C1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
 		BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
@@ -304,8 +307,6 @@
 		BDAD85F11E3E7032008289AE /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD855F1E3E7032008289AE /* TypeAlias.swift */; };
 		BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD855F1E3E7032008289AE /* TypeAlias.swift */; };
 		BDAD85F61E3E703A008289AE /* CollectionAdapter+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85F51E3E703A008289AE /* CollectionAdapter+tvOS.swift */; };
-		BDAE76BA1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
-		BDAE76BC1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -384,6 +385,7 @@
 		BD108DB81E499EE600623CEA /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BD1B2C391E4A09BC00B862C1 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD352E5E1CBAD6EC002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/iOS/Brick.framework; sourceTree = "<group>"; };
 		BD352E601CBAD6F9002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/Mac/Brick.framework; sourceTree = "<group>"; };
@@ -519,7 +521,6 @@
 		BDAD855E1E3E7032008289AE /* StateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateCache.swift; sourceTree = "<group>"; };
 		BDAD855F1E3E7032008289AE /* TypeAlias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BDAD85F51E3E703A008289AE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
-		BDAE76B91E46542900415051 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BDB538321C444D460005E498 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
@@ -668,6 +669,7 @@
 				BDAD848F1E3E701C008289AE /* ListWrapper.swift */,
 				BDAD84901E3E701C008289AE /* RowSpot.swift */,
 				BDAD84911E3E701C008289AE /* RowSpotCell.swift */,
+				BD1B2C391E4A09BC00B862C1 /* Spot.swift */,
 				BDAD84921E3E701C008289AE /* SpotsContentView.swift */,
 				BDAD84931E3E701C008289AE /* SpotsScrollView.swift */,
 			);
@@ -784,7 +786,6 @@
 				BDAD852D1E3E7032008289AE /* Delegate.swift */,
 				BDAD852E1E3E7032008289AE /* SpotFactory.swift */,
 				BDAD852F1E3E7032008289AE /* ViewSpot.swift */,
-				BDAE76B91E46542900415051 /* Spot.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1491,6 +1492,7 @@
 				BDAD84A91E3E701C008289AE /* CarouselSpotHeader.swift in Sources */,
 				BDAD85741E3E7032008289AE /* Paginate.swift in Sources */,
 				BDAD84AF1E3E701C008289AE /* GridComposite.swift in Sources */,
+				BD1B2C3B1E4A09BC00B862C1 /* Spot.swift in Sources */,
 				BDAD859B1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */,
 				BDAD84D31E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */,
 				BDAD85AD1E3E7032008289AE /* Composable.swift in Sources */,
@@ -1521,7 +1523,6 @@
 				BDAD84A71E3E701C008289AE /* CarouselSpotCell.swift in Sources */,
 				BDAD85BC1E3E7032008289AE /* Spotable.swift in Sources */,
 				BDAD85E31E3E7032008289AE /* Interaction.swift in Sources */,
-				BDAE76BC1E46542900415051 /* Spot.swift in Sources */,
 				BDAD84A51E3E701C008289AE /* CarouselSpot.swift in Sources */,
 				BDAD84AD1E3E701C008289AE /* GridableLayout.swift in Sources */,
 				BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */,
@@ -1595,6 +1596,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D55B7B0C1E4234C3000125C8 /* RxSpotsDelegate.swift in Sources */,
+				BD1B2C3C1E4A09BC00B862C1 /* Spot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1632,7 +1634,6 @@
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD84C21E3E701C008289AE /* RowSpot.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
-				BDAE76BA1E46542900415051 /* Spot.swift in Sources */,
 				BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,
 				BDAD85841E3E7032008289AE /* Listable+Extension.swift in Sources */,
 				BDAD856C1E3E7032008289AE /* ViewSpot.swift in Sources */,
@@ -1660,6 +1661,7 @@
 				BDAD85B11E3E7032008289AE /* Listable.swift in Sources */,
 				BDAD85C31E3E7032008289AE /* SpotsFocusDelegate.swift in Sources */,
 				BDAD84A41E3E701C008289AE /* CarouselSpot.swift in Sources */,
+				BD1B2C3A1E4A09BC00B862C1 /* Spot.swift in Sources */,
 				BDAD85811E3E7032008289AE /* Item+Extensions.swift in Sources */,
 				BDAD84E21E3E701C008289AE /* UIViewController+Extensions.swift in Sources */,
 				BDAD84A21E3E701C008289AE /* CarouselComposite.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -15,12 +15,15 @@
 		BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
 		BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
 		BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
-		BD108DB91E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
-		BD108DBA1E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
-		BD108DBB1E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
 		BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
+		BD17B4511E4A0A4C0087DAC6 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B4501E4A0A4C0087DAC6 /* Spot.swift */; };
+		BD17B4571E4A1D230087DAC6 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B4561E4A1D230087DAC6 /* TestSpot.swift */; };
+		BD17B4581E4A1D290087DAC6 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B4521E4A1D170087DAC6 /* TestSpot.swift */; };
+		BD17B4591E4A1D2B0087DAC6 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B4521E4A1D170087DAC6 /* TestSpot.swift */; };
+		BD17B45A1E4A1D2B0087DAC6 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B4521E4A1D170087DAC6 /* TestSpot.swift */; };
+		BD17B45C1E4A47020087DAC6 /* GridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD17B45B1E4A47020087DAC6 /* GridView.swift */; };
 		BD1B2C3A1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
 		BD1B2C3B1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
 		BD1B2C3C1E4A09BC00B862C1 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1B2C391E4A09BC00B862C1 /* Spot.swift */; };
@@ -382,9 +385,12 @@
 		52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageIndicatorPlacement.swift; sourceTree = "<group>"; };
 		BD01BD0D1DAEA464009C10FF /* TestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestParser.swift; sourceTree = "<group>"; };
 		BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListComposite.swift; sourceTree = "<group>"; };
-		BD108DB81E499EE600623CEA /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BD17B4501E4A0A4C0087DAC6 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
+		BD17B4521E4A1D170087DAC6 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
+		BD17B4561E4A1D230087DAC6 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
+		BD17B45B1E4A47020087DAC6 /* GridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridView.swift; sourceTree = "<group>"; };
 		BD1B2C391E4A09BC00B862C1 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD352E5E1CBAD6EC002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/iOS/Brick.framework; sourceTree = "<group>"; };
@@ -727,6 +733,8 @@
 				BDAD84F61E3E7025008289AE /* RowSpotItem.swift */,
 				BDAD84F71E3E7025008289AE /* SpotsContentView.swift */,
 				BDAD84F81E3E7025008289AE /* SpotsScrollView.swift */,
+				BD17B4501E4A0A4C0087DAC6 /* Spot.swift */,
+				BD17B45B1E4A47020087DAC6 /* GridView.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -897,6 +905,7 @@
 		BDDF2CCE1DC7C4FC00B766BA /* macOS */ = {
 			isa = PBXGroup;
 			children = (
+				BD17B4561E4A1D230087DAC6 /* TestSpot.swift */,
 				BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */,
 				BD45D98E1E30935500C2D6B2 /* TestLayoutExtensions.swift */,
 			);
@@ -989,6 +998,7 @@
 		D58478271C43FF34006EBA49 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				BD17B4521E4A1D170087DAC6 /* TestSpot.swift */,
 				BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */,
 				BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */,
 				BD4295541D81D39700E07E1C /* TestCarouselSpot.swift */,
@@ -1023,7 +1033,6 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
 				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
-				BD108DB81E499EE600623CEA /* TestSpot.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1571,7 +1580,7 @@
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */,
-				BD108DBB1E499EE600623CEA /* TestSpot.swift in Sources */,
+				BD17B4591E4A1D2B0087DAC6 /* TestSpot.swift in Sources */,
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
@@ -1604,6 +1613,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD17B45A1E4A1D2B0087DAC6 /* TestSpot.swift in Sources */,
 				D55B7B4F1E423C65000125C8 /* RxSpotsDelegateTests.swift in Sources */,
 				BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */,
 			);
@@ -1721,7 +1731,7 @@
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
-				BD108DB91E499EE600623CEA /* TestSpot.swift in Sources */,
+				BD17B4581E4A1D290087DAC6 /* TestSpot.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */,
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
@@ -1747,6 +1757,7 @@
 				BDAD851B1E3E7025008289AE /* SpotsScrollView.swift in Sources */,
 				BDAD85EB1E3E7032008289AE /* Registry.swift in Sources */,
 				BDAD85BB1E3E7032008289AE /* Spotable.swift in Sources */,
+				BD17B45C1E4A47020087DAC6 /* GridView.swift in Sources */,
 				BDAD85D91E3E7032008289AE /* Dispatch.swift in Sources */,
 				BDAD85091E3E7025008289AE /* CarouselSpot.swift in Sources */,
 				BDAD85F11E3E7032008289AE /* TypeAlias.swift in Sources */,
@@ -1786,6 +1797,7 @@
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85131E3E7025008289AE /* ListSpot.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
+				BD17B4511E4A0A4C0087DAC6 /* Spot.swift in Sources */,
 				BDAD85191E3E7025008289AE /* RowSpotItem.swift in Sources */,
 				BDAD85EE1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,
@@ -1831,7 +1843,7 @@
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
-				BD108DBA1E499EE600623CEA /* TestSpot.swift in Sources */,
+				BD17B4571E4A1D230087DAC6 /* TestSpot.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BD45D9881E30906300C2D6B2 /* TestLayout.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
 		BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
 		BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
+		BD108DB91E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
+		BD108DBA1E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
+		BD108DBB1E499EE600623CEA /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD108DB81E499EE600623CEA /* TestSpot.swift */; };
 		BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
@@ -379,6 +382,7 @@
 		52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageIndicatorPlacement.swift; sourceTree = "<group>"; };
 		BD01BD0D1DAEA464009C10FF /* TestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestParser.swift; sourceTree = "<group>"; };
 		BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListComposite.swift; sourceTree = "<group>"; };
+		BD108DB81E499EE600623CEA /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
@@ -1019,6 +1023,7 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
 				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
+				BD108DB81E499EE600623CEA /* TestSpot.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1566,6 +1571,7 @@
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD4295591D81D45D00E07E1C /* TestViewSpot.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponent.swift in Sources */,
+				BD108DBB1E499EE600623CEA /* TestSpot.swift in Sources */,
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
@@ -1714,6 +1720,7 @@
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
+				BD108DB91E499EE600623CEA /* TestSpot.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */,
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
@@ -1824,6 +1831,7 @@
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
+				BD108DBA1E499EE600623CEA /* TestSpot.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BD45D9881E30906300C2D6B2 /* TestLayout.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -301,6 +301,9 @@
 		BDAD85F11E3E7032008289AE /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD855F1E3E7032008289AE /* TypeAlias.swift */; };
 		BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD855F1E3E7032008289AE /* TypeAlias.swift */; };
 		BDAD85F61E3E703A008289AE /* CollectionAdapter+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85F51E3E703A008289AE /* CollectionAdapter+tvOS.swift */; };
+		BDAE76BA1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
+		BDAE76BB1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
+		BDAE76BC1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -513,6 +516,7 @@
 		BDAD855E1E3E7032008289AE /* StateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateCache.swift; sourceTree = "<group>"; };
 		BDAD855F1E3E7032008289AE /* TypeAlias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		BDAD85F51E3E703A008289AE /* CollectionAdapter+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionAdapter+tvOS.swift"; sourceTree = "<group>"; };
+		BDAE76B91E46542900415051 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BDB538321C444D460005E498 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
@@ -777,6 +781,7 @@
 				BDAD852D1E3E7032008289AE /* Delegate.swift */,
 				BDAD852E1E3E7032008289AE /* SpotFactory.swift */,
 				BDAD852F1E3E7032008289AE /* ViewSpot.swift */,
+				BDAE76B91E46542900415051 /* Spot.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1512,6 +1517,7 @@
 				BDAD84A71E3E701C008289AE /* CarouselSpotCell.swift in Sources */,
 				BDAD85BC1E3E7032008289AE /* Spotable.swift in Sources */,
 				BDAD85E31E3E7032008289AE /* Interaction.swift in Sources */,
+				BDAE76BC1E46542900415051 /* Spot.swift in Sources */,
 				BDAD84A51E3E701C008289AE /* CarouselSpot.swift in Sources */,
 				BDAD84AD1E3E701C008289AE /* GridableLayout.swift in Sources */,
 				BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */,
@@ -1621,6 +1627,7 @@
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD84C21E3E701C008289AE /* RowSpot.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
+				BDAE76BA1E46542900415051 /* Spot.swift in Sources */,
 				BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,
 				BDAD85841E3E7032008289AE /* Listable+Extension.swift in Sources */,
 				BDAD856C1E3E7032008289AE /* ViewSpot.swift in Sources */,
@@ -1771,6 +1778,7 @@
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85131E3E7025008289AE /* ListSpot.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
+				BDAE76BB1E46542900415051 /* Spot.swift in Sources */,
 				BDAD85191E3E7025008289AE /* RowSpotItem.swift in Sources */,
 				BDAD85EE1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -305,7 +305,6 @@
 		BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD855F1E3E7032008289AE /* TypeAlias.swift */; };
 		BDAD85F61E3E703A008289AE /* CollectionAdapter+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85F51E3E703A008289AE /* CollectionAdapter+tvOS.swift */; };
 		BDAE76BA1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
-		BDAE76BB1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
 		BDAE76BC1E46542900415051 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAE76B91E46542900415051 /* Spot.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -1785,7 +1784,6 @@
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85131E3E7025008289AE /* ListSpot.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
-				BDAE76BB1E46542900415051 /* Spot.swift in Sources */,
 				BDAD85191E3E7025008289AE /* RowSpotItem.swift in Sources */,
 				BDAD85EE1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -47,6 +47,124 @@ struct Helper {
 }
 
 #if !os(OSX)
+
+  class HeaderView: UIView, SpotConfigurable, Componentable {
+
+    public var preferredHeaderHeight: CGFloat = 50.0
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: UILabel = {
+      let label = UILabel()
+      label.textAlignment = .center
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+
+    func configure(_ item: inout Item) {
+      titleLabel.text = item.title
+    }
+
+    func configure(_ component: Component) {
+      titleLabel.text = component.title
+    }
+  }
+
+  class FooterView: UIView, SpotConfigurable, Componentable {
+
+    var preferredHeaderHeight: CGFloat = 50
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: UILabel = {
+      let label = UILabel()
+      label.textAlignment = .center
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+
+    func configure(_ item: inout Item) {
+      titleLabel.text = item.title
+    }
+
+    func configure(_ component: Component) {
+      titleLabel.text = "This is a footer"
+    }
+  }
+
+  class TextView: UIView, SpotConfigurable {
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: UILabel = {
+      let label = UILabel()
+      label.textAlignment = .center
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+
+      backgroundColor = UIColor.gray.withAlphaComponent(0.25)
+
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+
+    func configure(_ item: inout Item) {
+      titleLabel.text = item.title
+    }
+  }
+
+
   class CustomListCell: UITableViewCell, SpotConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 0, height: 44)

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -47,7 +47,6 @@ struct Helper {
 }
 
 #if !os(OSX)
-
   class HeaderView: UIView, SpotConfigurable, Componentable {
 
     public var preferredHeaderHeight: CGFloat = 50.0
@@ -199,7 +198,119 @@ struct Helper {
       textLabel.text = component.title
     }
   }
+#else
+import Cocoa
+
+  class HeaderView: View, SpotConfigurable, Componentable {
+
+    public var preferredHeaderHeight: CGFloat = 50.0
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: NSTextField = {
+      let label = NSTextField()
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+
+    func configure(_ item: inout Item) {
+      titleLabel.stringValue = item.title
+    }
+
+    func configure(_ component: Component) {
+      titleLabel.stringValue = component.title
+    }
+  }
+
+  class FooterView: View, SpotConfigurable, Componentable {
+
+    var preferredHeaderHeight: CGFloat = 50
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: NSTextField = {
+      let label = NSTextField()
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+
+    func configure(_ item: inout Item) {
+      titleLabel.stringValue = item.title
+    }
+
+    func configure(_ component: Component) {
+      titleLabel.stringValue = "This is a footer"
+    }
+  }
+
+  class TextView: View, SpotConfigurable {
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    lazy var titleLabel: NSTextField = {
+      let label = NSTextField()
+      return label
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      addSubview(titleLabel)
+      configureConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+      titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+      titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+      titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+    }
+    
+    func configure(_ item: inout Item) {
+      titleLabel.stringValue = item.title
+    }
+  }
 #endif
+
+
 
 class TestView: View, SpotConfigurable {
   var preferredViewSize: CGSize = CGSize(width: 50, height: 50)

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -167,4 +167,25 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
   }
+
+  func testHybridCarouselSpotWithHeaderAndFooterAndBelowPageIndicator() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0, pageIndicatorPlacement: .below),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 210))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 210))
+  }
 }

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -22,4 +22,83 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.items[1].size,    CGSize(width: 414, height: 44))
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 88))
   }
+
+  func testCompareHybridListSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.list.string, items: items, hybrid: true)
+    let listComponent = Component(kind: Component.Kind.list.string, items: items)
+    let spot = Spot(component: component)
+    let listSpot = ListSpot(component: listComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: listSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    listSpot.setup(CGSize(width: 100, height: 100))
+    listSpot.layout(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, listSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, listSpot.view.contentSize)
+  }
+
+  func testCompareHybridGridSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.grid.string, items: items, hybrid: true)
+    let gridComponent = Component(kind: Component.Kind.grid.string, items: items)
+    let spot = Spot(component: component)
+    let gridSpot = GridSpot(component: gridComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: gridSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    gridSpot.setup(CGSize(width: 100, height: 100))
+    gridSpot.layout(CGSize(width: 100, height: 100))
+    gridSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, gridSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, gridSpot.view.contentSize)
+  }
+
+  func testCompareHybridCarouselSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.carousel.string, items: items, hybrid: true)
+    let carouselComponent = Component(kind: Component.Kind.carousel.string, items: items)
+    let spot = Spot(component: component)
+    let carouselSpot = CarouselSpot(component: carouselComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: carouselSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.layout(CGSize(width: 100, height: 100))
+    carouselSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, carouselSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, carouselSpot.view.contentSize)
+  }
+
+  func testCompareHybridRowSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.row.string, items: items, hybrid: true)
+    let rowComponent = Component(kind: Component.Kind.row.string, items: items)
+    let spot = Spot(component: component)
+    let rowSpot = RowSpot(component: rowComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: rowSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    rowSpot.setup(CGSize(width: 100, height: 100))
+    rowSpot.layout(CGSize(width: 100, height: 100))
+    rowSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, rowSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, rowSpot.view.contentSize)
+  }
 }

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -1,0 +1,8 @@
+@testable import Spots
+import XCTest
+
+class TestSpot: XCTestCase {
+
+  
+
+}

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -1,8 +1,25 @@
 @testable import Spots
+import Brick
 import XCTest
 
 class TestSpot: XCTestCase {
 
-  
+  override func setUp() {
+    Configuration.views.storage = [:]
+    Configuration.views.defaultItem = nil
+  }
 
+  func testDefaultValues() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(items: items, hybrid: true)
+    let spot = Spot(component: component)
+
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertTrue(spot.view is TableView)
+    XCTAssertTrue(spot.view.isEqual(spot.tableView))
+    XCTAssertEqual(spot.items[0].size,    CGSize(width: 414, height: 44))
+    XCTAssertEqual(spot.items[1].size,    CGSize(width: 414, height: 44))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 88))
+  }
 }

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -125,4 +125,25 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 276))
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 276))
   }
+
+  func testHybridCarouselSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
+  }
 }

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -104,4 +104,25 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.view.frame, rowSpot.view.frame)
     XCTAssertEqual(spot.view.contentSize, rowSpot.view.contentSize)
   }
+
+  func testHybridGridSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.grid.string,
+      layout: Layout(span: 2.0),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 276))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 276))
+  }
 }

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -7,6 +7,9 @@ class TestSpot: XCTestCase {
   override func setUp() {
     Configuration.views.storage = [:]
     Configuration.views.defaultItem = nil
+    Configuration.register(view: HeaderView.self, identifier: "Header")
+    Configuration.register(view: TextView.self,   identifier: "TextView")
+    Configuration.register(view: FooterView.self, identifier: "Footer")
   }
 
   func testDefaultValues() {

--- a/SpotsTests/Shared/TestSpot.swift
+++ b/SpotsTests/Shared/TestSpot.swift
@@ -146,4 +146,25 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
   }
+
+  func testHybridCarouselSpotWithHeaderAndFooterAndOverlayPageIndicator() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0, pageIndicatorPlacement: .overlay),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
+  }
 }

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -21,8 +21,8 @@ class TestSpot: XCTestCase {
 
     XCTAssertTrue(spot.view is TableView)
     XCTAssertTrue(spot.view.isEqual(spot.tableView))
-    XCTAssertEqual(spot.items[0].size,    CGSize(width: 414, height: 44))
-    XCTAssertEqual(spot.items[1].size,    CGSize(width: 414, height: 44))
+    XCTAssertEqual(spot.items[0].size,    CGSize(width: UIScreen.main.bounds.width, height: 44))
+    XCTAssertEqual(spot.items[1].size,    CGSize(width: UIScreen.main.bounds.width, height: 44))
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 88))
   }
 

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -1,0 +1,191 @@
+@testable import Spots
+import Brick
+import XCTest
+
+class TestSpot: XCTestCase {
+
+  override func setUp() {
+    Configuration.views.storage = [:]
+    Configuration.views.defaultItem = nil
+    Configuration.register(view: HeaderView.self, identifier: "Header")
+    Configuration.register(view: TextView.self,   identifier: "TextView")
+    Configuration.register(view: FooterView.self, identifier: "Footer")
+  }
+
+  func testDefaultValues() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(items: items, hybrid: true)
+    let spot = Spot(component: component)
+
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertTrue(spot.view is TableView)
+    XCTAssertTrue(spot.view.isEqual(spot.tableView))
+    XCTAssertEqual(spot.items[0].size,    CGSize(width: 414, height: 44))
+    XCTAssertEqual(spot.items[1].size,    CGSize(width: 414, height: 44))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 88))
+  }
+
+  func testCompareHybridListSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.list.string, items: items, hybrid: true)
+    let listComponent = Component(kind: Component.Kind.list.string, items: items)
+    let spot = Spot(component: component)
+    let listSpot = ListSpot(component: listComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: listSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    listSpot.setup(CGSize(width: 100, height: 100))
+    listSpot.layout(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, listSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, listSpot.view.contentSize)
+  }
+
+  func testCompareHybridGridSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.grid.string, items: items, hybrid: true)
+    let gridComponent = Component(kind: Component.Kind.grid.string, items: items)
+    let spot = Spot(component: component)
+    let gridSpot = GridSpot(component: gridComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: gridSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    gridSpot.setup(CGSize(width: 100, height: 100))
+    gridSpot.layout(CGSize(width: 100, height: 100))
+    gridSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, gridSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, gridSpot.view.contentSize)
+  }
+
+  func testCompareHybridCarouselSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.carousel.string, items: items, hybrid: true)
+    let carouselComponent = Component(kind: Component.Kind.carousel.string, items: items)
+    let spot = Spot(component: component)
+    let carouselSpot = CarouselSpot(component: carouselComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: carouselSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.layout(CGSize(width: 100, height: 100))
+    carouselSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, carouselSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, carouselSpot.view.contentSize)
+  }
+
+  func testCompareHybridRowSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.row.string, items: items, hybrid: true)
+    let rowComponent = Component(kind: Component.Kind.row.string, items: items)
+    let spot = Spot(component: component)
+    let rowSpot = RowSpot(component: rowComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: rowSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    rowSpot.setup(CGSize(width: 100, height: 100))
+    rowSpot.layout(CGSize(width: 100, height: 100))
+    rowSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, rowSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, rowSpot.view.contentSize)
+  }
+
+  func testHybridGridSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.grid.string,
+      layout: Layout(span: 2.0),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 276))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 276))
+  }
+
+  func testHybridCarouselSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
+  }
+
+  func testHybridCarouselSpotWithHeaderAndFooterAndOverlayPageIndicator() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0, pageIndicatorPlacement: .overlay),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 188))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 188))
+  }
+
+  func testHybridCarouselSpotWithHeaderAndFooterAndBelowPageIndicator() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      layout: Layout(span: 2.0, pageIndicatorPlacement: .below),
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 200, height: 210))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 200, height: 210))
+  }
+}

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -1,0 +1,104 @@
+@testable import Spots
+import Brick
+import XCTest
+
+class TestSpot: XCTestCase {
+
+  override func setUp() {
+    Configuration.views.storage = [:]
+    Configuration.views.defaultItem = nil
+    Configuration.register(view: HeaderView.self, identifier: "Header")
+    Configuration.register(view: TextView.self,   identifier: "TextView")
+    Configuration.register(view: FooterView.self, identifier: "Footer")
+  }
+
+  func testDefaultValues() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(items: items, hybrid: true)
+    let spot = Spot(component: component)
+
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertTrue(spot.userInterface is TableView)
+    XCTAssertEqual(spot.items[0].size,    CGSize(width: 100, height: 88))
+    XCTAssertEqual(spot.items[1].size,    CGSize(width: 100, height: 88))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 180))
+  }
+
+  func testCompareHybridListSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.list.string, items: items, hybrid: true)
+    let listComponent = Component(kind: Component.Kind.list.string, items: items)
+    let spot = Spot(component: component)
+    let listSpot = ListSpot(component: listComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: listSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    listSpot.setup(CGSize(width: 100, height: 100))
+    listSpot.layout(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, listSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, listSpot.view.contentSize)
+  }
+
+  func testCompareHybridGridSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.grid.string, items: items, hybrid: true)
+    let gridComponent = Component(kind: Component.Kind.grid.string, items: items)
+    let spot = Spot(component: component)
+    let gridSpot = GridSpot(component: gridComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: gridSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    gridSpot.setup(CGSize(width: 100, height: 100))
+    gridSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, gridSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, gridSpot.view.contentSize)
+  }
+
+  func testCompareHybridCarouselSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.carousel.string, items: items, hybrid: true)
+    let carouselComponent = Component(kind: Component.Kind.carousel.string, items: items)
+    let spot = Spot(component: component)
+    let carouselSpot = CarouselSpot(component: carouselComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: carouselSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.setup(CGSize(width: 100, height: 100))
+    carouselSpot.layout(CGSize(width: 100, height: 100))
+    carouselSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, carouselSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, carouselSpot.view.contentSize)
+  }
+
+  func testCompareHybridRowSpotWithCoreType() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(kind: Component.Kind.row.string, items: items, hybrid: true)
+    let rowComponent = Component(kind: Component.Kind.row.string, items: items)
+    let spot = Spot(component: component)
+    let rowSpot = RowSpot(component: rowComponent)
+
+    XCTAssertTrue(type(of: spot.view) == type(of: rowSpot.view))
+
+    spot.setup(CGSize(width: 100, height: 100))
+    rowSpot.setup(CGSize(width: 100, height: 100))
+    rowSpot.view.layoutSubviews()
+
+    XCTAssertEqual(spot.items[0].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.items[1].size, rowSpot.items[0].size)
+    XCTAssertEqual(spot.view.frame, rowSpot.view.frame)
+    XCTAssertEqual(spot.view.contentSize, rowSpot.view.contentSize)
+  }
+}


### PR DESCRIPTION
This PR introduces a new `Spot` class that contains the logic for all core types. This is intended to reduce and eventually get rid of the core types that we have in Spots.

With configuration, we can now instead make `Spot` conform to our needs instead of having to pick a foundation to build upon. It's implementation uses `Configuration.views` so that you are free to pick what ever view type that you want instead of having to build views twice if they were to be presented as a list, grid or a carousel.

The iOS implementation of `Spot` has pretty decent test coverage now but it would probably be a good idea to compare more things than just the `contentSize`. I'd love some feed back on this.

I also created specific tests to see that a hybrid `Spot` that is configured as a `GridSpot` ends up getting the same configuration for items, frame and content size.

Oh yeah, and sorry for the size of the PR 😢 

### TODO
- [ ] Fix tests on macOS
- [ ] Test implementtion on both macOS and iOS