### PR TITLE
Remove Gridable as a dependency in GridableLayout

### DIFF
--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -26,7 +26,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// Subclasses should always call super if they override.
   open override func prepare() {
     guard let delegate = collectionView?.delegate as? Delegate,
-      let spot = delegate.spot as? Gridable
+      let spot = delegate.spot
       else {
         return
     }
@@ -96,7 +96,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
         #endif
       }
     case .vertical:
-      contentSize.width = spot.collectionView.frame.width - spot.collectionView.contentInset.left - spot.collectionView.contentInset.right
+      contentSize.width = spot.view.frame.width - sectionInset.left - sectionInset.right
       contentSize.height = super.collectionViewContentSize.height
     }
   }

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -96,7 +96,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
         #endif
       }
     case .vertical:
-      contentSize.width = spot.view.frame.width - sectionInset.left - sectionInset.right
+      contentSize.width = spot.view.frame.width - spot.view.contentInset.left - spot.view.contentInset.right
       contentSize.height = super.collectionViewContentSize.height
     }
   }


### PR DESCRIPTION
Minor change, instead of resolving the `spot` as `Gridable`. It will now use `view` to get the frame. It will also use `sectionInset` when setting the width for vertical layouts.

Ref this PR that applies `sectionInset` instead of `contentInset` #464