### PR TITLE
Run bundle update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 
 before_install:
   - bundle install
-  - brew install swiftlint
   - travis_wait 35; bin/bootstrap-if-needed
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ cache:
   - Carthage
 
 before_install:
-- travis_wait 35; bin/bootstrap-if-needed
+  - bundle install
+  - brew install swiftlint
+  - travis_wait 35; bin/bootstrap-if-needed
 
 script:
 - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GEM
       nap
       open4 (~> 1.3)
     colored (1.2)
-    colored2 (3.1.1)
+    colored2 (3.1.2)
     cork (0.2.0)
       colored (~> 1.2)
-    danger (4.2.1)
+    danger (4.3.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -49,4 +49,4 @@ DEPENDENCIES
   danger
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,5 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build | xcpretty
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
   post:
     - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   override:
     - bin/bootstrap-if-needed
+    - bundle install
     - brew install swiftlint
   cache_directories:
     - "Carthage"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  xcode:
+    version: "8.2.1"
+
+dependencies:
+  override:
+    - bin/bootstrap-if-needed
+    - brew install swiftlint
+  cache_directories:
+    - "Carthage"
+
+test:
+  override:
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
+  post:
+    - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Circle CI failed with:

> Your bundle is locked to colored2 (3.1.1), but that version could not be found
in any of the sources listed in your Gemfile. If you haven't changed sources,
that means the author of colored2 (3.1.1) has removed it. You'll need to update
your bundle to a different version of colored2 (3.1.1) that hasn't been removed
in order to install.

So this PR runs `bundle update` in hopes that it might fix the issue.