### PR TITLE
Add skeleton for Spot class

### DIFF
--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -1,0 +1,151 @@
+import UIKit
+import Tailor
+
+public class Spot: NSObject, Spotable {
+
+  public static var layout: Layout = Layout(span: 1.0)
+  public static var headers: Registry = Registry()
+  public static var views: Registry = Registry()
+  public static var defaultKind: String = Component.Kind.list.string
+
+  open static var configure: ((_ view: View) -> Void)?
+
+  weak public var focusDelegate: SpotsFocusDelegate?
+  weak public var delegate: SpotsDelegate?
+
+  public var component: Component
+  public var componentKind: Component.Kind = .list
+  public var compositeSpots: [CompositeSpot] = []
+  public var configure: ((SpotConfigurable) -> Void)?
+  public var spotDelegate: Delegate?
+  public var spotDataSource: DataSource?
+  public var stateCache: StateCache?
+  public var userInterface: UserInterface?
+
+  open lazy var pageControl = UIPageControl()
+  open lazy var backgroundView = UIView()
+
+  var collectionViewLayout: CollectionLayout?
+
+  public var view: ScrollView = ScrollView()
+
+  public var tableView: TableView? {
+    return userInterface as? TableView
+  }
+
+  public var collectionView: CollectionView? {
+    return userInterface as? CollectionView
+  }
+
+  public required init(component: Component) {
+    var component = component
+    if component.kind.isEmpty {
+      component.kind = Spot.defaultKind
+    }
+
+    self.component = component
+
+    if let componentKind = Component.Kind(rawValue: component.kind) {
+      self.componentKind = componentKind
+    }
+
+    if component.layout == nil {
+      switch componentKind {
+      case .carousel:
+        self.component.layout = CarouselSpot.layout
+      case .grid:
+        self.component.layout = GridSpot.layout
+      case .list:
+        self.component.layout = ListSpot.layout
+      case .row:
+        self.component.layout = RowSpot.layout
+      }
+    }
+
+    super.init()
+
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
+
+    if let componentLayout = component.layout {
+      configure(with: componentLayout)
+    }
+
+    prepareItems()
+  }
+
+  deinit {
+    spotDataSource = nil
+    spotDelegate = nil
+    userInterface = nil
+  }
+
+  public func configure(with layout: Layout) {
+
+  }
+
+  func configureDataSourceAndDelegate() {
+    if let tableView = self.tableView {
+      tableView.dataSource = spotDataSource
+      tableView.delegate = spotDelegate
+    } else if let collectionView = self.collectionView {
+      collectionView.dataSource = spotDataSource
+      collectionView.delegate = spotDelegate
+    }
+  }
+
+  public func setup(_ size: CGSize) {
+    type(of: self).configure?(view)
+
+    if let tableView = self.tableView {
+      setupTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      setupCollectionView(collectionView, with: size)
+    }
+
+    layout(size)
+  }
+
+  public func layout(_ size: CGSize) {
+    if let tableView = self.tableView {
+      layoutTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      layoutCollectionView(collectionView, with: size)
+    }
+  }
+
+  fileprivate func setupTableView(_ tableView: TableView, with size: CGSize) {
+
+  }
+
+  fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func setupVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+  }
+
+  fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutTableView(_ tableView: TableView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  public func register() {
+
+  }
+}

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -84,7 +84,7 @@ public class Spot: NSObject, Spotable {
 
   }
 
