### PR TITLE
Rename exception to expectation and use type inference

### DIFF
--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -99,28 +99,28 @@ class CompositionTests: XCTestCase {
     spot.view.layoutSubviews()
 
     var composite: Composable?
-    var ItemConfigurable: ItemConfigurable?
+    var itemConfigurable: ItemConfigurable?
 
     composite = spot.ui(at: 0)
-    ItemConfigurable = spot.compositeSpots[0].spot.ui(at: 0)
+    itemConfigurable = spot.compositeSpots[0].spot.ui(at: 0)
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spot.compositeSpots[0].parentSpot!.component == spot.component)
     XCTAssertTrue(spot.compositeSpots[0].spot is Listable)
     XCTAssertEqual(spot.compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[0].spot.items.count))
 
     composite = spot.ui(at: 1)
-    ItemConfigurable = spot.compositeSpots[0].spot.ui(at: 1)
+    itemConfigurable = spot.compositeSpots[0].spot.ui(at: 1)
 
     XCTAssertNotNil(composite)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spot.compositeSpots[1].parentSpot!.component == spot.component)
     XCTAssertTrue(spot.compositeSpots[1].spot is Listable)
     XCTAssertEqual(spot.compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[1].spot.items.count))
 
     composite = spot.ui(at: 2)
     XCTAssertNil(composite)
@@ -217,48 +217,48 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var ItemConfigurable: ItemConfigurable?
+    var itemConfigurable: ItemConfigurable?
 
     composite = spots[0].ui(at: 0)
-    ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
       Component(kind: Component.Kind.grid.rawValue,
@@ -350,46 +350,46 @@ class CompositionTests: XCTestCase {
       let spots = controller.spots
 
       composite = spots[0].ui(at: 0)
-      ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertNotNil(composite?.contentView)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 
@@ -639,48 +639,48 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var ItemConfigurable: ItemConfigurable?
+    var itemConfigurable: ItemConfigurable?
 
     composite = spots[0].ui(at: 0)
-    ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
       Component(kind: Component.Kind.grid.rawValue,
@@ -818,47 +818,47 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(spots.count, 3)
 
       composite = spots[0].ui(at: 0)
-      ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot?.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 11)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
-      ItemConfigurable = spots[1].compositeSpots[0].spot.ui(at: 0)
+      itemConfigurable = spots[1].compositeSpots[0].spot.ui(at: 0)
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[0].parentSpot?.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 11)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[1].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[1].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 11)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 
@@ -958,48 +958,48 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var ItemConfigurable: ItemConfigurable?
+    var itemConfigurable: ItemConfigurable?
 
     composite = spots[0].ui(at: 0)
-    ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
     XCTAssertNotNil(composite)
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[0].spot.items.count))
 
-    ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+    itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-    XCTAssertNotNil(ItemConfigurable)
+    XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
-                   (ItemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spots[1].compositeSpots[1].spot.items.count))
 
     let newComponents: [Component] = [
       Component(kind: Component.Kind.grid.rawValue,
@@ -1054,26 +1054,26 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(spots.count, 1)
 
       composite = spots[0].ui(at: 0)
-      ItemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
 
       XCTAssertNotNil(composite)
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[0].spot.items.count))
 
-      ItemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
+      itemConfigurable = spots[0].compositeSpots[1].spot.ui(at: 0)
 
