### PR TITLE
Feature: view state

### DIFF
--- a/Sources/Shared/Enums/ViewState.swift
+++ b/Sources/Shared/Enums/ViewState.swift
@@ -1,0 +1,5 @@
+enum ViewState {
+  case normal
+  case highlighted
+  case selected
+}

--- a/Sources/Shared/Enums/ViewState.swift
+++ b/Sources/Shared/Enums/ViewState.swift
@@ -1,4 +1,4 @@
-enum ViewState {
+public enum ViewState {
   case normal
   case highlighted
   case selected

--- a/Sources/Shared/Protocols/Cell.swift
+++ b/Sources/Shared/Protocols/Cell.swift
@@ -1,0 +1,17 @@
+protocol Cell {
+  var isHighlighted: Bool { get }
+  var isSelected: Bool { get }
+}
+
+extension Cell {
+
+  var viewState: ViewState {
+    if isHighlighted {
+      return .highlighted
+    } else if isSelected {
+      return .selected
+    } else {
+      return .normal
+    }
+  }
+}

--- a/Sources/Shared/Protocols/ViewStateDelegate.swift
+++ b/Sources/Shared/Protocols/ViewStateDelegate.swift
@@ -1,0 +1,7 @@
+public protocol ViewStateDelegate: class {
+
+  /// Invoked when ever a view state is changed.
+  ///
+  /// - parameter viewState: The current view state.
+  func viewStateDidChange(_ viewState: ViewState)
+}

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class GridWrapper: UICollectionViewCell, Wrappable {
+class GridWrapper: UICollectionViewCell, Wrappable, Cell {
 
   weak var wrappedView: View?
 
@@ -19,5 +19,19 @@ class GridWrapper: UICollectionViewCell, Wrappable {
 
   override func prepareForReuse() {
     wrappedView?.removeFromSuperview()
+  }
+
+  // MARK: - View state
+
+  override var isSelected: Bool {
+    didSet {
+      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
+    }
+  }
+
+  override var isHighlighted: Bool {
+    didSet {
+      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
+    }
   }
 }

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ListWrapper: UITableViewCell, Wrappable {
+class ListWrapper: UITableViewCell, Wrappable, Cell {
 
   weak var wrappedView: View?
 
@@ -18,5 +18,19 @@ class ListWrapper: UITableViewCell, Wrappable {
 
   override func prepareForReuse() {
     wrappedView?.removeFromSuperview()
+  }
+
+  // MARK: - View state
+
+  override var isSelected: Bool {
+    didSet {
+      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
+    }
+  }
+
+  override var isHighlighted: Bool {
+    didSet {
+      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
+    }
   }
 }

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -22,15 +22,13 @@ class ListWrapper: UITableViewCell, Wrappable, Cell {
 
   // MARK: - View state
 
-  override var isSelected: Bool {
-    didSet {
-      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
-    }
+  override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+    super.setHighlighted(highlighted, animated: animated)
+    (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
   }
 
-  override var isHighlighted: Bool {
-    didSet {
-      (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
-    }
+  override func setSelected(_ selected: Bool, animated: Bool) {
+    super.setSelected(selected, animated: animated)
+    (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
   }
 }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -365,6 +365,8 @@
 		D5D2826F1E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
 		D5D282701E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
 		D5D282711E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
+		D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282721E54773C004BF251 /* TestListWrapper.swift */; };
+		D5D282741E547742004BF251 /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282721E54773C004BF251 /* TestListWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -588,6 +590,7 @@
 		D5D282661E54710D004BF251 /* ViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewState.swift; sourceTree = "<group>"; };
 		D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateDelegate.swift; sourceTree = "<group>"; };
 		D5D2826E1E5474E0004BF251 /* Cell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
+		D5D282721E54773C004BF251 /* TestListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1053,6 +1056,7 @@
 				BD4295571D81D45D00E07E1C /* TestViewSpot.swift */,
 				BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */,
 				BD42CA841E4C9B2600A86E3B /* TestSpot.swift */,
+				D5D282721E54773C004BF251 /* TestListWrapper.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1624,6 +1628,7 @@
 				BD4295501D81CE4F00E07E1C /* TestGridSpot.swift in Sources */,
 				BDB8D5951E4DFADC00220BC3 /* TestItem.swift in Sources */,
 				BDA8DAF61DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
+				D5D282741E547742004BF251 /* TestListWrapper.swift in Sources */,
 				BD4295531D81D32400E07E1C /* TestListSpot.swift in Sources */,
 				BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */,
 				BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
@@ -1781,6 +1786,7 @@
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
 				BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */,
+				D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */,
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		D5D282711E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
 		D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282721E54773C004BF251 /* TestListWrapper.swift */; };
 		D5D282741E547742004BF251 /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282721E54773C004BF251 /* TestListWrapper.swift */; };
+		D5D282761E547D1D004BF251 /* TestGridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282751E547D1D004BF251 /* TestGridWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -591,6 +592,7 @@
 		D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateDelegate.swift; sourceTree = "<group>"; };
 		D5D2826E1E5474E0004BF251 /* Cell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		D5D282721E54773C004BF251 /* TestListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListWrapper.swift; sourceTree = "<group>"; };
+		D5D282751E547D1D004BF251 /* TestGridWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1057,6 +1059,7 @@
 				BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */,
 				BD42CA841E4C9B2600A86E3B /* TestSpot.swift */,
 				D5D282721E54773C004BF251 /* TestListWrapper.swift */,
+				D5D282751E547D1D004BF251 /* TestGridWrapper.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1766,6 +1769,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD4295581D81D45D00E07E1C /* TestViewSpot.swift in Sources */,
+				D5D282761E547D1D004BF251 /* TestGridWrapper.swift in Sources */,
 				BD4295551D81D39700E07E1C /* TestCarouselSpot.swift in Sources */,
 				D58478571C43FFFD006EBA49 /* TestComponent.swift in Sources */,
 				BD43459B1E35EB7D0032EB3E /* TestInteraction.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -356,6 +356,9 @@
 		D58478E71C440645006EBA49 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponent.swift */; };
 		D58478ED1C440726006EBA49 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
 		D58478F91C44076B006EBA49 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F71C44076B006EBA49 /* Tailor.framework */; };
+		D5D282671E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
+		D5D282681E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
+		D5D282691E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -576,6 +579,7 @@
 		D58478E91C440726006EBA49 /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/iOS/Tailor.framework; sourceTree = "<group>"; };
 		D58478EC1C440726006EBA49 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/iOS/Cache.framework; sourceTree = "<group>"; };
 		D58478F71C44076B006EBA49 /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/Mac/Tailor.framework; sourceTree = "<group>"; };
+		D5D282661E54710D004BF251 /* ViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -823,6 +827,7 @@
 				BDAD85321E3E7032008289AE /* Paginate.swift */,
 				BDAD85331E3E7032008289AE /* RegistryType.swift */,
 				52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */,
+				D5D282661E54710D004BF251 /* ViewState.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1558,6 +1563,7 @@
 				BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */,
 				BDAD85CE1E3E7032008289AE /* Viewable.swift in Sources */,
 				BDAD85831E3E7032008289AE /* Item+Extensions.swift in Sources */,
+				D5D282691E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD85CB1E3E7032008289AE /* UserInterface.swift in Sources */,
 				BDDCF6F11E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BDAD84E11E3E701C008289AE /* UITableView+UserInterface.swift in Sources */,
@@ -1703,6 +1709,7 @@
 				BDAD85AB1E3E7032008289AE /* Composable.swift in Sources */,
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
 				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
+				D5D282671E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD857E1E3E7032008289AE /* Gridable+Extensions.swift in Sources */,
 				BDAD84C61E3E701C008289AE /* SpotsContentView.swift in Sources */,
 				BDAD84E01E3E701C008289AE /* UITableView+UserInterface.swift in Sources */,
@@ -1834,6 +1841,7 @@
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,
 				BDAD85821E3E7032008289AE /* Item+Extensions.swift in Sources */,
 				BDAD850D1E3E7025008289AE /* GridComposite.swift in Sources */,
+				D5D282681E54710D004BF251 /* ViewState.swift in Sources */,
 				BDDCF6F01E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BDAD85611E3E7032008289AE /* CompositeSpot.swift in Sources */,
 				BDAD851D1E3E7025008289AE /* DataSource+macOS+Extensions.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -359,6 +359,12 @@
 		D5D282671E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282681E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282691E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
+		D5D2826B1E547219004BF251 /* ViewStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */; };
+		D5D2826C1E547219004BF251 /* ViewStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */; };
+		D5D2826D1E547219004BF251 /* ViewStateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */; };
+		D5D2826F1E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
+		D5D282701E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
+		D5D282711E5474E0004BF251 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D2826E1E5474E0004BF251 /* Cell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -580,6 +586,8 @@
 		D58478EC1C440726006EBA49 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/iOS/Cache.framework; sourceTree = "<group>"; };
 		D58478F71C44076B006EBA49 /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/Mac/Tailor.framework; sourceTree = "<group>"; };
 		D5D282661E54710D004BF251 /* ViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewState.swift; sourceTree = "<group>"; };
+		D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateDelegate.swift; sourceTree = "<group>"; };
+		D5D2826E1E5474E0004BF251 /* Cell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -876,6 +884,8 @@
 				BDAD85511E3E7032008289AE /* UserInterface.swift */,
 				BDAD85521E3E7032008289AE /* Viewable.swift */,
 				BDAD85531E3E7032008289AE /* Wrappable.swift */,
