### PR TITLE
Feature list spot implementation for macOS

### DIFF
--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -1,0 +1,54 @@
+import Cocoa
+
+public class GridableLayout: FlowLayout {
+
+  public var contentSize = CGSize.zero
+
+  open override var collectionViewContentSize: CGSize {
+    if scrollDirection != .horizontal {
+      contentSize.height = super.collectionViewContentSize.height
+    }
+
+    return contentSize
+  }
+
+  open override func prepare() {
+    guard let delegate = collectionView?.delegate as? Delegate,
+      let spot = delegate.spot
+      else {
+        return
+    }
+
+    super.prepare()
+
+    switch scrollDirection {
+    case .horizontal:
+      guard let firstItem = spot.items.first else { return }
+
+      contentSize.width = spot.items.reduce(0, { $0 + floor($1.size.width) })
+      contentSize.width += minimumInteritemSpacing * CGFloat(spot.items.count - 1)
+
+      contentSize.height = firstItem.size.height
+    case .vertical:
+      contentSize.width = spot.view.frame.width
+      contentSize.height = super.collectionViewContentSize.height
+    }
+  }
+
+  public override func shouldInvalidateLayout(forBoundsChange newBounds: NSRect) -> Bool {
+    guard let collectionView = collectionView,
+      let delegate = collectionView.delegate as? Delegate,
+      let spot = delegate.spot else {
+        return false
+    }
+
+    var offset: CGFloat = 0.0
+    if let spot = spot as? Spot {
+      offset += spot.headerHeight + spot.footerHeight
+    }
+
+    let shouldInvalidateLayout = newBounds.size.height != collectionView.frame.height + offset
+
+    return shouldInvalidateLayout
+  }
+}

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -75,11 +75,8 @@ public class Spot: NSObject, Spotable {
     }
   }
 