-  func configureDataSourceAndDelegate() {
+  fileprivate func configureDataSourceAndDelegate() {
     if let tableView = self.tableView {
       tableView.dataSource = spotDataSource
       tableView.delegate = spotDelegate

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -1,0 +1,195 @@
+import Cocoa
+import Tailor
+
+public class Spot: NSObject, Spotable {
+
+  public static var layout: Layout = Layout(span: 1.0)
+  public static var headers: Registry = Registry()
+  public static var views: Registry = Registry()
+  public static var defaultKind: String = Component.Kind.list.string
+
+  open static var configure: ((_ view: View) -> Void)?
+
+  weak public var focusDelegate: SpotsFocusDelegate?
+  weak public var delegate: SpotsDelegate?
+
+  public var component: Component
+  public var componentKind: Component.Kind = .list
+  public var compositeSpots: [CompositeSpot] = []
+  public var configure: ((SpotConfigurable) -> Void)?
+  public var spotDelegate: Delegate?
+  public var spotDataSource: DataSource?
+  public var stateCache: StateCache?
+  public var userInterface: UserInterface?
+  open var gradientLayer: CAGradientLayer?
+
+  public var responder: NSResponder {
+    switch self.userInterface {
+    case let tableView as TableView:
+      return tableView
+    case let collectionView as CollectionView:
+      return collectionView
+    default:
+      return scrollView
+    }
+  }
+
+  public var nextResponder: NSResponder? {
+    get {
+      switch self.userInterface {
+      case let tableView as TableView:
+        return tableView.nextResponder
+      case let collectionView as CollectionView:
+        return collectionView.nextResponder
+      default:
+        return scrollView.nextResponder
+      }
+    }
+    set {
+      switch self.userInterface {
+      case let tableView as TableView:
+        tableView.nextResponder = newValue
+      case let collectionView as CollectionView:
+        collectionView.nextResponder = newValue
+      default:
+        scrollView.nextResponder = newValue
+      }
+    }
+  }
+
+  public func deselect() {
+    switch self.userInterface {
+    case let tableView as TableView:
+      tableView.deselectAll(nil)
+    case let collectionView as CollectionView:
+      collectionView.deselectAll(nil)
+    default: break
+    }
+  }
+
+  open lazy var scrollView: ScrollView = {
+    let scrollView = ScrollView()
+    scrollView.documentView = NSView()
+    return scrollView
+  }()
+
+  public var view: ScrollView {
+    return scrollView
+  }
+
+  public var tableView: TableView? {
+    return userInterface as? TableView
+  }
+
+  public var collectionView: CollectionView? {
+    return userInterface as? CollectionView
+  }
+
+  public required init(component: Component) {
+    var component = component
+    if component.kind.isEmpty {
+      component.kind = Spot.defaultKind
+    }
+
+    self.component = component
+
+    if let componentKind = Component.Kind(rawValue: component.kind) {
+      self.componentKind = componentKind
+    }
+
+    if component.layout == nil {
+      switch componentKind {
+      case .carousel:
+        self.component.layout = CarouselSpot.layout
+      case .grid:
+        self.component.layout = GridSpot.layout
+      case .list:
+        self.component.layout = ListSpot.layout
+      case .row:
+        self.component.layout = RowSpot.layout
+      }
+    }
+
+    super.init()
+
+    self.spotDataSource = DataSource(spot: self)
+    self.spotDelegate = Delegate(spot: self)
+
+    if let componentLayout = component.layout {
+      configure(with: componentLayout)
+    }
+  }
+
+  deinit {
+    spotDataSource = nil
+    spotDelegate = nil
+    userInterface = nil
+  }
+
+  public func configure(with layout: Layout) {
+
+  }
+
+  fileprivate func configureDataSourceAndDelegate() {
+    if let tableView = self.tableView {
+      tableView.dataSource = spotDataSource
+      tableView.delegate = spotDelegate
+    } else if let collectionView = self.collectionView {
+      collectionView.dataSource = spotDataSource
+      collectionView.delegate = spotDelegate
+    }
+  }
+
+  public func setup(_ size: CGSize) {
+
+  }
+
+  public func layout(_ size: CGSize) {
+
+  }
+
+  fileprivate func setupTableView(_ tableView: TableView, with size: CGSize) {
+
+  }
+
+  fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    switch componentKind {
+    case .carousel:
+      setupHorizontalCollectionView(collectionView, with: size)
+    default:
+      setupVerticalCollectionView(collectionView, with: size)
+    }
+  }
+
+  fileprivate func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func setupVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutTableView(_ tableView: TableView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+    if componentKind == .carousel {
+      layoutHorizontalCollectionView(collectionView, with: size)
+    } else {
+      layoutVerticalCollectionView(collectionView, with: size)
+    }
+  }
+
+  fileprivate func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  fileprivate func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
+
+  }
+
+  public func register() {
+
+  }
+}

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD24030C1E4B981A005BAA19 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Spot.swift */; };
 		BD24030D1E4B981A005BAA19 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Spot.swift */; };
