### PR TITLE
ListSpotCell: Add accessibility support

### DIFF
--- a/Sources/iOS/Classes/ListSpotCell.swift
+++ b/Sources/iOS/Classes/ListSpotCell.swift
@@ -1,6 +1,10 @@
 import UIKit
 
 /// A boilerplate cell for ListSpot
+///
+/// Accessibility: This class is per default an accessibility element, and gets its attributes
+/// from any `Item` that it's configured with. You can override this behavior at any point, and
+/// disable accessibility by setting `isAccessibilityElement = false` on the cell.
 open class ListSpotCell: UITableViewCell, ItemConfigurable {
 
   /// The preferred view size for the view, width will be ignored for ListSpot cells
@@ -16,6 +20,7 @@ open class ListSpotCell: UITableViewCell, ItemConfigurable {
   /// - returns: An initialized UITableViewCell object or nil if the object could not be created.
   public override init(style: UITableViewCellStyle, reuseIdentifier: String!) {
     super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+    isAccessibilityElement = true
   }
 
   /// Init with coder
@@ -41,5 +46,16 @@ open class ListSpotCell: UITableViewCell, ItemConfigurable {
 
     item.size.height = item.size.height > 0.0 ? item.size.height : preferredViewSize.height
     self.item = item
+
+    assignAccesibilityAttributes(from: item)
+  }
+
+  private func assignAccesibilityAttributes(from item: Item) {
+    guard isAccessibilityElement else {
+      return
+    }
+
+    accessibilityIdentifier = item.title
+    accessibilityLabel = item.title + "." + item.subtitle
   }
 }

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -81,4 +81,24 @@ class ListSpotTests: XCTestCase {
     }
     XCTAssertEqual(invokeCount, 2)
   }
+
+  func testAccessibilityForDefaultCells() {
+    let cell = ListSpotCell(style: .default, reuseIdentifier: "reuse")
+    var item = Item(title: "Title", subtitle: "Subtitle")
+    cell.configure(&item)
+
+    XCTAssertTrue(cell.isAccessibilityElement)
+    XCTAssertEqual(cell.accessibilityIdentifier, "Title")
+    XCTAssertEqual(cell.accessibilityLabel, "Title.Subtitle")
+
+    // If disabling accessibility, properties should not be set when reconfiguring the cell
+    cell.isAccessibilityElement = false
+    cell.accessibilityIdentifier = nil
+    cell.accessibilityLabel = nil
+    cell.configure(&item)
+
+    XCTAssertFalse(cell.isAccessibilityElement)
+    XCTAssertNil(cell.accessibilityIdentifier)
+    XCTAssertNil(cell.accessibilityLabel)
+  }
 }


### PR DESCRIPTION
Per default, `ListSpotCell` is now made accessible - by using its `item`’s title and subtitle to form an `accessibilityLabel`. The `title` is used for the identifier, which an be used to perform UI tests. This behavior is opt-out, by setting `isAccessibilityElement` to `false`.