### PR TITLE
Improve/horizontally scrolling views

### DIFF
--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -10,7 +10,7 @@ open class ViewSpot: NSObject, Spotable, Viewable {
     return scrollView
   }
 
-  public static var layout: Layout = Layout([:])
+  public static var layout: Layout = .init()
 
   /// Reload spot with ItemChanges.
   ///

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -222,7 +222,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
               footer: String = "",
               kind: String = "",
               layout: Layout? = nil,
-              interaction: Interaction = Interaction([:]),
+              interaction: Interaction = .init(),
               span: Double? = nil,
               items: [Item] = [],
               meta: [String : Any] = [:],

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -96,7 +96,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
   /// The header identifier
   public var header: String = ""
   /// User interaction properties
-  public var interaction: Interaction?
+  public var interaction: Interaction
   /// The footer identifier
   public var footer: String = ""
   /// Layout properties
@@ -151,10 +151,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
       JSONComponents[Key.layout] = layout.dictionary
     }
 
-    if let interaction = interaction {
-      JSONComponents[Key.interaction] = interaction.dictionary
-    }
-
+    JSONComponents[Key.interaction] = interaction.dictionary
     JSONComponents[Key.identifier.string] = identifier
 
     if !title.isEmpty { JSONComponents[Key.title.string] = title }
@@ -192,6 +189,8 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
 
       if let interactionDictionary: [String : Any] = map.property(Interaction.rootKey) {
         self.interaction = Interaction(interactionDictionary)
+      } else {
+        self.interaction = Interaction()
       }
     }
 
@@ -222,7 +221,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
               footer: String = "",
               kind: String = "",
               layout: Layout? = nil,
-              interaction: Interaction? = nil,
+              interaction: Interaction = Interaction([:]),
               span: Double? = nil,
               items: [Item] = [],
               meta: [String : Any] = [:],

