### PR TITLE
Implement cache for Spot and reduce code duplication in Spot

### DIFF
--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -104,6 +104,13 @@ public class Spot: NSObject, Spotable {
     self.spotDelegate = Delegate(spot: self)
   }
 
+  public convenience init(cacheKey: String) {
+    let stateCache = StateCache(key: cacheKey)
+
+    self.init(component: Component(stateCache.load()))
+    self.stateCache = stateCache
+  }
+
   deinit {
     spotDataSource = nil
     spotDelegate = nil

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -202,12 +202,7 @@ public class Spot: NSObject, Spotable {
       }
     }
 
-    if !component.header.isEmpty,
-      let resolve = Configuration.views.make(component.header),
-      let view = resolve.view {
-      layout.headerReferenceSize.width = collectionView.frame.size.width
-      layout.headerReferenceSize.height = view.frame.size.height
-    }
+    configureCollectionViewHeader(collectionView, with: size)
 
     CarouselSpot.configure?(collectionView, layout)
 
@@ -234,7 +229,17 @@ public class Spot: NSObject, Spotable {
       return
     }
 
+    configureCollectionViewHeader(collectionView, with: size)
+
     GridSpot.configure?(collectionView, collectionViewLayout)
+
+
+  }
+
+  fileprivate func configureCollectionViewHeader(_ collectionView: CollectionView, with size: CGSize) {
+    guard let collectionViewLayout = collectionView.collectionViewLayout as? GridableLayout else {
+      return
+    }
 
     guard !component.header.isEmpty else {
       return

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -232,8 +232,6 @@ public class Spot: NSObject, Spotable {
     configureCollectionViewHeader(collectionView, with: size)
 
     GridSpot.configure?(collectionView, collectionViewLayout)
-
-
   }
 
   fileprivate func configureCollectionViewHeader(_ collectionView: CollectionView, with size: CGSize) {

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -53,9 +53,14 @@ extension Controller {
 
 struct Helper {
   static func clearCache(for stateCache: StateCache?) {
-    if FileManager().fileExists(atPath: stateCache!.path) {
+    guard let stateCache = stateCache else {
+      XCTFail()
+      return
+    }
+
+    if FileManager().fileExists(atPath: stateCache.path) {
       do {
-        try? FileManager().removeItem(atPath: stateCache!.path)
+        try? FileManager().removeItem(atPath: stateCache.path)
       }
     }
   }

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,4 +1,5 @@
 @testable import Spots
+import XCTest
 #if os(OSX)
 import Foundation
 #else

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -1,5 +1,4 @@
 @testable import Spots
-import XCTest
 #if os(OSX)
 import Foundation
 #else

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -54,7 +54,9 @@ extension Controller {
 struct Helper {
   static func clearCache(for stateCache: StateCache?) {
     if FileManager().fileExists(atPath: stateCache!.path) {
-      try! FileManager().removeItem(atPath: stateCache!.path)
+      do {
+        try? FileManager().removeItem(atPath: stateCache!.path)
+      }
     }
   }
 }

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -52,21 +52,6 @@ extension Controller {
   }
 }
 
-struct Helper {
-  static func clearCache(for stateCache: StateCache?) {
-    guard let stateCache = stateCache else {
-      XCTFail()
-      return
-    }
-
-    if FileManager().fileExists(atPath: stateCache.path) {
-      do {
-        try? FileManager().removeItem(atPath: stateCache.path)
-      }
-    }
-  }
-}
-
 #if !os(OSX)
   class HeaderView: UIView, ItemConfigurable, Componentable {
 

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -10,7 +10,7 @@ class CarouselSpotTests: XCTestCase {
   override func setUp() {
     spot = CarouselSpot(component: Component(span: 1.0))
     cachedSpot = CarouselSpot(cacheKey: "cached-carousel-spot")
-    Helper.clearCache(for: cachedSpot.stateCache)
+    cachedSpot.stateCache?.clear()
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -10,6 +10,7 @@ class CarouselSpotTests: XCTestCase {
   override func setUp() {
     spot = CarouselSpot(component: Component(span: 1.0))
     cachedSpot = CarouselSpot(cacheKey: "cached-carousel-spot")
+    XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }
 

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -10,6 +10,7 @@ class GridSpotTests: XCTestCase {
   override func setUp() {
     spot = GridSpot(component: Component(span: 1.0))
     cachedSpot = GridSpot(cacheKey: "cached-grid-spot")
+    XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }
 

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -10,7 +10,7 @@ class GridSpotTests: XCTestCase {
   override func setUp() {
     spot = GridSpot(component: Component(span: 1.0))
     cachedSpot = GridSpot(cacheKey: "cached-grid-spot")
-    Helper.clearCache(for: cachedSpot.stateCache)
+    cachedSpot.stateCache?.clear()
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -8,7 +8,7 @@ class ListSpotTests: XCTestCase {
 
   override func setUp() {
     cachedSpot = ListSpot(cacheKey: "cached-list-spot")
-    Helper.clearCache(for: cachedSpot.stateCache)
+    cachedSpot.stateCache?.clear()
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -8,6 +8,7 @@ class ListSpotTests: XCTestCase {
 
   override func setUp() {
     cachedSpot = ListSpot(cacheKey: "cached-list-spot")
+    XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }
 

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -10,6 +10,7 @@ class RowSpotTests: XCTestCase {
   override func setUp() {
     spot = RowSpot(component: Component(span: 1))
     cachedSpot = RowSpot(cacheKey: "cached-row-spot")
+    XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }
 

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -10,7 +10,7 @@ class RowSpotTests: XCTestCase {
   override func setUp() {
     spot = RowSpot(component: Component(span: 1))
     cachedSpot = RowSpot(cacheKey: "cached-row-spot")
-    Helper.clearCache(for: cachedSpot.stateCache)
+    cachedSpot.stateCache?.clear()
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -52,6 +52,7 @@ class TestSpot: XCTestCase {
       }
 
       let cachedSpot = Spot(cacheKey: cacheKey)
+      XCTAssertEqual(cachedSpot.component.items[0].title, "test")
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
       exception?.fulfill()

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -57,7 +57,7 @@ class TestSpot: XCTestCase {
       exception?.fulfill()
       exception = nil
 
-      Helper.clearCache(for: cachedSpot.stateCache)
+      cachedSpot.stateCache?.clear()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -45,7 +45,7 @@ class TestSpot: XCTestCase {
     }
 
     var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
-    Dispatch.after(seconds: 0.25) {
+    Dispatch.after(seconds: 2.5) {
       guard let cacheKey = spot.stateCache?.key else {
         XCTFail()
         return
@@ -59,7 +59,7 @@ class TestSpot: XCTestCase {
 
       cachedSpot.stateCache?.clear()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testCompareHybridListSpotWithCoreType() {

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -35,6 +35,33 @@ class TestSpot: XCTestCase {
     XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: expectedContentSizeHeight))
   }
 
+  func testSpotCache() {
+    let item = Item(title: "test")
+    let spot = Spot(cacheKey: "test-spot-cache")
+
+    XCTAssertEqual(spot.component.items.count, 0)
+    spot.append(item) {
+      spot.cache()
+    }
+
+    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    Dispatch.after(seconds: 0.25) {
+      guard let cacheKey = spot.stateCache?.key else {
+        XCTFail()
+        return
+      }
+
+      let cachedSpot = Spot(cacheKey: cacheKey)
+      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      cachedSpot.stateCache?.clear()
+      exception?.fulfill()
+      exception = nil
+
+      Helper.clearCache(for: cachedSpot.stateCache)
+    }
+    waitForExpectations(timeout: 0.5, handler: nil)
+  }
+
   func testCompareHybridListSpotWithCoreType() {
     let items = [Item(title: "A"), Item(title: "B")]
     let component = Component(kind: Component.Kind.list.string, items: items, hybrid: true)


### PR DESCRIPTION
This PR implements `convenience init(cacheKey: String)` for `Spot`.

It also reduces some code duplication by extracting code that configures the collection view header into one method.