### PR TITLE
Optimize prepare(items:) method

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -106,42 +106,19 @@ public extension Spotable {
     var preparedItems = items
     var spanWidth: CGFloat?
 
-    if let layout = component.layout {
-      if layout.span > 0.0 {
-        #if os(OSX)
-          if let gridable = self as? Gridable,
-            let layout = gridable.layout as? FlowLayout,
-            let componentLayout = component.layout {
-            let newWidth = gridable.collectionView.frame.width / CGFloat(componentLayout.span) - layout.sectionInset.left - layout.sectionInset.right
+    if let layout = component.layout, layout.span > 0.0 {
+      var spotWidth: CGFloat = view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
 
-            if newWidth > 0.0 {
-              spanWidth = newWidth
-            }
-          } else if let spot = self as? Spot,
-            let layout = spot.collectionView?.collectionViewLayout as? FlowLayout,
-            let componentLayout = component.layout {
-            let newWidth = spot.view.frame.width / CGFloat(componentLayout.span) - layout.sectionInset.left - layout.sectionInset.right
+      #if !os(OSX)
+        if view.frame.size.width == 0.0 {
+          spotWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
+        }
+      #endif
 
-            if newWidth > 0.0 {
-              spanWidth = newWidth
-            }
-          }
-        #else
-          var spotWidth: CGFloat
-
-          if view.frame.size.width == 0.0 {
-            spotWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
-          } else {
-            spotWidth = view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
-          }
-
-          spanWidth = (spotWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
-        #endif
-      }
+      spanWidth = (spotWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in
-
       if let configuredItem = configure(item: item, at: index, usesViewSize: true) {
         preparedItems[index].index = index
         preparedItems[index] = configuredItem


### PR DESCRIPTION
This PR improves the performance of the prepare items methods as we no longer do unnecessary computation when calculating the width of the items when using span.

So instead of running the calculation for each item, it will no do the calculation once, store the value and use that in the for loop.

It also reduces the amount of preprocessors used.