### PR TITLE
Refactor wrapped views setup

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -237,9 +237,9 @@ public extension Spotable {
       let kind = identifier(at: index)
       let view: View?
 
-      if let (_, resolvedView) = Self.views.make(kind, parentFrame: self.view.frame) {
+      if let (_, resolvedView) = Self.views.make(kind, parentFrame: self.view.bounds) {
         view = resolvedView
-      } else if let (_, resolvedView) = Configuration.views.make(kind, parentFrame: self.view.frame) {
+      } else if let (_, resolvedView) = Configuration.views.make(kind, parentFrame: self.view.bounds) {
         view = resolvedView
       } else {
         return nil

--- a/Sources/Shared/Extensions/Wrappable+Extensions.swift
+++ b/Sources/Shared/Extensions/Wrappable+Extensions.swift
@@ -5,7 +5,6 @@ public extension Wrappable {
       previousView.removeFromSuperview()
     }
 
-    view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     view.frame = bounds
     self.wrappedView = view
     configureWrappedView()

--- a/Sources/Shared/Extensions/Wrappable+Extensions.swift
+++ b/Sources/Shared/Extensions/Wrappable+Extensions.swift
@@ -5,9 +5,12 @@ public extension Wrappable {
       previousView.removeFromSuperview()
     }
 
-    configureWrappedView()
-    contentView.addSubview(view)
+    view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.frame = bounds
     self.wrappedView = view
+    configureWrappedView()
+
+    contentView.addSubview(view)
   }
 
   func configureWrappedView() {}

--- a/Sources/Shared/Protocols/Wrappable.swift
+++ b/Sources/Shared/Protocols/Wrappable.swift
@@ -1,5 +1,8 @@
+import CoreGraphics
+
 public protocol Wrappable: class {
 
+  var bounds: CGRect { get }
   var contentView: View { get }
   var wrappedView: View? { get set }
 

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -8,6 +8,11 @@ class GridWrapper: UICollectionViewCell, Wrappable {
     super.layoutSubviews()
 
     self.wrappedView?.frame = contentView.bounds
+  func configureWrappedView() {
+    if let cell = wrappedView as? UICollectionViewCell {
+      cell.contentView.frame = contentView.frame
+      cell.isUserInteractionEnabled = false
+    }
   }
 
   override func prepareForReuse() {

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -8,6 +8,8 @@ class GridWrapper: UICollectionViewCell, Wrappable {
     super.layoutSubviews()
 
     wrappedView?.frame.size = contentView.bounds.size
+  }
+
   func configureWrappedView() {
     if let cell = wrappedView as? UICollectionViewCell {
       cell.contentView.frame = contentView.frame

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -7,7 +7,7 @@ class GridWrapper: UICollectionViewCell, Wrappable {
   override func layoutSubviews() {
     super.layoutSubviews()
 
-    self.wrappedView?.frame = contentView.bounds
+    wrappedView?.frame.size = contentView.bounds.size
   func configureWrappedView() {
     if let cell = wrappedView as? UICollectionViewCell {
       cell.contentView.frame = contentView.frame

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -10,6 +10,7 @@ class ListWrapper: UITableViewCell, Wrappable {
       cell.isUserInteractionEnabled = false
     }
   }
+
   override func layoutSubviews() {
     super.layoutSubviews()
     wrappedView?.frame.size = contentView.bounds.size

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -4,6 +4,12 @@ class ListWrapper: UITableViewCell, Wrappable {
 
   weak var wrappedView: View?
 
+  func configureWrappedView() {
+    if let cell = wrappedView as? UITableViewCell {
+      cell.contentView.frame = contentView.frame
+      cell.isUserInteractionEnabled = false
+    }
+  }
   override func layoutSubviews() {
     super.layoutSubviews()
 

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -12,8 +12,7 @@ class ListWrapper: UITableViewCell, Wrappable {
   }
   override func layoutSubviews() {
     super.layoutSubviews()
-
-    self.wrappedView?.frame = contentView.bounds
+    wrappedView?.frame.size = contentView.bounds.size
   }
 
   override func prepareForReuse() {

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -92,7 +92,7 @@ extension DataSource: UICollectionViewDataSource {
 
     switch cell {
     case let cell as GridWrapper:
-      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind),
+      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind, parentFrame: cell.bounds),
         let customView = view {
         cell.configure(with: customView)
 
@@ -161,7 +161,7 @@ extension DataSource: UITableViewDataSource {
 
     switch cell {
     case let cell as ListWrapper:
-      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind),
+      if let (_, view) = Configuration.views.make(spot.component.items[indexPath.item].kind, parentFrame: cell.bounds),
         let customView = view {
         cell.configure(with: customView)
 

--- a/Sources/macOS/Classes/GridWrapper.swift
+++ b/Sources/macOS/Classes/GridWrapper.swift
@@ -2,6 +2,10 @@ import Cocoa
 
 class GridWrapper: NSCollectionViewItem, Wrappable {
 
+  public var bounds: CGRect {
+    return coreView.bounds
+  }
+
   weak var wrappedView: View?
 
   public var contentView: View {

--- a/Sources/macOS/Classes/ListWrapper.swift
+++ b/Sources/macOS/Classes/ListWrapper.swift
@@ -1,6 +1,7 @@
 import Cocoa
 
 class ListWrapper: NSTableRowView, Wrappable {
+
   public var contentView: View {
     return self
   }


### PR DESCRIPTION
This PR improves how wrapped views pass size when using a reusable cell as a view.
It will also pass the parent frame to the make method when constructing the wrapped view.

What this means for existing projects is that you no longer need to refactor your views to make this work properly.