### PR TITLE
Fix missing configure method

### DIFF
--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -13,6 +13,8 @@ extension DataSource {
         if spot.component.items[index].size.height == 0.0 {
           spot.component.items[index].size = configurableView.preferredViewSize
         }
+
+        spot.configure?(configurableView)
       } else {
         spot.component.items[index].size.height = wrappedView.frame.size.height
       }


### PR DESCRIPTION
This is a minor fix, it will run the configuration closure on the wrapped view if it is `ItemConfigurable`.