### PR TITLE
Register default and composite spot in init

### DIFF
--- a/Sources/macOS/Classes/RowSpot.swift
+++ b/Sources/macOS/Classes/RowSpot.swift
@@ -166,6 +166,8 @@ open class RowSpot: NSObject, Gridable {
       self.component.kind = Component.Kind.grid.string
     }
 
+    registerDefault(view: RowSpotItem.self)
+    registerComposite(view: GridComposite.self)
     registerAndPrepare()
     setupCollectionView()
     scrollView.addSubview(titleView)


### PR DESCRIPTION
Minor bug fix, I noticed that default and composite views were not properly registered on `RowSpot`.