### PR TITLE
Remove highlighting for ListWrapper

### DIFF
--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -33,12 +33,12 @@ class ListWrapper: UITableViewCell, Wrappable, Cell {
   // MARK: - View state
 
   override func setHighlighted(_ highlighted: Bool, animated: Bool) {
-    super.setHighlighted(highlighted, animated: animated)
+    super.setHighlighted(false, animated: false)
     (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
   }
 
   override func setSelected(_ selected: Bool, animated: Bool) {
-    super.setSelected(selected, animated: animated)
+    super.setSelected(false, animated: false)
     (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
   }
 }


### PR DESCRIPTION
This PR removes highlighting from `ListWrapper`. You want this on the view, not the wrapper view.