### PR TITLE
Fix bug with insets when using paginated scrolling in carousel spots.

### DIFF
--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -87,6 +87,7 @@ extension Delegate: UIScrollViewDelegate {
     let pointXUpperBound = collectionViewLayout.collectionViewContentSize.width - scrollView.frame.width / 2
     var point = targetContentOffset.pointee
     point.x += scrollView.frame.width / 2
+    point.y = scrollView.frame.midY
     var indexPath: IndexPath?
 
     while indexPath == nil && point.x < pointXUpperBound {


### PR DESCRIPTION
We have a minor issue that pagination would fail to check which view to scroll to if you were using insets. This PR fixes that issue by setting the `point.y` to the middle of the scroll view.