--- a/Sources/Shared/Structs/Component.swift
+++ b/Sources/Shared/Structs/Component.swift
@@ -210,6 +210,7 @@ public struct Component: Mappable, Equatable, DictionaryConvertible {
   /// - parameter header: Determines which header item that should be used for the component.
   /// - parameter kind: The type of Component that should be used.
   /// - parameter layout: Configures the layout properties for the component.
+  /// - parameter interaction: Configures the interaction properties for the component.
   /// - parameter span: Configures the layout span for the component.
   /// - parameter items: A collection of view models
   /// - parameter meta: A key-value dictionary for any additional information

--- a/Sources/Shared/Structs/Inset.swift
+++ b/Sources/Shared/Structs/Inset.swift
@@ -48,7 +48,7 @@ public struct Inset: Mappable, Equatable {
   ///
   /// - Parameter block: A mutating closure.
   public init(_ block: (inout Inset) -> Void) {
-    self.init([:])
+    self.init()
     block(&self)
   }
 

--- a/Sources/Shared/Structs/Interaction.swift
+++ b/Sources/Shared/Structs/Interaction.swift
@@ -23,7 +23,7 @@ public struct Interaction: Mappable {
   /// Delcares what kind of interaction should be used for pagination. See `Paginate` struct for more information.
   var paginate: Paginate = .disabled
   /// Indicates which scrolling direction will be used, default to false.
-  var scrollsHorizontally: Bool = false
+  var scrollDirection: ScrollDirection = .vertical
 
   /// The root key used when parsing JSON into a Interaction struct.
   static let rootKey: String = String(describing: Interaction.self).lowercased()

--- a/Sources/Shared/Structs/Interaction.swift
+++ b/Sources/Shared/Structs/Interaction.swift
@@ -1,6 +1,14 @@
 import Foundation
 import Tailor
 
+/// Indicates if the UI has vertical or horizontal scrolling.
+///
+/// - horizontal: UI uses horizontal scrolling.
+/// - vertical: UI uses vertical scrolling.
+enum ScrollDirection: String {
+  case horizontal, vertical
+}
+
 /// A user interaction struct used for mapping behavior to a Spotable object.
 /// Note: `paginate` is currently only available on iOS.
 public struct Interaction: Mappable {

--- a/Sources/Shared/Structs/Interaction.swift
+++ b/Sources/Shared/Structs/Interaction.swift
@@ -14,6 +14,8 @@ public struct Interaction: Mappable {
 
   /// Delcares what kind of interaction should be used for pagination. See `Paginate` struct for more information.
   var paginate: Paginate = .disabled
+  /// Indicates which scrolling direction will be used, default to false.
+  var scrollsHorizontally: Bool = false
 
   /// The root key used when parsing JSON into a Interaction struct.
   static let rootKey: String = String(describing: Interaction.self).lowercased()

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -82,7 +82,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   ///   - itemSpacing: Sets minimum item spacing for the component.
   ///   - lineSpacing: Sets minimum lines spacing for items in component.
   ///   - inset: An inset struct used to insert margins for the component.
-  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = Inset()) {
+  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init()) {
     self.span = span
     self.dynamicSpan = dynamicSpan
     self.dynamicHeight = dynamicHeight

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -100,7 +100,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   }
 
   public init(_ block: (inout Layout) -> Void) {
-    self.init([:])
+    self.init()
     block(&self)
   }
 

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -81,7 +81,7 @@ open class CarouselSpot: NSObject, Gridable {
       self.component.layout = type(of: self).layout
     }
 
-    self.component.interaction.scrollsHorizontally = true
+    self.component.interaction.scrollDirection = .horizontal
 
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -81,9 +81,7 @@ open class CarouselSpot: NSObject, Gridable {
       self.component.layout = type(of: self).layout
     }
 
-    if self.component.interaction == nil {
-      self.component.interaction = type(of: self).interaction
-    }
+    self.component.interaction.scrollsHorizontally = true
 
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
@@ -234,97 +232,5 @@ open class CarouselSpot: NSObject, Gridable {
       pageControl.currentPageIndicatorTintColor = nil
       collectionView.addSubview(pageControl)
     }
-  }
-}
-
-/// A scroll view extension on CarouselSpot to handle scrolling specifically for this object.
-extension Delegate: UIScrollViewDelegate {
-
-  /// Tells the delegate when the user scrolls the content view within the receiver.
-  ///
-  /// - parameter scrollView: The scroll-view object in which the scrolling occurred.
-  public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    guard let spot = spot as? CarouselSpot else {
-      return
-    }
-
-    /// This will restrict the scroll view to only scroll horizontally.
-    let constrainedYOffset = spot.collectionView.contentSize.height - spot.collectionView.frame.size.height
-    if constrainedYOffset >= 0.0 {
-      spot.collectionView.contentOffset.y = constrainedYOffset
-    }
-
-    spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
-
-    if spot.component.layout?.pageIndicatorPlacement == .overlay {
-      spot.pageControl.frame.origin.x = scrollView.contentOffset.x
-    }
-  }
-
-  public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    guard let spot = spot as? CarouselSpot else {
-      return
-    }
-
-    let itemIndex = Int(scrollView.contentOffset.x / scrollView.frame.width)
-
-    guard itemIndex >= 0 else {
-      return
-    }
-
-    guard itemIndex < spot.items.count else {
-      return
-    }
-
-    spot.pageControl.currentPage = itemIndex
-  }
-
-  #if os(iOS)
-
-  public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-    guard let spot = spot as? CarouselSpot else {
-      return
-    }
-
-    spot.carouselScrollDelegate?.spotableCarouselDidEndScrollingAnimated(spot)
-  }
-
-  #endif
-
-  /// Tells the delegate when the user finishes scrolling the content.
-  ///
-  /// - parameter scrollView:          The scroll-view object where the user ended the touch.
-  /// - parameter velocity:            The velocity of the scroll view (in points) at the moment the touch was released.
-  /// - parameter targetContentOffset: The expected offset when the scrolling action decelerates to a stop.
-  public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    guard let spot = spot as? CarouselSpot else {
-      return
-    }
-
-    #if os(iOS)
-      guard spot.component.interaction?.paginate == .page else {
-        return
-      }
-    #endif
-
-    let pointXUpperBound = spot.layout.collectionViewContentSize.width - scrollView.frame.width / 2
-    var point = targetContentOffset.pointee
-    point.x += scrollView.frame.width / 2
-    var indexPath: IndexPath?
-
-    while indexPath == nil && point.x < pointXUpperBound {
-      indexPath = spot.collectionView.indexPathForItem(at: point)
-      point.x += max(spot.layout.minimumInteritemSpacing, 1)
-    }
-
-    guard let centerIndexPath = indexPath else {
-      return
-    }
-
-    guard let centerLayoutAttributes = spot.layout.layoutAttributesForItem(at: centerIndexPath) else {
-      return
-    }
-
-    targetContentOffset.pointee.x = centerLayoutAttributes.frame.midX - scrollView.frame.width / 2
   }
 }

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -5,8 +5,8 @@ import UIKit
 /// A CarouselSpot, a collection view based Spotable object that lays out its items in a horizontal order
 open class CarouselSpot: NSObject, Gridable {
 
-  public static var layout: Layout = Layout([:])
-  public static var interaction: Interaction = Interaction([:])
+  public static var layout: Layout = .init()
+  public static var interaction: Interaction = .init()
 
   /// Child spots
   public var compositeSpots: [CompositeSpot] = []

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -66,7 +66,7 @@ public class Spot: NSObject, Spotable {
       let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
 
       if componentKind == .carousel {
-        self.component.interaction.scrollsHorizontally = true
+        self.component.interaction.scrollDirection = .horizontal
         collectionViewLayout.scrollDirection = .horizontal
       }
 
@@ -163,9 +163,10 @@ public class Spot: NSObject, Spotable {
     collectionView.dataSource = spotDataSource
     collectionView.delegate = spotDelegate
 
-    if component.interaction.scrollsHorizontally {
+    switch component.interaction.scrollDirection {
+    case .horizontal:
       setupHorizontalCollectionView(collectionView, with: size)
-    } else {
+    case .vertical:
       setupVerticalCollectionView(collectionView, with: size)
     }
   }
@@ -251,9 +252,11 @@ public class Spot: NSObject, Spotable {
 
   fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     prepareItems()
-    if component.interaction.scrollsHorizontally {
+
+    switch component.interaction.scrollDirection {
+    case .horizontal:
       layoutHorizontalCollectionView(collectionView, with: size)
-    } else {
+    case .vertical:
       layoutVerticalCollectionView(collectionView, with: size)
     }
   }

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -163,7 +163,7 @@ public class Spot: NSObject, Spotable {
     collectionView.dataSource = spotDataSource
     collectionView.delegate = spotDelegate
 
-    if (collectionView.collectionViewLayout as? GridableLayout)?.scrollDirection == .horizontal {
+    if component.interaction.scrollsHorizontally {
       setupHorizontalCollectionView(collectionView, with: size)
     } else {
       setupVerticalCollectionView(collectionView, with: size)
@@ -251,7 +251,7 @@ public class Spot: NSObject, Spotable {
 
   fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     prepareItems()
-    if (collectionView.collectionViewLayout as? GridableLayout)?.scrollDirection == .horizontal {
+    if component.interaction.scrollsHorizontally {
       layoutHorizontalCollectionView(collectionView, with: size)
     } else {
       layoutVerticalCollectionView(collectionView, with: size)

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -66,6 +66,7 @@ public class Spot: NSObject, Spotable {
       let collectionView = CollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
 
       if componentKind == .carousel {
+        self.component.interaction.scrollsHorizontally = true
         collectionViewLayout.scrollDirection = .horizontal
       }
 

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -273,7 +273,6 @@ public class Spot: NSObject, Spotable {
 
     collectionViewLayout.prepare()
     collectionViewLayout.invalidateLayout()
-
     collectionView.frame.size.width = size.width
     collectionView.frame.size.height = collectionViewLayout.contentSize.height
   }

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -14,6 +14,7 @@ public class Spot: NSObject, Spotable {
 
   weak public var focusDelegate: SpotsFocusDelegate?
   weak public var delegate: SpotsDelegate?
+  weak public var carouselScrollDelegate: CarouselScrollDelegate?
 
   public var component: Component
   public var componentKind: Component.Kind = .list

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -177,7 +177,6 @@ public class Spot: NSObject, Spotable {
     }
 
     collectionView.isScrollEnabled = true
-    prepareItems()
     configurePageControl()
 
     if collectionView.contentSize.height > 0 {

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -172,6 +172,7 @@ extension DataSource: UITableViewDataSource {
             spot.component.items[indexPath.item].size = configurableView.preferredViewSize
           }
 
+          spot.configure?(configurableView)
         } else {
           spot.component.items[indexPath.item].size.height = customView.frame.size.height
         }

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -3,9 +3,6 @@ import UIKit
 /// A scroll view extension on CarouselSpot to handle scrolling specifically for this object.
 extension Delegate: UIScrollViewDelegate {
 
-  /// Tells the delegate when the user scrolls the content view within the receiver.
-  ///
-  /// - parameter scrollView: The scroll-view object in which the scrolling occurred.
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
     guard let spot = spot,
       let collectionView = spot.userInterface as? CollectionView,

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -57,8 +57,6 @@ extension Delegate: UIScrollViewDelegate {
     }
   }
 
-  #if os(iOS)
-
   public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
     guard let spot = spot as? CarouselSpot else {
       return
@@ -66,8 +64,6 @@ extension Delegate: UIScrollViewDelegate {
 
     spot.carouselScrollDelegate?.spotableCarouselDidEndScrollingAnimated(spot)
   }
-
-  #endif
 
   /// Tells the delegate when the user finishes scrolling the content.
   ///

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -9,7 +9,7 @@ extension Delegate: UIScrollViewDelegate {
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
     guard let spot = spot,
       let collectionView = spot.userInterface as? CollectionView,
-      spot.component.interaction.scrollsHorizontally else {
+      spot.component.interaction.scrollDirection == .horizontal else {
         return
     }
 
@@ -36,7 +36,7 @@ extension Delegate: UIScrollViewDelegate {
   }
 
   public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    guard let spot = spot, spot.component.interaction.scrollsHorizontally else {
+    guard let spot = spot, spot.component.interaction.scrollDirection == .horizontal else {
       return
     }
 
@@ -81,7 +81,7 @@ extension Delegate: UIScrollViewDelegate {
     guard let spot = spot,
       let collectionView = spot.userInterface as? CollectionView,
       let collectionViewLayout = collectionView.collectionViewLayout as? CollectionLayout,
-      spot.component.interaction.scrollsHorizontally else {
+      spot.component.interaction.scrollDirection == .horizontal else {
         return
     }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -63,11 +63,11 @@ extension Delegate: UIScrollViewDelegate {
   #if os(iOS)
 
   public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-  guard let spot = spot as? CarouselSpot else {
-  return
-  }
+    guard let spot = spot as? CarouselSpot else {
+      return
+    }
 
-  spot.carouselScrollDelegate?.spotableCarouselDidEndScrollingAnimated(spot)
+    spot.carouselScrollDelegate?.spotableCarouselDidEndScrollingAnimated(spot)
   }
 
   #endif

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -1,0 +1,114 @@
+import UIKit
+
+/// A scroll view extension on CarouselSpot to handle scrolling specifically for this object.
+extension Delegate: UIScrollViewDelegate {
+
+  /// Tells the delegate when the user scrolls the content view within the receiver.
+  ///
+  /// - parameter scrollView: The scroll-view object in which the scrolling occurred.
+  public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    guard let spot = spot,
+      let collectionView = spot.userInterface as? CollectionView,
+      spot.component.interaction.scrollsHorizontally else {
+        return
+    }
+
+    /// This will restrict the scroll view to only scroll horizontally.
+    let constrainedYOffset = collectionView.contentSize.height - collectionView.frame.size.height
+    if constrainedYOffset >= 0.0 {
+      collectionView.contentOffset.y = constrainedYOffset
+    }
+
+    switch spot {
+    case let spot as Spot:
+      spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
+      if spot.component.layout?.pageIndicatorPlacement == .overlay {
+        spot.pageControl.frame.origin.x = scrollView.contentOffset.x
+      }
+    case let spot as CarouselSpot:
+      spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
+      if spot.component.layout?.pageIndicatorPlacement == .overlay {
+        spot.pageControl.frame.origin.x = scrollView.contentOffset.x
+      }
+    default:
+      break
+    }
+  }
+
+  public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    guard let spot = spot, spot.component.interaction.scrollsHorizontally else {
+      return
+    }
+
+    let itemIndex = Int(scrollView.contentOffset.x / scrollView.frame.width)
+
+    guard itemIndex >= 0 else {
+      return
+    }
+
+    guard itemIndex < spot.items.count else {
+      return
+    }
+
+    switch spot {
+    case let spot as Spot:
+      spot.pageControl.currentPage = itemIndex
+    case let spot as CarouselSpot:
+      spot.pageControl.currentPage = itemIndex
+    default:
+      break
+    }
+  }
+
+  #if os(iOS)
+
+  public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+  guard let spot = spot as? CarouselSpot else {
+  return
+  }
+
+  spot.carouselScrollDelegate?.spotableCarouselDidEndScrollingAnimated(spot)
+  }
+
+  #endif
+
+  /// Tells the delegate when the user finishes scrolling the content.
+  ///
+  /// - parameter scrollView:          The scroll-view object where the user ended the touch.
+  /// - parameter velocity:            The velocity of the scroll view (in points) at the moment the touch was released.
+  /// - parameter targetContentOffset: The expected offset when the scrolling action decelerates to a stop.
+  public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    guard let spot = spot,
+      let collectionView = spot.userInterface as? CollectionView,
+      let collectionViewLayout = collectionView.collectionViewLayout as? CollectionLayout,
+      spot.component.interaction.scrollsHorizontally else {
+        return
+    }
+
+    #if os(iOS)
+      guard spot.component.interaction.paginate == .page else {
+        return
+      }
+    #endif
+
+    let pointXUpperBound = collectionViewLayout.collectionViewContentSize.width - scrollView.frame.width / 2
+    var point = targetContentOffset.pointee
+    point.x += scrollView.frame.width / 2
+    var indexPath: IndexPath?
+
+    while indexPath == nil && point.x < pointXUpperBound {
+      indexPath = collectionView.indexPathForItem(at: point)
+      point.x += max(collectionViewLayout.minimumInteritemSpacing, 1)
+    }
+
+    guard let centerIndexPath = indexPath else {
+      return
+    }
+
+    guard let centerLayoutAttributes = collectionViewLayout.layoutAttributesForItem(at: centerIndexPath) else {
+      return
+    }
+
+    targetContentOffset.pointee.x = centerLayoutAttributes.frame.midX - scrollView.frame.width / 2
+  }
+}

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		BDB8D5961E4DFBB200220BC3 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
 		BDB8D5971E4DFBBA00220BC3 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F71C44076B006EBA49 /* Tailor.framework */; };
 		BDB8D5981E4DFBC300220BC3 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD63FAB1D941A80008E885A /* Tailor.framework */; };
+		BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -539,6 +540,7 @@
 		BDB538321C444D460005E498 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDB8D5921E4DFADC00220BC3 /* TestItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestItem.swift; sourceTree = "<group>"; };
+		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
 		BDD63FAB1D941A80008E885A /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/tvOS/Tailor.framework; sourceTree = "<group>"; };
 		BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridComposite.swift; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 				BDAD849F1E3E701C008289AE /* UICollectionView+UserInterface.swift */,
 				BDAD84A01E3E701C008289AE /* UITableView+UserInterface.swift */,
 				BDAD84A11E3E701C008289AE /* UIViewController+Extensions.swift */,
+				BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1663,6 +1666,7 @@
 				BDAD84BE1E3E701C008289AE /* ListSpotCell.swift in Sources */,
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDAD84C21E3E701C008289AE /* RowSpot.swift in Sources */,
+				BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
 				BD24030C1E4B981A005BAA19 /* Spot.swift in Sources */,
 				BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -409,7 +409,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 0)
 
     var composite: Composable?
-    var ItemConfigurable: ItemConfigurable?
+    var itemConfigurable: ItemConfigurable?
 
     let newComponents: [Component] = [
       Component(kind: Component.Kind.grid.rawValue,
@@ -501,45 +501,45 @@ class CompositionTests: XCTestCase {
       let spots = controller.spots
 
       composite = spots[0].ui(at: 0)
-      ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 

--- a/SpotsTests/Shared/TestInset.swift
+++ b/SpotsTests/Shared/TestInset.swift
@@ -20,7 +20,7 @@ class TestInset: XCTestCase {
   }
 
   func testJSONMapping() {
-    var contentInset = Inset([:])
+    var contentInset = Inset()
     contentInset.configure(withJSON: json)
 
     XCTAssertEqual(contentInset, Inset(top: 1, left: 2, bottom: 3, right: 4))

--- a/SpotsTests/Shared/TestLayout.swift
+++ b/SpotsTests/Shared/TestLayout.swift
@@ -77,7 +77,7 @@ class LayoutTests: XCTestCase {
   }
 
   func testConfigureWithJSON() {
-    var layout = Layout([:])
+    var layout = Layout()
 
     XCTAssertNotEqual(layout.span, 4.0)
     XCTAssertNotEqual(layout.itemSpacing, 8.0)

--- a/SpotsTests/iOS/TestInteraction.swift
+++ b/SpotsTests/iOS/TestInteraction.swift
@@ -49,7 +49,7 @@ class InteractionTests: XCTestCase {
     interaction = Interaction(json)
     XCTAssertEqual(interaction.paginate, .disabled)
 
-    interaction = Interaction([:])
+    interaction = Interaction()
     XCTAssertEqual(interaction.paginate, .disabled)
   }
 

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -49,6 +49,7 @@ class TestSpot: XCTestCase {
     listSpot.layout(CGSize(width: 100, height: 100))
     listSpot.view.layoutSubviews()
 
+    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, listSpot.component.interaction.scrollsHorizontally)
     XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), listSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -71,6 +72,7 @@ class TestSpot: XCTestCase {
     gridSpot.layout(CGSize(width: 100, height: 100))
     gridSpot.view.layoutSubviews()
 
+    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, gridSpot.component.interaction.scrollsHorizontally)
     XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), gridSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -93,6 +95,7 @@ class TestSpot: XCTestCase {
     carouselSpot.layout(CGSize(width: 100, height: 100))
     carouselSpot.view.layoutSubviews()
 
+    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, carouselSpot.component.interaction.scrollsHorizontally)
     XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), carouselSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -49,7 +49,7 @@ class TestSpot: XCTestCase {
     listSpot.layout(CGSize(width: 100, height: 100))
     listSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, listSpot.component.interaction.scrollsHorizontally)
+    XCTAssertEqual(spot.component.interaction.scrollDirection, listSpot.component.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), listSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -72,7 +72,7 @@ class TestSpot: XCTestCase {
     gridSpot.layout(CGSize(width: 100, height: 100))
     gridSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, gridSpot.component.interaction.scrollsHorizontally)
+    XCTAssertEqual(spot.component.interaction.scrollDirection, gridSpot.component.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), gridSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -95,7 +95,7 @@ class TestSpot: XCTestCase {
     carouselSpot.layout(CGSize(width: 100, height: 100))
     carouselSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollsHorizontally, carouselSpot.component.interaction.scrollsHorizontally)
+    XCTAssertEqual(spot.component.interaction.scrollDirection, carouselSpot.component.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), carouselSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))


### PR DESCRIPTION
This PR introduces a new boolean property on `Interaction` called `scrollsHorizontally`. This makes it a lot easier to check if the layout is horizontal and vertical. It also helps us life the constraint of checking if the `Spotable` object is a `CarouselSpot` to know if it is horizontal. Either that or check the actual layout.

I also took the opportunity to move the scroll extensions out of `CarouselSpot` and into its own file.
Those methods have been refactored to not have the `CarouselSpot` constraints.

It also adds a missing closure call in `tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)`.