+				D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */,
+				D5D2826E1E5474E0004BF251 /* Cell.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1548,6 +1558,7 @@
 				BDAD85DD1E3E7032008289AE /* GridableMeta.swift in Sources */,
 				BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */,
 				BDAD85C51E3E7032008289AE /* SpotsFocusDelegate.swift in Sources */,
+				D5D282711E5474E0004BF251 /* Cell.swift in Sources */,
 				BDAD85771E3E7032008289AE /* RegistryType.swift in Sources */,
 				BDAD85DA1E3E7032008289AE /* Dispatch.swift in Sources */,
 				BDAD84C11E3E701C008289AE /* ListWrapper.swift in Sources */,
@@ -1563,6 +1574,7 @@
 				BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */,
 				BDAD85CE1E3E7032008289AE /* Viewable.swift in Sources */,
 				BDAD85831E3E7032008289AE /* Item+Extensions.swift in Sources */,
+				D5D2826D1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
 				D5D282691E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD85CB1E3E7032008289AE /* UserInterface.swift in Sources */,
 				BDDCF6F11E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
@@ -1694,6 +1706,7 @@
 				BDAD85EA1E3E7032008289AE /* Registry.swift in Sources */,
 				BDAD85C61E3E7032008289AE /* SpotsProtocol.swift in Sources */,
 				BDAD85E41E3E7032008289AE /* Layout.swift in Sources */,
