### PR TITLE
Reduce code duplication by introducing configureClosureDidChange()

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -62,6 +62,27 @@ public extension Spotable {
     return height
   }
 
+  #if !os(OSX)
+  public func configureClosureDidChange() {
+    guard let configure = configure else {
+      return
+    }
+
+    userInterface?.visibleViews.forEach { view in
+      switch view {
+      case let view as SpotConfigurable:
+        configure(view)
+      case let view as Wrappable:
+        if let wrappedView = view.wrappedView as? SpotConfigurable {
+          configure(wrappedView)
+        }
+      default:
+        break
+      }
+    }
+  }
+  #endif
+
   /// A helper method to return self as a Spotable type.
   ///
   /// - returns: Self as a Spotable type

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -4,6 +4,8 @@ import Brick
 public protocol UserInterface: class {
 
   #if !os(OSX)
+  var visibleViews: [View] { get }
+
   /// The index of the current selected item
   @available(iOS 9.0, *)
   var selectedIndex: Int { get }

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -32,12 +32,16 @@ open class CarouselSpot: NSObject, Gridable {
 
   /// A component struct used as configuration and data source for the CarouselSpot
   open var component: Component {
-    didSet { configurePageControl() }
+    didSet {
+      configurePageControl()
+    }
   }
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet { configureClosureDidChange() }
+    didSet {
+      configureClosureDidChange()
+    }
   }
 
   /// A CarouselScrollDelegate, used when a CarouselSpot scrolls

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -37,24 +37,7 @@ open class CarouselSpot: NSObject, Gridable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet {
-      guard let configure = configure else {
-        return
-      }
-
-      collectionView.visibleCells.forEach { cell in
-        switch cell {
-        case let cell as SpotConfigurable:
-          configure(cell)
-        case let cell as Wrappable:
-          if let wrappedView = cell.wrappedView as? SpotConfigurable {
-            configure(wrappedView)
-          }
-        default:
-          break
-        }
-      }
-    }
+    didSet { configureClosureDidChange() }
   }
 
   /// A CarouselScrollDelegate, used when a CarouselSpot scrolls

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -28,24 +28,7 @@ open class GridSpot: NSObject, Gridable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet {
-      guard let configure = configure else {
-        return
-      }
-
-      collectionView.visibleCells.forEach { cell in
-        switch cell {
-        case let cell as SpotConfigurable:
-          configure(cell)
-        case let cell as Wrappable:
-          if let wrappedView = cell.wrappedView as? SpotConfigurable {
-            configure(wrappedView)
-          }
-        default:
-          break
-        }
-      }
-    }
+    didSet { configureClosureDidChange() }
   }
 
   /// A SpotsDelegate that is used for the GridSpot

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -28,7 +28,9 @@ open class GridSpot: NSObject, Gridable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet { configureClosureDidChange() }
+    didSet {
+      configureClosureDidChange()
+    }
   }
 
   /// A SpotsDelegate that is used for the GridSpot

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -36,7 +36,9 @@ open class ListSpot: NSObject, Listable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet { configureClosureDidChange() }
+    didSet {
+      configureClosureDidChange()
+    }
   }
 
   /// A SpotsDelegate that is used for the ListSpot

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -36,24 +36,7 @@ open class ListSpot: NSObject, Listable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet {
-      guard let configure = configure else {
-        return
-      }
-
-      tableView.visibleCells.forEach { cell in
-        switch cell {
-        case let cell as SpotConfigurable:
-          configure(cell)
-        case let cell as Wrappable:
-          if let wrappedView = cell.wrappedView as? SpotConfigurable {
-            configure(wrappedView)
-          }
-        default:
-          break
-        }
-      }
-    }
+    didSet { configureClosureDidChange() }
   }
 
   /// A SpotsDelegate that is used for the ListSpot

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -28,24 +28,7 @@ open class RowSpot: NSObject, Gridable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet {
-      guard let configure = configure else {
-        return
-      }
-
-      collectionView.visibleCells.forEach { cell in
-        switch cell {
-        case let cell as SpotConfigurable:
-          configure(cell)
-        case let cell as Wrappable:
-          if let wrappedView = cell.wrappedView as? SpotConfigurable {
-            configure(wrappedView)
-          }
-        default:
-          break
-        }
-      }
-    }
+    didSet { configureClosureDidChange() }
   }
 
   /// A SpotsDelegate that is used for the RowSpot

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -28,7 +28,9 @@ open class RowSpot: NSObject, Gridable {
 
   /// A configuration closure
   open var configure: ((SpotConfigurable) -> Void)? {
-    didSet { configureClosureDidChange() }
+    didSet {
+      configureClosureDidChange()
+    }
   }
 
   /// A SpotsDelegate that is used for the RowSpot

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -18,7 +18,9 @@ public class Spot: NSObject, Spotable {
   public var compositeSpots: [CompositeSpot] = []
 
   public var configure: ((SpotConfigurable) -> Void)? {
-    didSet { configureClosureDidChange() }
+    didSet {
+      configureClosureDidChange()
+    }
   }
 
   public var spotDelegate: Delegate?

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -16,7 +16,11 @@ public class Spot: NSObject, Spotable {
   public var component: Component
   public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
-  public var configure: ((SpotConfigurable) -> Void)?
+
+  public var configure: ((SpotConfigurable) -> Void)? {
+    didSet { configureClosureDidChange() }
+  }
+
   public var spotDelegate: Delegate?
   public var spotDataSource: DataSource?
   public var stateCache: StateCache?

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -2,6 +2,10 @@ import UIKit
 
 extension UICollectionView: UserInterface {
 
+  public var visibleViews: [View] {
+    return visibleCells
+  }
+
   /// The index of the current selected item
   @available(iOS 9.0, *)
   public var selectedIndex: Int {

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -2,6 +2,10 @@ import UIKit
 
 extension UITableView: UserInterface {
 
+  public var visibleViews: [View] {
+    return visibleCells
+  }
+
   public var selectedIndex: Int {
     return indexPathForSelectedRow?.row ?? 0
   }


### PR DESCRIPTION
By adding `configureClosureDidChange` as an extension on `Spotable`,  we can now use the same method for all `Spotable` objects.

This suggestion was made by @JohnSundell in https://github.com/hyperoslo/Spots/pull/467#pullrequestreview-20870520

To make both `UITableView` and `UICollectionView` use the same implementation, I added the following on `UserInterface`.

```swift
var visibleViews: [View] { get }
```

And the extension on `Spotable` looks like this:

```swift
public func configureClosureDidChange() {
  guard let configure = configure else {
    return
  }

  userInterface?.visibleViews.forEach { view in
    switch view {
    case let view as SpotConfigurable:
      configure(view)
    case let view as Wrappable:
      if let wrappedView = view.wrappedView as? SpotConfigurable {
        configure(wrappedView)
      }
    default:
      break
    }
  }
}
```

The nifty thing here is that it never references anything platform specific.