### PR TITLE
Refactor prepare item methods to make it a tinsy bit smarter

### DIFF
--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -119,13 +119,14 @@ public extension Spotable {
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in
+      var item = item
+      if let spanWidth = spanWidth {
+        item.size.width = spanWidth
+      }
+
       if let configuredItem = configure(item: item, at: index, usesViewSize: true) {
         preparedItems[index].index = index
         preparedItems[index] = configuredItem
-      }
-
-      if let spanWidth = spanWidth {
-        preparedItems[index].size.width = spanWidth
       }
     }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -273,12 +273,6 @@ public extension Spotable {
       }
     #endif
 
-    if let layout = component.layout, index < component.items.count && index > -1 &&
-      self is Gridable &&
-      (layout.span > 0.0 || item.size.width == 0) && fullWidth > 0.0 {
-      item.size.width = fullWidth / CGFloat(layout.span)
-    }
-
     return item
   }
 

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -223,8 +223,13 @@ public extension Spotable {
     var item = item
     item.index = index
 
+    var fullWidth: CGFloat = item.size.width
+
     #if !os(OSX)
-      let fullWidth: CGFloat = UIScreen.main.bounds.width
+      if fullWidth == 0.0 {
+        fullWidth = UIScreen.main.bounds.width
+      }
+
       let kind = identifier(at: index)
       let view: View?
 
@@ -243,7 +248,10 @@ public extension Spotable {
       prepare(kind: kind, view: view as Any, item: &item)
     #else
       let spotableKind = self
-      let fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
+
+      if fullWidth == 0.0 {
+        fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
+      }
 
       switch spotableKind {
       case let grid as Gridable:


### PR DESCRIPTION
This PR refactor the prepare method when using `span`. It will now directly assign the size that it gets back to the item instead of using the fallback size which usually ends up being the screen size. It also removes some redundant code that was applying the span width twice.