+				D5D2826F1E5474E0004BF251 /* Cell.swift in Sources */,
 				BDAD85D51E3E7032008289AE /* Configuration.swift in Sources */,
 				BDAD858A1E3E7032008289AE /* Spotable+Extensions.swift in Sources */,
 				BDAD85931E3E7032008289AE /* SpotsDelegate+Extensions.swift in Sources */,
@@ -1709,6 +1722,7 @@
 				BDAD85AB1E3E7032008289AE /* Composable.swift in Sources */,
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
 				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
+				D5D2826B1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
 				D5D282671E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD857E1E3E7032008289AE /* Gridable+Extensions.swift in Sources */,
 				BDAD84C61E3E701C008289AE /* SpotsContentView.swift in Sources */,
@@ -1826,6 +1840,7 @@
 				BDAD85D61E3E7032008289AE /* Configuration.swift in Sources */,
 				BDAD85C41E3E7032008289AE /* SpotsFocusDelegate.swift in Sources */,
 				BDAD857F1E3E7032008289AE /* Gridable+Extensions.swift in Sources */,
+				D5D282701E5474E0004BF251 /* Cell.swift in Sources */,
 				BDAD85B81E3E7032008289AE /* ScrollDelegate.swift in Sources */,
 				BDAD85271E3E7025008289AE /* SpotView.swift in Sources */,
 				BDAD851C1E3E7025008289AE /* Composable+macOS.swift in Sources */,