-  open lazy var scrollView: ScrollView = {
-    let scrollView = ScrollView()
-    scrollView.documentView = NSView()
-    return scrollView
-  }()
+  open lazy var scrollView: ScrollView = ScrollView(documentView: self.documentView)
+  open lazy var documentView: FlippedView = FlippedView()
 
   public var view: ScrollView {
     return scrollView

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -171,7 +171,19 @@ public class Spot: NSObject, Spotable {
   }
 
   public func setup(_ size: CGSize) {
+    type(of: self).configure?(view)
 
+    scrollView.frame.size = size
+
+    if let tableView = self.tableView {
+      documentView.addSubview(tableView)
+      setupTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      documentView.addSubview(collectionView)
+      setupCollectionView(collectionView, with: size)
+    }
+
+    layout(size)
   }
 
   public func layout(_ size: CGSize) {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -254,7 +254,16 @@ public class Spot: NSObject, Spotable {
   }
 
   fileprivate func layoutTableView(_ tableView: TableView, with size: CGSize) {
+    tableView.frame.origin.y = headerHeight
+    tableView.sizeToFit()
+    tableView.frame.size.width = size.width
 
+    if let layout = component.layout {
+      tableView.frame.origin.x = CGFloat(layout.inset.left)
+      tableView.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
+    }
+
+    scrollView.frame.size.height = tableView.frame.height + headerHeight + footerHeight
   }
 
   fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -282,28 +282,8 @@ public class Spot: NSObject, Spotable {
 
   }
 
-  fileprivate static func setupLayout(_ component: Component) -> NSCollectionViewLayout {
-    let layout: NSCollectionViewLayout
-
-    switch LayoutType(rawValue: component.meta(Key.layout, Default.defaultLayout)) ?? LayoutType.flow {
-    case .grid:
-      let gridLayout = NSCollectionViewGridLayout()
-
-      gridLayout.maximumItemSize = CGSize(width: component.meta(Key.gridLayoutMaximumItemWidth, Default.gridLayoutMaximumItemWidth),
-                                          height: component.meta(Key.gridLayoutMaximumItemHeight, Default.gridLayoutMaximumItemHeight))
-      gridLayout.minimumItemSize = CGSize(width: component.meta(Key.gridLayoutMinimumItemWidth, Default.gridLayoutMinimumItemWidth),
-                                          height: component.meta(Key.gridLayoutMinimumItemHeight, Default.gridLayoutMinimumItemHeight))
-      layout = gridLayout
-    case .left:
-      let leftLayout = CollectionViewLeftLayout()
-      layout = leftLayout
-    default:
-      let flowLayout = GridableLayout()
-      flowLayout.scrollDirection = .vertical
-      layout = flowLayout
     }
 
-    return layout
   }
 
   public func register() {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -282,7 +282,21 @@ public class Spot: NSObject, Spotable {
 
   }
 
+  func registerDefaultIfNeeded(view: View.Type) {
+    guard Configuration.views.storage[Configuration.views.defaultIdentifier] == nil else {
+      return
     }
+
+    Configuration.views.defaultItem = Registry.Item.classType(view)
+  }
+
+  open func doubleAction(_ sender: Any?) {
+    guard let tableView = tableView,
+      let item = item(at: tableView.clickedRow) else {
+      return
+    }
+    delegate?.spotable(self, itemSelected: item)
+  }
 
   }
 

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -197,7 +197,43 @@ public class Spot: NSObject, Spotable {
   }
 
   fileprivate func setupTableView(_ tableView: TableView, with size: CGSize) {
+    scrollView.addSubview(tableView)
 
+    component.items.enumerated().forEach {
+      component.items[$0.offset].size.width = size.width
+    }
+
+    tableView.frame.size = size
+
+    prepareItems()
+
+    tableView.dataSource = spotDataSource
+    tableView.delegate = spotDelegate
+    tableView.backgroundColor = NSColor.clear
+    tableView.allowsColumnReordering = false
+    tableView.allowsColumnResizing = false
+    tableView.allowsColumnSelection = false
+    tableView.allowsEmptySelection = true
+    tableView.allowsMultipleSelection = false
+    tableView.headerView = nil
+    tableView.selectionHighlightStyle = .none
+    tableView.allowsTypeSelect = true
+    tableView.focusRingType = .none
+    tableView.target = self
+    tableView.action = #selector(self.action(_:))
+    tableView.doubleAction = #selector(self.doubleAction(_:))
+    tableView.sizeToFit()
+
+    guard tableView.tableColumns.isEmpty else {
+      return
+    }
+
+    let column = NSTableColumn(identifier: "tableview-column")
+    column.maxWidth = 250
+    column.width = 250
+    column.minWidth = 150
+
+    tableView.addTableColumn(column)
   }
 
   fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -298,6 +298,12 @@ public class Spot: NSObject, Spotable {
     delegate?.spotable(self, itemSelected: item)
   }
 
+  open func action(_ sender: Any?) {
+    guard let tableView = tableView,
+      let item = item(at: tableView.clickedRow) else {
+        return
+    }
+    delegate?.spotable(self, itemSelected: item)
   }
 
   public func register() {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -187,7 +187,13 @@ public class Spot: NSObject, Spotable {
   }
 
   public func layout(_ size: CGSize) {
+    if let tableView = self.tableView {
+      layoutTableView(tableView, with: size)
+    } else if let collectionView = self.collectionView {
+      layoutCollectionView(collectionView, with: size)
+    }
 
+    view.layoutSubviews()
   }
 
   fileprivate func setupTableView(_ tableView: TableView, with size: CGSize) {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -203,6 +203,30 @@ public class Spot: NSObject, Spotable {
 
   }
 
+  fileprivate static func setupLayout(_ component: Component) -> NSCollectionViewLayout {
+    let layout: NSCollectionViewLayout
+
+    switch LayoutType(rawValue: component.meta(Key.layout, Default.defaultLayout)) ?? LayoutType.flow {
+    case .grid:
+      let gridLayout = NSCollectionViewGridLayout()
+
+      gridLayout.maximumItemSize = CGSize(width: component.meta(Key.gridLayoutMaximumItemWidth, Default.gridLayoutMaximumItemWidth),
+                                          height: component.meta(Key.gridLayoutMaximumItemHeight, Default.gridLayoutMaximumItemHeight))
+      gridLayout.minimumItemSize = CGSize(width: component.meta(Key.gridLayoutMinimumItemWidth, Default.gridLayoutMinimumItemWidth),
+                                          height: component.meta(Key.gridLayoutMinimumItemHeight, Default.gridLayoutMinimumItemHeight))
+      layout = gridLayout
+    case .left:
+      let leftLayout = CollectionViewLeftLayout()
+      layout = leftLayout
+    default:
+      let flowLayout = GridableLayout()
+      flowLayout.scrollDirection = .vertical
+      layout = flowLayout
+    }
+
+    return layout
+  }
+
   public func register() {
 
   }

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -124,6 +124,13 @@ public class Spot: NSObject, Spotable {
     }
   }
 
+  public convenience init(cacheKey: String) {
+    let stateCache = StateCache(key: cacheKey)
+
+    self.init(component: Component(stateCache.load()))
+    self.stateCache = stateCache
+  }
+
   deinit {
     spotDataSource = nil
     spotDelegate = nil

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -18,6 +18,9 @@ public class Spot: NSObject, Spotable {
   var headerView: View?
   var footerView: View?
 
+  var headerHeight = CGFloat(0.0)
+  var footerHeight = CGFloat(0.0)
+
   public var component: Component
   public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -15,6 +15,9 @@ public class Spot: NSObject, Spotable {
   weak public var focusDelegate: SpotsFocusDelegate?
   weak public var delegate: SpotsDelegate?
 
+  var headerView: View?
+  var footerView: View?
+
   public var component: Component
   public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []

--- a/Sources/macOS/Extensions/NSScrollView+Extensions.swift
+++ b/Sources/macOS/Extensions/NSScrollView+Extensions.swift
@@ -2,6 +2,11 @@ import Cocoa
 
 extension NSScrollView {
 
+  convenience init(documentView: View?) {
+    self.init()
+    self.documentView = documentView
+  }
+
   public var contentOffset: CGPoint {
     get {
       return documentVisibleRect.origin

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
+		BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A361E6EAAA60023AF82 /* TestSpot.swift */; };
 		BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
@@ -418,6 +419,7 @@
 		BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListComposite.swift; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		BD165A361E6EAAA60023AF82 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
@@ -966,6 +968,7 @@
 			children = (
 				BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */,
 				BD45D98E1E30935500C2D6B2 /* TestLayoutExtensions.swift */,
+				BD165A361E6EAAA60023AF82 /* TestSpot.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -1929,6 +1932,7 @@
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
+				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BD45D9881E30906300C2D6B2 /* TestLayout.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A361E6EAAA60023AF82 /* TestSpot.swift */; };
 		BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A381E6EAD750023AF82 /* HelperViews.swift */; };
+		BD165A3B1E6EAF310023AF82 /* GridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */; };
 		BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
@@ -422,6 +423,7 @@
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD165A361E6EAAA60023AF82 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD165A381E6EAD750023AF82 /* HelperViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelperViews.swift; sourceTree = "<group>"; };
+		BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridableLayout.swift; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
@@ -782,6 +784,7 @@
 				BD2403101E4B9A02005BAA19 /* Spot.swift */,
 				BDAD84F71E3E7025008289AE /* SpotsContentView.swift */,
 				BDAD84F81E3E7025008289AE /* SpotsScrollView.swift */,
+				BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1875,6 +1878,7 @@
 				BDAD85E21E3E7032008289AE /* Interaction.swift in Sources */,
 				BDAD85D61E3E7032008289AE /* Configuration.swift in Sources */,
 				BDAD85C41E3E7032008289AE /* SpotsFocusDelegate.swift in Sources */,
+				BD165A3B1E6EAF310023AF82 /* GridableLayout.swift in Sources */,
 				BDAD857F1E3E7032008289AE /* Gridable+Extensions.swift in Sources */,
 				D5D282701E5474E0004BF251 /* Cell.swift in Sources */,
 				BDAD85B81E3E7032008289AE /* ScrollDelegate.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A361E6EAAA60023AF82 /* TestSpot.swift */; };
+		BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A381E6EAD750023AF82 /* HelperViews.swift */; };
 		BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
 		BD21C2561E4358CF00FE2B26 /* TestGridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */; };
@@ -420,6 +421,7 @@
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD165A361E6EAAA60023AF82 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
+		BD165A381E6EAD750023AF82 /* HelperViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelperViews.swift; sourceTree = "<group>"; };
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Spot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spot.swift; sourceTree = "<group>"; };
@@ -969,6 +971,7 @@
 				BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */,
 				BD45D98E1E30935500C2D6B2 /* TestLayoutExtensions.swift */,
 				BD165A361E6EAAA60023AF82 /* TestSpot.swift */,
+				BD165A381E6EAD750023AF82 /* HelperViews.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -1930,6 +1933,7 @@
 				D58478E71C440645006EBA49 /* TestComponent.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
+				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestSpotable.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
 				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,

--- a/SpotsTests/macOS/HelperViews.swift
+++ b/SpotsTests/macOS/HelperViews.swift
@@ -1,0 +1,120 @@
+import Cocoa
+import Spots
+
+class HeaderView: NSView, ItemConfigurable, Componentable {
+
+  var preferredHeaderHeight: CGFloat = 50
+  var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+  lazy var titleLabel: NSTextField = {
+    let label = NSTextField()
+    return label
+  }()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    addSubview(titleLabel)
+
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.gray.withAlphaComponent(0.25).cgColor
+
+    configureConstraints()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configureConstraints() {
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+    titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+    titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+    titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+  }
+
+  func configure(_ item: inout Item) {
+    titleLabel.stringValue = item.title
+  }
+
+  func configure(_ component: Component) {
+    titleLabel.stringValue = component.title
+  }
+}
+
+class TextView: NSView, ItemConfigurable {
+
+  var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+  lazy var titleLabel: NSTextField = {
+    let label = NSTextField()
+    return label
+  }()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    addSubview(titleLabel)
+
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.gray.withAlphaComponent(0.25).cgColor
+
+    configureConstraints()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configureConstraints() {
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+    titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+    titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+    titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+  }
+
+  func configure(_ item: inout Item) {
+    titleLabel.stringValue = item.title
+  }
+}
+
+class FooterView: NSView, ItemConfigurable, Componentable {
+
+  var preferredHeaderHeight: CGFloat = 50
+  var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+  lazy var titleLabel: NSTextField = {
+    let label = NSTextField()
+    return label
+  }()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    addSubview(titleLabel)
+
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.gray.withAlphaComponent(0.25).cgColor
+
+    configureConstraints()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configureConstraints() {
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    titleLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+    titleLabel.leftAnchor.constraint(equalTo: titleLabel.superview!.leftAnchor).isActive = true
+    titleLabel.rightAnchor.constraint(equalTo: titleLabel.superview!.rightAnchor).isActive = true
+    titleLabel.centerYAnchor.constraint(equalTo: titleLabel.superview!.centerYAnchor).isActive = true
+  }
+
+  func configure(_ item: inout Item) {
+    titleLabel.stringValue = item.title
+  }
+
+  func configure(_ component: Component) {
+    titleLabel.stringValue = component.title
+  }
+}

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -1,0 +1,117 @@
+@testable import Spots
+import XCTest
+
+class TestSpot: XCTestCase {
+
+  override func setUp() {
+    Configuration.views.storage = [:]
+    Configuration.views.defaultItem = nil
+    Configuration.register(view: HeaderView.self, identifier: "Header")
+    Configuration.register(view: TextView.self, identifier: "TextView")
+    Configuration.register(view: FooterView.self, identifier: "Footer")
+  }
+
+  func testDefaultValues() {
+    let items = [Item(title: "A"), Item(title: "B")]
+    let component = Component(items: items, hybrid: true)
+    let spot = Spot(component: component)
+
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertNotNil(spot.view)
+    XCTAssertNotNil(spot.tableView)
+    XCTAssertEqual(spot.items[0].size, CGSize(width: 100, height: 88))
+    XCTAssertEqual(spot.items[1].size, CGSize(width: 100, height: 88))
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 180))
+    let expectedContentSizeHeight: CGFloat = 180
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: expectedContentSizeHeight))
+  }
+
+  func testSpotCache() {
+    let item = Item(title: "test")
+    let spot = Spot(cacheKey: "test-spot-cache")
+
+    XCTAssertEqual(spot.component.items.count, 0)
+    spot.append(item) {
+      spot.cache()
+    }
+
+    let expectation = self.expectation(description: "Wait for cache")
+    Dispatch.after(seconds: 2.5) {
+      guard let cacheKey = spot.stateCache?.key else {
+        XCTFail()
+        return
+      }
+
+      let cachedSpot = Spot(cacheKey: cacheKey)
+      XCTAssertEqual(cachedSpot.component.items[0].title, "test")
+      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      cachedSpot.stateCache?.clear()
+      expectation.fulfill()
+
+      cachedSpot.stateCache?.clear()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testHybridListSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.list.string,
+      items: [
+        Item(title: "A"),
+        Item(title: "B"),
+        Item(title: "C"),
+        Item(title: "D")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 460))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 460))
+  }
+
+  func testHybridGridSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.grid.string,
+      items: [
+        Item(title: "A", kind: "TextView"),
+        Item(title: "B", kind: "TextView"),
+        Item(title: "C", kind: "TextView"),
+        Item(title: "D", kind: "TextView")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.collectionView?.collectionViewLayout?.collectionViewContentSize, CGSize(width: 100, height: 200))
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 300))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 300))
+  }
+
+  func testHybridCarouselSpotWithHeaderAndFooter() {
+    let component = Component(
+      header: "Header",
+      footer: "Footer",
+      kind: Component.Kind.carousel.string,
+      items: [
+        Item(title: "A", kind: "TextView"),
+        Item(title: "B", kind: "TextView"),
+        Item(title: "C", kind: "TextView"),
+        Item(title: "D", kind: "TextView")
+      ],
+      hybrid: true
+    )
+    let spot = Spot(component: component)
+    spot.setup(CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 150))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 150))
+  }
+}

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -70,48 +70,7 @@ class TestSpot: XCTestCase {
     let spot = Spot(component: component)
     spot.setup(CGSize(width: 100, height: 100))
 
-    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 460))
-    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 460))
-  }
-
-  func testHybridGridSpotWithHeaderAndFooter() {
-    let component = Component(
-      header: "Header",
-      footer: "Footer",
-      kind: Component.Kind.grid.string,
-      items: [
-        Item(title: "A", kind: "TextView"),
-        Item(title: "B", kind: "TextView"),
-        Item(title: "C", kind: "TextView"),
-        Item(title: "D", kind: "TextView")
-      ],
-      hybrid: true
-    )
-    let spot = Spot(component: component)
-    spot.setup(CGSize(width: 100, height: 100))
-
-    XCTAssertEqual(spot.collectionView?.collectionViewLayout?.collectionViewContentSize, CGSize(width: 100, height: 200))
-    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 300))
-    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 300))
-  }
-
-  func testHybridCarouselSpotWithHeaderAndFooter() {
-    let component = Component(
-      header: "Header",
-      footer: "Footer",
-      kind: Component.Kind.carousel.string,
-      items: [
-        Item(title: "A", kind: "TextView"),
-        Item(title: "B", kind: "TextView"),
-        Item(title: "C", kind: "TextView"),
-        Item(title: "D", kind: "TextView")
-      ],
-      hybrid: true
-    )
-    let spot = Spot(component: component)
-    spot.setup(CGSize(width: 100, height: 100))
-
-    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 150))
-    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 150))
+    XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 360))
+    XCTAssertEqual(spot.view.contentSize, CGSize(width: 100, height: 360))
   }
 }


### PR DESCRIPTION
This is the first PR for implementing `Spot` on `macOS`.
The implementation is inspired by the `iOS`, `tvOS` equivalent with a more handy `init` method. Right now this PR only supports `.list`, the other variants of `Spot` will be added later.

This PR also adds `GridableLayout` to `macOS`, it is not currently used in this PR (whoops), but I intended to add implementations for `Grid` and `Carousel` as a follow up to this one.

It also adds some helper views that will be used in tests.