### PR TITLE
Fix spot configure closures on iOS

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -280,7 +280,8 @@ public extension Spotable {
     case let view as SpotConfigurable:
       view.configure(&item)
       setFallbackViewSize(to: &item, with: view)
-    default: break
+    default:
+      break
     }
   }
 

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -50,7 +50,8 @@ open class CarouselSpot: NSObject, Gridable {
           if let wrappedView = cell.wrappedView as? SpotConfigurable {
             configure(wrappedView)
           }
-        default: break
+        default:
+          break
         }
       }
     }

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -38,9 +38,20 @@ open class CarouselSpot: NSObject, Gridable {
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
     didSet {
-      guard let configure = configure else { return }
-      for case let cell as SpotConfigurable in collectionView.visibleCells {
-        configure(cell)
+      guard let configure = configure else {
+        return
+      }
+
+      collectionView.visibleCells.forEach { cell in
+        switch cell {
+        case let cell as SpotConfigurable:
+          configure(cell)
+        case let cell as Wrappable:
+          if let wrappedView = cell.wrappedView as? SpotConfigurable {
+            configure(wrappedView)
+          }
+        default: break
+        }
       }
     }
   }

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -41,7 +41,8 @@ open class GridSpot: NSObject, Gridable {
           if let wrappedView = cell.wrappedView as? SpotConfigurable {
             configure(wrappedView)
           }
-        default: break
+        default:
+          break
         }
       }
     }

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -29,9 +29,20 @@ open class GridSpot: NSObject, Gridable {
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
     didSet {
-      guard let configure = configure else { return }
-      for case let cell as SpotConfigurable in collectionView.visibleCells {
-        configure(cell)
+      guard let configure = configure else {
+        return
+      }
+
+      collectionView.visibleCells.forEach { cell in
+        switch cell {
+        case let cell as SpotConfigurable:
+          configure(cell)
+        case let cell as Wrappable:
+          if let wrappedView = cell.wrappedView as? SpotConfigurable {
+            configure(wrappedView)
+          }
+        default: break
+        }
       }
     }
   }

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -37,9 +37,20 @@ open class ListSpot: NSObject, Listable {
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
     didSet {
-      guard let configure = configure else { return }
-      for case let cell as SpotConfigurable in tableView.visibleCells {
-        configure(cell)
+      guard let configure = configure else {
+        return
+      }
+
+      tableView.visibleCells.forEach { cell in
+        switch cell {
+        case let cell as SpotConfigurable:
+          configure(cell)
+        case let cell as Wrappable:
+          if let wrappedView = cell.wrappedView as? SpotConfigurable {
+            configure(wrappedView)
+          }
+        default: break
+        }
       }
     }
   }

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -49,7 +49,8 @@ open class ListSpot: NSObject, Listable {
           if let wrappedView = cell.wrappedView as? SpotConfigurable {
             configure(wrappedView)
           }
-        default: break
+        default:
+          break
         }
       }
     }

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -29,9 +29,20 @@ open class RowSpot: NSObject, Gridable {
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
     didSet {
-      guard let configure = configure else { return }
-      for case let cell as SpotConfigurable in collectionView.visibleCells {
-        configure(cell)
+      guard let configure = configure else {
+        return
+      }
+
+      collectionView.visibleCells.forEach { cell in
+        switch cell {
+        case let cell as SpotConfigurable:
+          configure(cell)
+        case let cell as Wrappable:
+          if let wrappedView = cell.wrappedView as? SpotConfigurable {
+            configure(wrappedView)
+          }
+        default: break
+        }
       }
     }
   }

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -41,7 +41,8 @@ open class RowSpot: NSObject, Gridable {
           if let wrappedView = cell.wrappedView as? SpotConfigurable {
             configure(wrappedView)
           }
-        default: break
+        default:
+          break
         }
       }
     }

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -65,7 +65,8 @@ extension DataSource: UICollectionViewDataSource {
       }
     case let view as Componentable:
       view.configure(spot.component)
-    default: break
+    default:
+      break
     }
 
     return view
@@ -115,7 +116,8 @@ extension DataSource: UICollectionViewDataSource {
       }
 
       spot.configure?(cell)