+		BD2403111E4B9A02005BAA19 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2403101E4B9A02005BAA19 /* Spot.swift */; };
 		BD352E5F1CBAD6EC002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E5E1CBAD6EC002CD032 /* Brick.framework */; };
 		BD352E611CBAD6F9002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E601CBAD6F9002CD032 /* Brick.framework */; };
 		BD42954F1D81CE4F00E07E1C /* TestGridSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42954E1D81CE4F00E07E1C /* TestGridSpot.swift */; };
@@ -382,6 +383,7 @@
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
+		BD2403101E4B9A02005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD352E5E1CBAD6EC002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/iOS/Brick.framework; sourceTree = "<group>"; };
 		BD352E601CBAD6F9002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/Mac/Brick.framework; sourceTree = "<group>"; };
 		BD42954E1D81CE4F00E07E1C /* TestGridSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridSpot.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 				BDAD84F41E3E7025008289AE /* NoScrollView.swift */,
 				BDAD84F51E3E7025008289AE /* RowSpot.swift */,
 				BDAD84F61E3E7025008289AE /* RowSpotItem.swift */,
+				BD2403101E4B9A02005BAA19 /* Spot.swift */,
 				BDAD84F71E3E7025008289AE /* SpotsContentView.swift */,
 				BDAD84F81E3E7025008289AE /* SpotsScrollView.swift */,
 			);
@@ -1777,6 +1780,7 @@
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85131E3E7025008289AE /* ListSpot.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
+				BD2403111E4B9A02005BAA19 /* Spot.swift in Sources */,
 				BDAD85191E3E7025008289AE /* RowSpotItem.swift in Sources */,
 				BDAD85EE1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
+		BD24030C1E4B981A005BAA19 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Spot.swift */; };
+		BD24030D1E4B981A005BAA19 /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Spot.swift */; };
 		BD352E5F1CBAD6EC002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E5E1CBAD6EC002CD032 /* Brick.framework */; };
 		BD352E611CBAD6F9002CD032 /* Brick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD352E601CBAD6F9002CD032 /* Brick.framework */; };
 		BD42954F1D81CE4F00E07E1C /* TestGridSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42954E1D81CE4F00E07E1C /* TestGridSpot.swift */; };
@@ -379,6 +381,7 @@
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
+		BD24030B1E4B981A005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD352E5E1CBAD6EC002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/iOS/Brick.framework; sourceTree = "<group>"; };
 		BD352E601CBAD6F9002CD032 /* Brick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Brick.framework; path = Carthage/Build/Mac/Brick.framework; sourceTree = "<group>"; };
 		BD42954E1D81CE4F00E07E1C /* TestGridSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridSpot.swift; sourceTree = "<group>"; };
@@ -661,6 +664,7 @@
 				BDAD848F1E3E701C008289AE /* ListWrapper.swift */,
 				BDAD84901E3E701C008289AE /* RowSpot.swift */,
 				BDAD84911E3E701C008289AE /* RowSpotCell.swift */,
+				BD24030B1E4B981A005BAA19 /* Spot.swift */,
 				BDAD84921E3E701C008289AE /* SpotsContentView.swift */,
 				BDAD84931E3E701C008289AE /* SpotsScrollView.swift */,
 			);
@@ -1512,6 +1516,7 @@
 				BDAD84A71E3E701C008289AE /* CarouselSpotCell.swift in Sources */,
 				BDAD85BC1E3E7032008289AE /* Spotable.swift in Sources */,
 				BDAD85E31E3E7032008289AE /* Interaction.swift in Sources */,
+				BD24030D1E4B981A005BAA19 /* Spot.swift in Sources */,
 				BDAD84A51E3E701C008289AE /* CarouselSpot.swift in Sources */,
 				BDAD84AD1E3E701C008289AE /* GridableLayout.swift in Sources */,
 				BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */,
@@ -1621,6 +1626,7 @@
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD84C21E3E701C008289AE /* RowSpot.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
+				BD24030C1E4B981A005BAA19 /* Spot.swift in Sources */,
 				BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,
 				BDAD85841E3E7032008289AE /* Listable+Extension.swift in Sources */,
 				BDAD856C1E3E7032008289AE /* ViewSpot.swift in Sources */,


### PR DESCRIPTION
This PR adds a new class called `Spot`. In the future, it is meant to replace the core types, so instead of deciding on a foundation, layout and interaction configuration will construct a "hybrid" spot for you.

It only adds the files to show how the class is structured.