@@ -1841,6 +1856,7 @@
 				BDAD856D1E3E7032008289AE /* ViewSpot.swift in Sources */,
 				BDAD85821E3E7032008289AE /* Item+Extensions.swift in Sources */,
 				BDAD850D1E3E7025008289AE /* GridComposite.swift in Sources */,
+				D5D2826C1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
 				D5D282681E54710D004BF251 /* ViewState.swift in Sources */,
 				BDDCF6F01E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BDAD85611E3E7032008289AE /* CompositeSpot.swift in Sources */,

--- a/SpotsTests/iOS/TestGridWrapper.swift
+++ b/SpotsTests/iOS/TestGridWrapper.swift
@@ -1,0 +1,49 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+// MARK: - Mocks
+
+fileprivate class ViewMock: UIView, ViewStateDelegate {
+
+  var viewState: ViewState?
+
+  func viewStateDidChange(_ viewState: ViewState) {
+    self.viewState = viewState
+  }
+}
+
+// MARK: - Test case
+
+class GridWrapperTests: XCTestCase {
+
+  private var gridWrapper: GridWrapper!
+  private var view: ViewMock!
+
+  override func setUp() {
+    super.setUp()
+    gridWrapper = GridWrapper()
+    view = ViewMock()
+    gridWrapper.wrappedView = view
+  }
+
+  func testIsHighlighted() {
+    XCTAssertNil(view.viewState)
+
+    gridWrapper.isHighlighted = true
+    XCTAssertEqual(view.viewState, .highlighted)
+
+    gridWrapper.isHighlighted = false
+    XCTAssertEqual(view.viewState, .normal)
+  }
+
+  func testIsSelected() {
+    XCTAssertNil(view.viewState)
+
+    gridWrapper.isSelected = true
+    XCTAssertEqual(view.viewState, .selected)
+
+    gridWrapper.isSelected = false
+    XCTAssertEqual(view.viewState, .normal)
+  }
+}

--- a/SpotsTests/iOS/TestListWrapper.swift
+++ b/SpotsTests/iOS/TestListWrapper.swift
@@ -1,0 +1,49 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+// MARK: - Mocks
+
+fileprivate class ViewMock: UIView, ViewStateDelegate {
+
+  var viewState: ViewState?
+
+  func viewStateDidChange(_ viewState: ViewState) {
+    self.viewState = viewState
+  }
+}
+
+// MARK: - Test case
+
+class ListWrapperTests: XCTestCase {
+
+  private var listWrapper: ListWrapper!
+  private var view: ViewMock!
+
+  override func setUp() {
+    super.setUp()
+    listWrapper = ListWrapper()
+    view = ViewMock()
+    listWrapper.wrappedView = view
+  }
+
+  func testIsHighlighted() {
+    XCTAssertNil(view.viewState)
+
+    listWrapper.setHighlighted(true, animated: true)
+    XCTAssertEqual(view.viewState, .highlighted)
+
+    listWrapper.setHighlighted(false, animated: true)
+    XCTAssertEqual(view.viewState, .normal)
+  }
+
+  func testIsSelected() {
+    XCTAssertNil(view.viewState)
+
+    listWrapper.setSelected(true, animated: true)
+    XCTAssertEqual(view.viewState, .selected)
+
+    listWrapper.setSelected(false, animated: true)
+    XCTAssertEqual(view.viewState, .normal)
+  }
+}


### PR DESCRIPTION
This PR introduces a view state that could be observed in `ListWrapper`'s and `GridWrapper`'s wrappedViews if they conform to `ViewStateDelegate`. It makes it possible to update UI when the parent `UITableViewCell` or `UICollectionViewCell` are highlighted or selected. Right now it's implemented on `iOS` and `tvOS` only, but could easily be adopted for `MacOS`.

Typical use case would be:

```swift
class View: UIView, ViewStateDelegate {

  func viewStateDidChange(_ viewState: ViewState) {
    switch {
      case .normal:
        // ...
      case .highlighted:
        // ...
      case .selected:
        // ..
    }
  }
}
```