-    default: break
+    default:
+      break
     }
 
     return cell
@@ -183,7 +185,8 @@ extension DataSource: UITableViewDataSource {
       }
 
       spot.configure?(cell)
-    default: break
+    default:
+      break
     }
 
     return cell

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -116,7 +116,8 @@ extension Delegate: UITableViewDelegate {
         }
       case let view as Componentable:
         view.configure(spot.component)
-      default: break
+      default:
+        break
       }
 
       return view?.frame.size.height ?? 0.0
@@ -145,7 +146,8 @@ extension Delegate: UITableViewDelegate {
         }
       case let view as Componentable:
         view.configure(spot.component)
-      default: break
+      default:
+        break
       }
 
       return view?.frame.size.height ?? 0.0
@@ -239,7 +241,8 @@ extension Delegate: UITableViewDelegate {
       }
       case let view as Componentable:
       view.configure(spot.component)
-      default: break
+      default:
+        break
     }
 
     return view
@@ -266,7 +269,8 @@ extension Delegate: UITableViewDelegate {
       }
     case let view as Componentable:
       view.configure(spot.component)
-    default: break
+    default:
+      break
     }
 
     return view

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -58,7 +58,8 @@ extension DataSource: NSCollectionViewDataSource {
       item.configure(&spot.component.items[indexPath.item], compositeSpots: spots)
     case let item as SpotConfigurable:
       item.configure(&spot.component.items[indexPath.item])
-    default: break
+    default:
+      break
     }
 
     return item

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -144,7 +144,8 @@ extension Delegate: NSTableViewDelegate {
       (customView as? SpotConfigurable)?.configure(&spot.component.items[row])
     case let view as SpotConfigurable:
       view.configure(&spot.component.items[row])
-    default: break
+    default:
+      break
     }
 
     (resolvedView as? NSTableRowView)?.identifier = reuseIdentifier

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -397,4 +397,20 @@ class CarouselSpotTests: XCTestCase {
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
+
+  func testSpotConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let spot = CarouselSpot(component: Component(span: 0.0, items: items))
+    spot.setup(CGSize(width: 100, height: 100))
+    spot.layout(CGSize(width: 100, height: 100))
+    spot.view.layoutSubviews()
+
+    var invokeCount = 0
+    spot.configure = { view in
+      invokeCount += 1
+    }
+    XCTAssertEqual(invokeCount, 2)
+  }
 }

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -136,4 +136,20 @@ class GridSpotTests: XCTestCase {
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
+
+  func testSpotConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let spot = GridSpot(component: Component(span: 0.0, items: items))
+    spot.setup(CGSize(width: 100, height: 100))
+    spot.layout(CGSize(width: 100, height: 100))
+    spot.view.layoutSubviews()
+
+    var invokeCount = 0
+    spot.configure = { view in
+      invokeCount += 1
+    }
+    XCTAssertEqual(invokeCount, 2)
+  }
 }

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -66,4 +66,20 @@ class ListSpotTests: XCTestCase {
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
+
+  func testSpotConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let spot = ListSpot(component: Component(span: 0.0, items: items))
+    spot.setup(CGSize(width: 100, height: 100))
+    spot.layout(CGSize(width: 100, height: 100))
+    spot.view.layoutSubviews()
+
+    var invokeCount = 0
+    spot.configure = { view in
+      invokeCount += 1
+    }
+    XCTAssertEqual(invokeCount, 2)
+  }
 }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -136,4 +136,20 @@ class RowSpotTests: XCTestCase {
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
+
+  func testSpotConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let spot = RowSpot(component: Component(span: 0.0, items: items))
+    spot.setup(CGSize(width: 100, height: 100))
+    spot.layout(CGSize(width: 100, height: 100))
+    spot.view.layoutSubviews()
+
+    var invokeCount = 0
+    spot.configure = { view in
+      invokeCount += 1
+    }
+    XCTAssertEqual(invokeCount, 2)
+  }
 }


### PR DESCRIPTION
This PR refactors the `didSet` closure on `Spotable` objects on iOS.

I added tests for all core types to check that the method is invoked the right amount of times.

It aims to fix this issue: https://github.com/hyperoslo/Spots/issues/463