### PR TITLE
Fix selected background view for list wrapper

### DIFF
--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -8,6 +8,7 @@ class ListWrapper: UITableViewCell, Wrappable, Cell {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
     backgroundColor = .clear
+    selectedBackgroundView = UIView()
   }
   
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This solves the same thing as #493 but in a better way. In #493 we screw with the state of the view which has some bad implications when we pass the state to the views.