-      XCTAssertNotNil(ItemConfigurable)
+      XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
-                     ((ItemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(spots[0].compositeSpots[1].spot.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -341,7 +341,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let exception = self.expectation(description: "Reload controller with components replaceSpot")
+    let expectation = self.expectation(description: "Reload controller with components replaceSpot")
     var reloadTimes: Int = 0
 
     controller.reloadIfNeeded(newComponents) {
@@ -393,7 +393,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertEqual(reloadTimes, 1)
 
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -492,7 +492,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let exception = self.expectation(description: "Reload controller with components newSpot")
+    let expectation = self.expectation(description: "Reload controller with components newSpot")
     var reloadTimes: Int = 0
 
     controller.reloadIfNeeded(newComponents) {
@@ -543,7 +543,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertEqual(reloadTimes, 1)
 
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -807,7 +807,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let exception: XCTestExpectation = self.expectation(description: "Reload controller with components triggering reloadMore")
+    let expectation: XCTestExpectation = self.expectation(description: "Reload controller with components triggering reloadMore")
     var reloadTimes: Int = 0
 
     controller.reloadIfNeeded(newComponents) {
@@ -862,7 +862,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertEqual(reloadTimes, 1)
 
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -1043,7 +1043,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    var exception: XCTestExpectation? = self.expectation(description: "Reload controller with components  triggering reloadLess")
+    let expectation = self.expectation(description: "Reload controller with components  triggering reloadLess")
     var reloadTimes: Int = 0
 
     controller.reloadIfNeeded(newComponents) {
@@ -1077,8 +1077,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertEqual(reloadTimes, 1)
 
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -395,7 +395,7 @@ class CompositionTests: XCTestCase {
 
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testReloadWithComponentsUsingCompositionTriggeringNewSpot() {
@@ -545,7 +545,7 @@ class CompositionTests: XCTestCase {
 
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testReloadWithComponentsUsingCompositionTriggeringReloadMore() {
@@ -864,7 +864,7 @@ class CompositionTests: XCTestCase {
 
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testReloadWithComponentsUsingCompositionTriggeringReloadLess() {
@@ -1079,6 +1079,6 @@ class CompositionTests: XCTestCase {
 
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 }

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -43,7 +43,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendOneMoreItemInListSpot() {
@@ -62,7 +62,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemsInListSpot() {
@@ -82,7 +82,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItemsInListSpot() {
@@ -102,7 +102,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependMoreItemsInListSpot() {
@@ -130,7 +130,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemInListSpot() {
@@ -159,7 +159,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items.count, 1)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemsInListSpot() {
@@ -179,7 +179,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items.count, 0)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemAtIndexInListSpot() {
@@ -203,7 +203,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items[2].title, "title4")
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemsWithIndexesInListSpot() {
@@ -226,7 +226,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items[1].title, "title4")
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemInGridSpot() {
@@ -247,7 +247,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemsInGridSpot() {
@@ -268,7 +268,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItemsInGridSpot() {
@@ -289,7 +289,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemInGridSpot() {
@@ -318,7 +318,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items.count, 1)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemInCarouselSpot() {
@@ -339,7 +339,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemsInCarouselSpot() {
@@ -361,7 +361,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItemsInCarouselSpot() {
@@ -382,7 +382,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemInCarouselSpot() {
@@ -411,7 +411,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spot!.component.items.count, 1)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testComputedPropertiesOnSpotable() {
@@ -499,7 +499,7 @@ class ControllerTests: XCTestCase {
       XCTAssert(jsonController.spot!.component.items.first?.title == "First grid item")
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDictionaryOnController() {
@@ -589,7 +589,7 @@ class ControllerTests: XCTestCase {
         expectation.fulfill()
       }
     }
-    waitForExpectations(timeout: 3.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testControllerItemChanges() {
@@ -840,7 +840,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 5.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotsDidReloadComponents() {
@@ -887,6 +887,6 @@ class ControllerTests: XCTestCase {
     controller.prepareController()
     controller.reloadIfNeeded(newComponents)
 
-    waitForExpectations(timeout: 2.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 }

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -36,11 +36,11 @@ class ControllerTests: XCTestCase {
     XCTAssertEqual(controller.spot!.component.items.count, 0)
 
     let item = Item(title: "title1", kind: "list")
-    let exception = self.expectation(description: "Test append item")
+    let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 1)
       XCTAssert(controller.spot!.component.items.first! == item)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -55,11 +55,11 @@ class ControllerTests: XCTestCase {
     XCTAssertEqual(controller.spot!.component.items.count, 1)
 
     let item = Item(title: "title2", kind: "list")
-    let exception = self.expectation(description: "Test append item")
+    let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 2)
       XCTAssert(controller.spot!.component.items.last! == item)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -75,11 +75,11 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
     ]
-    let exception = self.expectation(description: "Test append items")
+    let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
       XCTAssert(controller.spot!.component.items.count > 0)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -95,11 +95,11 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
     ]
-    let exception = self.expectation(description: "Test prepend items")
+    let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 2)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -120,14 +120,14 @@ class ControllerTests: XCTestCase {
       Item(title: "title3", kind: "list"),
       Item(title: "title4", kind: "list")
     ]
-    let exception = self.expectation(description: "Test prepend items")
+    let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 4)
       XCTAssertEqual(controller.spot!.component.items[0].title, "title3")
       XCTAssertEqual(controller.spot!.component.items[1].title, "title4")
       XCTAssertEqual(controller.spot!.component.items[2].title, "title1")
       XCTAssertEqual(controller.spot!.component.items[3].title, "title2")
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -148,7 +148,7 @@ class ControllerTests: XCTestCase {
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
-    let exception = self.expectation(description: "Test delete item")
+    let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
     listSpot.delete(component.items.first!) {
       let lastItem = controller.spot!.component.items.first
@@ -157,7 +157,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
       XCTAssertEqual(controller.spot!.component.items.count, 1)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -173,11 +173,11 @@ class ControllerTests: XCTestCase {
     controller.preloadView()
 
     let items = controller.spots.first!.items
-    let exception = self.expectation(description: "Test delete items")
+    let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete(items, withAnimation: .none) {
       XCTAssertEqual(controller.spot!.component.items.count, 0)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -194,14 +194,14 @@ class ControllerTests: XCTestCase {
 
     controller.preloadView()
 
-    let exception = self.expectation(description: "Test delete items")
+    let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete(1, withAnimation: .none) {
       XCTAssertEqual(controller.spot!.component.items.count, 3)
       XCTAssertEqual(controller.spot!.component.items[0].title, "title1")
       XCTAssertEqual(controller.spot!.component.items[1].title, "title3")
       XCTAssertEqual(controller.spot!.component.items[2].title, "title4")
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -218,13 +218,13 @@ class ControllerTests: XCTestCase {
 
     controller.preloadView()
 
-    let exception = self.expectation(description: "Test delete items")
+    let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete([1, 2], withAnimation: .none) {
       XCTAssertEqual(controller.spot!.component.items.count, 2)
       XCTAssertEqual(controller.spot!.component.items[0].title, "title1")
       XCTAssertEqual(controller.spot!.component.items[1].title, "title4")
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -239,12 +239,12 @@ class ControllerTests: XCTestCase {
     XCTAssert(controller.spot!.component.items.count == 0)
 
     let item = Item(title: "title1", kind: "grid")
-    let exception = self.expectation(description: "Test append item")
+    let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
       XCTAssert(controller.spot!.component.items.count == 1)
       XCTAssert(controller.spot!.component.items.first! == item)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -261,11 +261,11 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "grid"),
       Item(title: "title2", kind: "grid")
     ]
-    let exception = self.expectation(description: "Test append items")
+    let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
       XCTAssert(controller.spot!.component.items.count > 0)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -282,11 +282,11 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "grid"),
       Item(title: "title2", kind: "grid")
     ]
-    let exception = self.expectation(description: "Test prepend items")
+    let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 2)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -307,7 +307,7 @@ class ControllerTests: XCTestCase {
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
-    let exception = self.expectation(description: "Test delete item")
+    let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
     listSpot.delete(component.items.first!) {
       let lastItem = controller.spot!.component.items.first
@@ -316,7 +316,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
       XCTAssertEqual(controller.spot!.component.items.count, 1)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -331,12 +331,12 @@ class ControllerTests: XCTestCase {
     XCTAssert(controller.spot!.component.items.count == 0)
 
     let item = Item(title: "title1", kind: "carousel")
-    let exception = self.expectation(description: "Test append item")
+    let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
       XCTAssert(controller.spot!.component.items.count == 1)
       XCTAssert(controller.spot!.component.items.first! == item)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -353,12 +353,12 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "carousel"),
       Item(title: "title2", kind: "carousel")
     ]
-    let exception = self.expectation(description: "Test append items")
+    let expectation = self.expectation(description: "Test append items")
 
     controller.append(items, spotIndex: 0) {
       XCTAssert(controller.spot!.component.items.count > 0)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 0.5, handler: nil)
@@ -375,11 +375,11 @@ class ControllerTests: XCTestCase {
       Item(title: "title1", kind: "carousel"),
       Item(title: "title2", kind: "carousel")
     ]
-    let exception = self.expectation(description: "Test prepend items")
+    let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
       XCTAssertEqual(controller.spot!.component.items.count, 2)
       XCTAssert(controller.spot!.component.items == items)
-      exception.fulfill()
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 1.0, handler: nil)
@@ -400,7 +400,7 @@ class ControllerTests: XCTestCase {
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
-    let exception = self.expectation(description: "Test delete item")
+    let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
     listSpot.delete(component.items.first!) {
       let lastItem = controller.spot!.component.items.first
@@ -409,7 +409,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
       XCTAssertEqual(controller.spot!.component.items.count, 1)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -492,12 +492,12 @@ class ControllerTests: XCTestCase {
       ]
     ]
 
-    let exception = self.expectation(description: "Reload with JSON")
+    let expectation = self.expectation(description: "Reload with JSON")
     jsonController.reload(updateJSON) {
       XCTAssert(jsonController.spot!.component.kind == "grid")
       XCTAssert(jsonController.spot!.component.items.count == 2)
       XCTAssert(jsonController.spot!.component.items.first?.title == "First grid item")
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -567,7 +567,7 @@ class ControllerTests: XCTestCase {
     XCTAssertTrue(controller.spots.count == 2)
     XCTAssertTrue(controller.spots[0].compositeSpots.count == 0)
 
-    let exception = self.expectation(description: "Reload multiple times with JSON (if needed)")
+    let expectation = self.expectation(description: "Reload multiple times with JSON (if needed)")
 
     controller.reloadIfNeeded(newJSON) {
       XCTAssertEqual(controller.spots.count, 2)
@@ -586,7 +586,7 @@ class ControllerTests: XCTestCase {
         XCTAssertTrue(controller.spots[1] is ListSpot)
         XCTAssertTrue(controller.spots.count == 2)
         XCTAssertTrue(controller.spots[0].compositeSpots.count == 0)
-        exception.fulfill()
+        expectation.fulfill()
       }
     }
     waitForExpectations(timeout: 3.5, handler: nil)
@@ -775,7 +775,7 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.spots.first!.component.items[5].size, view!.frame.size)
     #endif
 
-    var exception: XCTestExpectation? = expectation(description: "Reload controller with components")
+    let expectation = self.expectation(description: "Reload controller with components")
     controller.reloadIfNeeded(newComponents) {
       XCTAssertEqual(controller.spots.first!.component.items[0].title, newComponents.first!.items[0].title)
       XCTAssertEqual(controller.spots.first!.component.items[0].subtitle, newComponents.first!.items[0].subtitle)
@@ -837,8 +837,7 @@ class ControllerTests: XCTestCase {
         XCTAssertEqual(controller.spots.first!.component.items[5].size, view!.frame.size)
       #endif
 
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
 
     waitForExpectations(timeout: 5.0, handler: nil)
@@ -875,12 +874,11 @@ class ControllerTests: XCTestCase {
       )
     ]
 
-    var exception: XCTestExpectation? = expectation(description: "Wait for spotsDidReloadComponents to be called")
+    let expectation = self.expectation(description: "Wait for spotsDidReloadComponents to be called")
 
     Controller.spotsDidReloadComponents = { controller in
       XCTAssert(true)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
 
     let spots = initialComponents.map { Factory.resolve(component: $0) }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -20,10 +20,10 @@ class SpotableTests: XCTestCase {
       }
     }
 
-    let exception = self.expectation(description: "Wait until done")
+    let expectation = self.expectation(description: "Wait until done")
     Dispatch.after(seconds: 1.0) {
       XCTAssertEqual(listSpot.items.count, 500)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.5, handler: nil)
   }
@@ -44,10 +44,10 @@ class SpotableTests: XCTestCase {
       }
     }
 
-    let exception = self.expectation(description: "Wait until done")
+    let expectation = self.expectation(description: "Wait until done")
     Dispatch.after(seconds: 1.0) {
       XCTAssertEqual(controller.spots[0].items.count, 500)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.5, handler: nil)
   }

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -25,7 +25,7 @@ class SpotableTests: XCTestCase {
       XCTAssertEqual(listSpot.items.count, 500)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendingMultipleItemsToSpotInController() {
@@ -49,7 +49,7 @@ class SpotableTests: XCTestCase {
       XCTAssertEqual(controller.spots[0].items.count, 500)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testResolvingUIFromGridableSpot() {

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -35,7 +35,7 @@ class StateCacheTests: XCTestCase {
       XCTAssertEqual(self.controller.stateCache!.load().count, 1)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testRemovingStateCacheFromController() {
@@ -45,7 +45,7 @@ class StateCacheTests: XCTestCase {
       XCTAssertEqual(self.controller.stateCache!.cacheExists, false)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testCacheWithEmptyKey() {
@@ -77,6 +77,6 @@ class StateCacheTests: XCTestCase {
 
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 }

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -28,22 +28,22 @@ class StateCacheTests: XCTestCase {
 
     controller.spots = [ListSpot(component: Component(span: 1.0))]
 
-    let exception = self.expectation(description: "Append item to Spotable object")
+    let expectation = self.expectation(description: "Append item to Spotable object")
     controller.append(Item(title: "foo"), spotIndex: 0, withAnimation: .automatic) {
       self.controller.cache()
       /// Check that the cache was saved to disk
       XCTAssertEqual(self.controller.stateCache!.load().count, 1)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
 
   func testRemovingStateCacheFromController() {
-    let exception = self.expectation(description: "Clear state cache")
+    let expectation = self.expectation(description: "Clear state cache")
     controller.stateCache?.clear {
       XCTAssertEqual(self.controller.stateCache!.load().count, 0)
       XCTAssertEqual(self.controller.stateCache!.cacheExists, false)
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -61,7 +61,7 @@ class StateCacheTests: XCTestCase {
 
     [cacheOne, cacheTwo].forEach { $0.save(["foo": "bar"]) }
 
-    let exception = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.5) {
       do {
         let files = try FileManager.default.contentsOfDirectory(atPath: path)
@@ -75,7 +75,7 @@ class StateCacheTests: XCTestCase {
         XCTAssertEqual(files.count, 0)
       } catch {}
 
-      exception.fulfill()
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -338,7 +338,7 @@ class CarouselSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItems() {
@@ -349,7 +349,7 @@ class CarouselSpotTests: XCTestCase {
       XCTAssert(spot.component.items == items)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testInsertItem() {
@@ -360,7 +360,7 @@ class CarouselSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItems() {
@@ -371,7 +371,7 @@ class CarouselSpotTests: XCTestCase {
       XCTAssert(spot.component.items == items)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 1.0, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotCache() {
@@ -390,7 +390,7 @@ class CarouselSpotTests: XCTestCase {
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotConfigurationClosure() {

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -333,11 +333,10 @@ class CarouselSpotTests: XCTestCase {
   func testAppendItem() {
     let item = Item(title: "test")
     let spot = CarouselSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Append item")
+    let expectation = self.expectation(description: "Append item")
     spot.append(item) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -345,11 +344,10 @@ class CarouselSpotTests: XCTestCase {
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = CarouselSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Append items")
+    let expectation = self.expectation(description: "Append items")
     spot.append(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -357,11 +355,10 @@ class CarouselSpotTests: XCTestCase {
   func testInsertItem() {
     let item = Item(title: "test")
     let spot = CarouselSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Insert item")
+    let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -369,11 +366,10 @@ class CarouselSpotTests: XCTestCase {
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = CarouselSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Prepend items")
+    let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 1.0, handler: nil)
   }
@@ -386,14 +382,13 @@ class CarouselSpotTests: XCTestCase {
       self.cachedSpot.cache()
     }
 
-    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) { [weak self] in
       guard let weakSelf = self else { return }
       let cachedSpot = CarouselSpot(cacheKey: weakSelf.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -63,11 +63,10 @@ class GridSpotTests: XCTestCase {
   func testAppendItem() {
     let item = Item(title: "test")
     let spot = GridSpot(component: Component(span: 1.0))
-    var exception: XCTestExpectation? = self.expectation(description: "Append item")
+    let expectation = self.expectation(description: "Append item")
     spot.append(item) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -75,11 +74,10 @@ class GridSpotTests: XCTestCase {
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = GridSpot(component: Component(span: 1.0))
-    var exception: XCTestExpectation? = self.expectation(description: "Append items")
+    let expectation = self.expectation(description: "Append items")
     spot.append(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -87,11 +85,10 @@ class GridSpotTests: XCTestCase {
   func testInsertItem() {
     let item = Item(title: "test")
     let spot = GridSpot(component: Component(span: 1.0))
-    var exception: XCTestExpectation? = self.expectation(description: "Insert item")
+    let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -99,11 +96,10 @@ class GridSpotTests: XCTestCase {
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = GridSpot(component: Component(span: 1.0))
-    var exception: XCTestExpectation? = self.expectation(description: "Prepend items")
+    let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -126,13 +122,12 @@ class GridSpotTests: XCTestCase {
       self?.cachedSpot.cache()
     }
 
-    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = GridSpot(cacheKey: self.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -68,7 +68,7 @@ class GridSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItems() {
@@ -79,7 +79,7 @@ class GridSpotTests: XCTestCase {
       XCTAssert(spot.component.items == items)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testInsertItem() {
@@ -90,7 +90,7 @@ class GridSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItems() {
@@ -101,7 +101,7 @@ class GridSpotTests: XCTestCase {
       XCTAssert(spot.component.items == items)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotCollectionDelegate() {
@@ -129,7 +129,7 @@ class GridSpotTests: XCTestCase {
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotConfigurationClosure() {

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -63,7 +63,7 @@ class ListSpotTests: XCTestCase {
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotConfigurationClosure() {

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -56,13 +56,12 @@ class ListSpotTests: XCTestCase {
       self.cachedSpot.cache()
     }
 
-    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = ListSpot(cacheKey: self.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -63,11 +63,10 @@ class RowSpotTests: XCTestCase {
   func testAppendItem() {
     let item = Item(title: "test")
     let spot = RowSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Append item")
+    let expectation = self.expectation(description: "Append item")
     spot.append(item) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -75,11 +74,10 @@ class RowSpotTests: XCTestCase {
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = RowSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Append items")
+    let expectation = self.expectation(description: "Append items")
     spot.append(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
@@ -87,11 +85,10 @@ class RowSpotTests: XCTestCase {
   func testInsertItem() {
     let item = Item(title: "test")
     let spot = RowSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Insert item")
+    let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
       XCTAssert(spot.component.items.first! == item)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -99,11 +96,10 @@ class RowSpotTests: XCTestCase {
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
     let spot = RowSpot(component: Component(span: 1))
-    var exception: XCTestExpectation? = self.expectation(description: "Prepend items")
+    let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
       XCTAssert(spot.component.items == items)
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }
@@ -126,13 +122,12 @@ class RowSpotTests: XCTestCase {
       self.cachedSpot.cache()
     }
 
-    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = RowSpot(cacheKey: self.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
     }
     waitForExpectations(timeout: 0.5, handler: nil)
   }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -68,7 +68,7 @@ class RowSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItems() {
@@ -90,7 +90,7 @@ class RowSpotTests: XCTestCase {
       XCTAssert(spot.component.items.first! == item)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testPrependItems() {
@@ -101,7 +101,7 @@ class RowSpotTests: XCTestCase {
       XCTAssert(spot.component.items == items)
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotCollectionDelegate() {
@@ -129,7 +129,7 @@ class RowSpotTests: XCTestCase {
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
-    waitForExpectations(timeout: 0.5, handler: nil)
+    waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testSpotConfigurationClosure() {

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -44,7 +44,7 @@ class TestSpot: XCTestCase {
       spot.cache()
     }
 
-    var exception: XCTestExpectation? = self.expectation(description: "Wait for cache")
+    let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 2.5) {
       guard let cacheKey = spot.stateCache?.key else {
         XCTFail()
@@ -55,8 +55,7 @@ class TestSpot: XCTestCase {
       XCTAssertEqual(cachedSpot.component.items[0].title, "test")
       XCTAssertEqual(cachedSpot.component.items.count, 1)
       cachedSpot.stateCache?.clear()
-      exception?.fulfill()
-      exception = nil
+      expectation.fulfill()
 
       cachedSpot.stateCache?.clear()
     }


### PR DESCRIPTION
This PR renames `exception` to `expectation` and removes type annotation for that variable. It also fixes the casing of the `ItemConfigurable` variable in the tests.