### PR TITLE
⚠️ Rename ItemConfigurable to ContentConfigurable ⚠️ 

### DIFF
--- a/Playgrounds/Playground-iOS.playground/Contents.swift
+++ b/Playgrounds/Playground-iOS.playground/Contents.swift
@@ -12,7 +12,7 @@ enum Cell: String, StringConvertible {
   }
 }
 
-public class ListCell: UITableViewCell, ItemConfigurable {
+public class ListCell: UITableViewCell, ContentConfigurable {
 
   public var preferredViewSize: CGSize(width: 0, height: 60)
   public var item: Item?
@@ -96,7 +96,7 @@ public class ListHeaderView: UIView, Componentable {
   }
 }
 
-class GridTopicCell: UICollectionViewCell, ItemConfigurable {
+class GridTopicCell: UICollectionViewCell, ContentConfigurable {
 
   var preferredViewSize: CGSize(width: 125, height: 160)
 
@@ -225,4 +225,4 @@ let controller = Controller(spots: [
   ]
 )
 
-XCPlaygroundPage.currentPage.liveView = controller.view
+XCPlaygroundPage.currentPage.liveView = controller

--- a/Playgrounds/Playground-iOS.playground/timeline.xctimeline
+++ b/Playgrounds/Playground-iOS.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7207&amp;EndingColumnNumber=16&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=508426754.737302"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7213&amp;EndingColumnNumber=16&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=510580573.357537"
          lockedSize = "{357, 436}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ What all **Spotable** objects have in common is that all of them use the same **
 They also share the same **Item** struct for its children.
 The child is a data container that includes the size of the view on screen and the remaining information to configure your view.
 
-To add your own view to **Spots**, you need the view to conform to **ItemConfigurable** and inherit from the core class that your component is based on (UITableViewCell on ListSpot, UICollectionViewCell on CarouselSpot and GridSpot).
-**ItemConfigurable** requires you to implement one property and one method.
+To add your own view to **Spots**, you need the view to conform to **ContentConfigurable** and inherit from the core class that your component is based on (UITableViewCell on ListSpot, UICollectionViewCell on CarouselSpot and GridSpot).
+**ContentConfigurable** requires you to implement one property and one method.
 
 We don’t like to dictate the terms of how you build your views, if you prefer to build them using `.nib` files, you should be free to do so, and with **Spots** you can. The only thing that differs is how you register the view on the component.
 
@@ -191,7 +191,7 @@ func configure(inout item: Item) {
 
 **Item** is a struct, but because of the **inout** keyword in the method declaration it can perform mutation and pass that back to the data source. If you prefer the size to be static, you can simply not set the height and **Spots** will handle setting it for you based on the **preferredViewSize**.
 
-When your view conforms to **ItemConfigurable**, you need to register it with a unique identifier for that view.
+When your view conforms to **ContentConfigurable**, you need to register it with a unique identifier for that view.
 
 You register your view on the component that you want to display it in.
 

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -32,7 +32,7 @@ open class ViewSpot: NSObject, Spotable, Viewable {
   open weak var delegate: SpotsDelegate?
   open var component: Component
   open var index = 0
-  open var configure: ((ItemConfigurable) -> Void)?
+  open var configure: ((ContentConfigurable) -> Void)?
 
   /// A SpotsFocusDelegate object
   weak public var focusDelegate: SpotsFocusDelegate?

--- a/Sources/Shared/Extensions/ContentConfigurable+Extensions.swift
+++ b/Sources/Shared/Extensions/ContentConfigurable+Extensions.swift
@@ -1,0 +1,4 @@
+public extension ContentConfigurable {
+
+  func prepareForReuse() {}
+}

--- a/Sources/Shared/Extensions/ItemConfigurable+Extensions.swift
+++ b/Sources/Shared/Extensions/ItemConfigurable+Extensions.swift
@@ -1,4 +1,0 @@
-public extension ItemConfigurable {
-
-  func prepareForReuse() {}
-}

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -68,10 +68,10 @@ public extension Spotable {
 
     userInterface?.visibleViews.forEach { view in
       switch view {
-      case let view as ItemConfigurable:
+      case let view as ContentConfigurable:
         configure(view)
       case let view as Wrappable:
-        if let wrappedView = view.wrappedView as? ItemConfigurable {
+        if let wrappedView = view.wrappedView as? ContentConfigurable {
           configure(wrappedView)
         }
       default:
@@ -289,7 +289,7 @@ public extension Spotable {
     switch view {
     case let view as Composable:
       prepare(composable: view, item: &item)
-    case let view as ItemConfigurable:
+    case let view as ContentConfigurable:
       view.configure(&item)
       setFallbackViewSize(to: &item, with: view)
     default:
@@ -305,7 +305,7 @@ public extension Spotable {
     // Set initial size for view
     view.frame.size.width = view.frame.size.width
 
-    if let itemConfigurable = view as? ItemConfigurable, view.frame.size.height == 0.0 {
+    if let itemConfigurable = view as? ContentConfigurable, view.frame.size.height == 0.0 {
       view.frame.size = itemConfigurable.preferredViewSize
     }
 
@@ -372,7 +372,7 @@ public extension Spotable {
   /// - Parameters:
   ///   - item: The item struct that is being configured.
   ///   - view: The view used for fallback size for the item.
-  private func setFallbackViewSize(to item: inout Item, with view: ItemConfigurable) {
+  private func setFallbackViewSize(to item: inout Item, with view: ContentConfigurable) {
     let hasExplicitHeight: Bool = item.size.height == 0.0
 
     if hasExplicitHeight {

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -297,7 +297,7 @@ public extension Spotable {
         let newItem = weakSelf.items[index]
 
         if newItem.kind != oldItem.kind || newItem.size.height != oldItem.size.height {
-          if let cell: ItemConfigurable = weakSelf.userInterface?.view(at: index), animation != .none {
+          if let cell: ContentConfigurable = weakSelf.userInterface?.view(at: index), animation != .none {
             weakSelf.userInterface?.beginUpdates()
             cell.configure(&weakSelf.items[index])
             weakSelf.userInterface?.endUpdates()
@@ -310,7 +310,7 @@ public extension Spotable {
             completion?()
           }
           return
-        } else if let cell: ItemConfigurable = weakSelf.userInterface?.view(at: index) {
+        } else if let cell: ContentConfigurable = weakSelf.userInterface?.view(at: index) {
           cell.configure(&weakSelf.items[index])
           weakSelf.view.superview?.layoutSubviews()
           completion?()

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -38,7 +38,7 @@ public extension Spotable where Self : Viewable {
       if case let Registry.Item.classType(classType)? = T.views.storage[item.kind], T.views.storage.keys.contains(item.kind) {
         let view = classType.init()
 
-        if let itemConfigurable = view as? ItemConfigurable {
+        if let itemConfigurable = view as? ContentConfigurable {
           itemConfigurable.configure(&component.items[index])
           view.frame.size = itemConfigurable.preferredViewSize
         }
@@ -73,8 +73,8 @@ public extension Spotable where Self : Viewable {
     guard case let Registry.Item.classType(classType)? = dynamic.views.storage[item.kind], dynamic.views.storage.keys.contains(item.kind) else { return }
 
     let view = classType.init()
-    (view as? ItemConfigurable)?.configure(&component.items[index])
-    if let size = (view as? ItemConfigurable)?.preferredViewSize {
+    (view as? ContentConfigurable)?.configure(&component.items[index])
+    if let size = (view as? ContentConfigurable)?.preferredViewSize {
       view.frame.size = size
     }
 
@@ -94,8 +94,8 @@ public extension Spotable where Self : Viewable {
       guard case let Registry.Item.classType(classType)? = dynamic.views.storage[item.kind], dynamic.views.storage.keys.contains(item.kind) else { return }
 
       let view = classType.init()
-      (view as? ItemConfigurable)?.configure(&component.items[index])
-      if let size = (view as? ItemConfigurable)?.preferredViewSize {
+      (view as? ContentConfigurable)?.configure(&component.items[index])
+      if let size = (view as? ContentConfigurable)?.preferredViewSize {
         view.frame.size = size
       }
 
@@ -116,8 +116,8 @@ public extension Spotable where Self : Viewable {
     guard case let Registry.Item.classType(classType)? = dynamic.views.storage[item.kind], dynamic.views.storage.keys.contains(item.kind) else { return }
 
     let view = classType.init()
-    (view as? ItemConfigurable)?.configure(&component.items[index])
-    if let size = (view as? ItemConfigurable)?.preferredViewSize {
+    (view as? ContentConfigurable)?.configure(&component.items[index])
+    if let size = (view as? ContentConfigurable)?.preferredViewSize {
       view.frame.size = size
     }
     #if os(iOS)
@@ -140,8 +140,8 @@ public extension Spotable where Self : Viewable {
       guard case let Registry.Item.classType(classType)? = dynamic.views.storage[item.kind], dynamic.views.storage.keys.contains(item.kind) else { return }
 
       let view = classType.init()
-      (view as? ItemConfigurable)?.configure(&component.items[index])
-      if let size = (view as? ItemConfigurable)?.preferredViewSize {
+      (view as? ContentConfigurable)?.configure(&component.items[index])
+      if let size = (view as? ContentConfigurable)?.preferredViewSize {
         view.frame.size = size
       }
       #if os(iOS)
@@ -158,7 +158,7 @@ public extension Spotable where Self : Viewable {
   /// - parameter animation:  A Animation that is used when performing the mutation (currently not in use).
   /// - parameter completion: A completion closure that is executed in the main queue when the view model has been removed.
   func update(_ item: Item, index: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    guard let view = scrollView.subviews[index] as? ItemConfigurable else { return }
+    guard let view = scrollView.subviews[index] as? ContentConfigurable else { return }
 
     component.items[index] = item
     view.configure(&component.items[index])

--- a/Sources/Shared/Protocols/ContentConfigurable.swift
+++ b/Sources/Shared/Protocols/ContentConfigurable.swift
@@ -3,7 +3,7 @@ import CoreGraphics
 /**
   A class protocol that requires configure(item: Item), it can be applied to UI components to annotate that they are intended to use Item.
  */
-public protocol ItemConfigurable: class {
+public protocol ContentConfigurable: class {
 
   /// The perferred view size of the view.
   var preferredViewSize: CGSize { get }
@@ -11,7 +11,7 @@ public protocol ItemConfigurable: class {
   /**
    A configure method that is used on reference types that can be configured using a view model
 
-   - parameter item: A inout Item so that the ItemConfigurable object can configure the view model width and height based on its UI components
+   - parameter item: A inout Item so that the ContentConfigurable object can configure the view model width and height based on its UI components
   */
   func configure(_ item: inout Item)
 

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -30,8 +30,8 @@ public protocol Spotable: class {
   var computedHeight: CGFloat { get }
   /// The component of a Spotable object
   var component: Component { get set }
-  /// A configuration closure for a ItemConfigurable object
-  var configure: ((ItemConfigurable) -> Void)? { get set }
+  /// A configuration closure for a ContentConfigurable object
+  var configure: ((ContentConfigurable) -> Void)? { get set }
   /// A cache for a Spotable object
   var stateCache: StateCache? { get }
   /// Indicator to calculate the height based on content

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -87,7 +87,7 @@ public struct Registry {
       #if !os(OSX)
         let cacheIdentifier: String = "\(registryType.rawValue)-\(identifier)"
         if let view = cache.object(forKey: cacheIdentifier as NSString) {
-          (view as? ItemConfigurable)?.prepareForReuse()
+          (view as? ContentConfigurable)?.prepareForReuse()
           return (type: registryType, view: view)
         }
       #endif

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -37,7 +37,7 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   }
 
   /// A configuration closure
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       configureClosureDidChange()
     }

--- a/Sources/iOS/Classes/CarouselSpotCell.swift
+++ b/Sources/iOS/Classes/CarouselSpotCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// A default cell for the CarouselSpot
-public class CarouselSpotCell: UICollectionViewCell, ItemConfigurable {
+public class CarouselSpotCell: UICollectionViewCell, ContentConfigurable {
 
   /// The preferred view size for the cell
   public var preferredViewSize: CGSize = CGSize(width: 88, height: 88)

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -26,7 +26,7 @@ open class GridSpot: NSObject, Gridable {
   open var component: Component
 
   /// A configuration closure
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       configureClosureDidChange()
     }

--- a/Sources/iOS/Classes/GridSpotCell.swift
+++ b/Sources/iOS/Classes/GridSpotCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// A default cell for the GridSpot
-public class GridSpotCell: UICollectionViewCell, ItemConfigurable {
+public class GridSpotCell: UICollectionViewCell, ContentConfigurable {
 
   /// The preferred view size for the view
   public var preferredViewSize = CGSize(width: 88, height: 88)

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -34,7 +34,7 @@ open class ListSpot: NSObject, Listable {
   public var compositeSpots: [CompositeSpot] = []
 
   /// A configuration closure
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       configureClosureDidChange()
     }

--- a/Sources/iOS/Classes/ListSpotCell.swift
+++ b/Sources/iOS/Classes/ListSpotCell.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Accessibility: This class is per default an accessibility element, and gets its attributes
 /// from any `Item` that it's configured with. You can override this behavior at any point, and
 /// disable accessibility by setting `isAccessibilityElement = false` on the cell.
-open class ListSpotCell: UITableViewCell, ItemConfigurable {
+open class ListSpotCell: UITableViewCell, ContentConfigurable {
 
   /// The preferred view size for the view, width will be ignored for ListSpot cells
   open var preferredViewSize = CGSize(width: 0, height: 44)

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -26,7 +26,7 @@ open class RowSpot: NSObject, Gridable {
   open var component: Component
 
   /// A configuration closure
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       configureClosureDidChange()
     }

--- a/Sources/iOS/Classes/RowSpotCell.swift
+++ b/Sources/iOS/Classes/RowSpotCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// A default cell for the RowSpot
-public class RowSpotCell: UICollectionViewCell, ItemConfigurable {
+public class RowSpotCell: UICollectionViewCell, ContentConfigurable {
 
   /// The preferred view size for the view
   public var preferredViewSize = CGSize(width: 88, height: 44)

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -19,7 +19,7 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
   public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
 
-  public var configure: ((ItemConfigurable) -> Void)? {
+  public var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       configureClosureDidChange()
     }

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -7,7 +7,7 @@ extension DataSource {
       let wrappedView = customView {
       view.configure(with: wrappedView)
 
-      if let configurableView = customView as? ItemConfigurable {
+      if let configurableView = customView as? ContentConfigurable {
         configurableView.configure(&spot.component.items[index])
 
         if spot.component.items[index].size.height == 0.0 {
@@ -26,7 +26,7 @@ extension DataSource {
     view.configure(&spot.component.items[index], compositeSpots: compositeSpots)
   }
 
-  func prepareItemConfigurableView(_ view: ItemConfigurable, atIndex index: Int, in spot: Spotable) {
+  func prepareContentConfigurableView(_ view: ContentConfigurable, atIndex index: Int, in spot: Spotable) {
     view.configure(&spot.component.items[index])
 
     if spot.component.items[index].size.height == 0.0 {
@@ -132,8 +132,8 @@ extension DataSource: UICollectionViewDataSource {
       prepareWrappableView(cell, atIndex: indexPath.item, in: spot, parentFrame: cell.bounds)
     case let cell as Composable:
       prepareComposableView(cell, atIndex: indexPath.item, in: spot)
-    case let cell as ItemConfigurable:
-      prepareItemConfigurableView(cell, atIndex: indexPath.item, in: spot)
+    case let cell as ContentConfigurable:
+      prepareContentConfigurableView(cell, atIndex: indexPath.item, in: spot)
     default:
       break
     }
@@ -182,8 +182,8 @@ extension DataSource: UITableViewDataSource {
       prepareWrappableView(cell, atIndex: indexPath.item, in: spot, parentFrame: cell.bounds)
     case let cell as Composable:
       prepareComposableView(cell, atIndex: indexPath.row, in: spot)
-    case let cell as ItemConfigurable:
-      prepareItemConfigurableView(cell, atIndex: indexPath.item, in: spot)
+    case let cell as ContentConfigurable:
+      prepareContentConfigurableView(cell, atIndex: indexPath.item, in: spot)
     default:
       break
     }

--- a/Sources/macOS/Classes/CarouselSpot.swift
+++ b/Sources/macOS/Classes/CarouselSpot.swift
@@ -63,10 +63,10 @@ open class CarouselSpot: NSObject, Gridable {
   open weak var delegate: SpotsDelegate?
 
   open var component: Component
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
-      for case let cell as ItemConfigurable in collectionView.visibleItems() {
+      for case let cell as ContentConfigurable in collectionView.visibleItems() {
         configure(cell)
       }
     }

--- a/Sources/macOS/Classes/CarouselSpotCell.swift
+++ b/Sources/macOS/Classes/CarouselSpotCell.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-class CarouselSpotCell: NSCollectionViewItem, ItemConfigurable {
+class CarouselSpotCell: NSCollectionViewItem, ContentConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 0, height: 120)
 

--- a/Sources/macOS/Classes/GridSpot.swift
+++ b/Sources/macOS/Classes/GridSpot.swift
@@ -92,10 +92,10 @@ open class GridSpot: NSObject, Gridable {
   open weak var delegate: SpotsDelegate?
 
   open var component: Component
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
-      for case let cell as ItemConfigurable in collectionView.visibleItems() {
+      for case let cell as ContentConfigurable in collectionView.visibleItems() {
         configure(cell)
       }
     }

--- a/Sources/macOS/Classes/GridSpotCell.swift
+++ b/Sources/macOS/Classes/GridSpotCell.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-class GridSpotCell: NSCollectionViewItem, ItemConfigurable {
+class GridSpotCell: NSCollectionViewItem, ContentConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 0, height: 120)
 

--- a/Sources/macOS/Classes/GridSpotItem.swift
+++ b/Sources/macOS/Classes/GridSpotItem.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-open class GridSpotItem: NSCollectionViewItem, ItemConfigurable {
+open class GridSpotItem: NSCollectionViewItem, ContentConfigurable {
 
   open override var isSelected: Bool {
     didSet {

--- a/Sources/macOS/Classes/ListSpot.swift
+++ b/Sources/macOS/Classes/ListSpot.swift
@@ -50,12 +50,12 @@ open class ListSpot: NSObject, Listable {
 
   /// A component struct used as configuration and data source for the ListSpot
   open var component: Component
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
       let range = tableView.rows(in: scrollView.contentView.visibleRect)
       (range.location..<range.length).forEach { i in
-        if let view = tableView.rowView(atRow: i, makeIfNecessary: false) as? ItemConfigurable {
+        if let view = tableView.rowView(atRow: i, makeIfNecessary: false) as? ContentConfigurable {
           configure(view)
         }
       }

--- a/Sources/macOS/Classes/ListSpotCell.swift
+++ b/Sources/macOS/Classes/ListSpotCell.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-class ListSpotCell: NSTableRowView, ItemConfigurable {
+class ListSpotCell: NSTableRowView, ContentConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 0, height: 120)
 

--- a/Sources/macOS/Classes/ListSpotItem.swift
+++ b/Sources/macOS/Classes/ListSpotItem.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-open class ListSpotItem: NSTableRowView, ItemConfigurable {
+open class ListSpotItem: NSTableRowView, ContentConfigurable {
 
   override open var isFlipped: Bool {
     return true

--- a/Sources/macOS/Classes/RowSpot.swift
+++ b/Sources/macOS/Classes/RowSpot.swift
@@ -94,10 +94,10 @@ open class RowSpot: NSObject, Gridable {
   open weak var delegate: SpotsDelegate?
 
   open var component: Component
-  open var configure: ((ItemConfigurable) -> Void)? {
+  open var configure: ((ContentConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
-      for case let cell as ItemConfigurable in collectionView.visibleItems() {
+      for case let cell as ContentConfigurable in collectionView.visibleItems() {
         configure(cell)
       }
     }

--- a/Sources/macOS/Classes/RowSpotItem.swift
+++ b/Sources/macOS/Classes/RowSpotItem.swift
@@ -6,7 +6,7 @@ open class FlippedView: NSView {
   }
 }
 
-open class RowSpotItem: NSCollectionViewItem, ItemConfigurable {
+open class RowSpotItem: NSCollectionViewItem, ContentConfigurable {
 
   open override var isSelected: Bool {
     didSet {

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -21,7 +21,7 @@ public class Spot: NSObject, Spotable {
   public var component: Component
   public var componentKind: Component.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
-  public var configure: ((ItemConfigurable) -> Void)?
+  public var configure: ((ContentConfigurable) -> Void)?
   public var spotDelegate: Delegate?
   public var spotDataSource: DataSource?
   public var stateCache: StateCache?

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -49,14 +49,14 @@ extension DataSource: NSCollectionViewDataSource {
     case let item as GridWrapper:
       if let (_, resolvedView) = Configuration.views.make(reuseIdentifier), let view = resolvedView {
         item.configure(with: view)
-        (view as? ItemConfigurable)?.configure(&spot.component.items[indexPath.item])
+        (view as? ContentConfigurable)?.configure(&spot.component.items[indexPath.item])
       }
     case let item as Composable:
       let spots = spot.compositeSpots.filter { $0.itemIndex == indexPath.item }
       item.contentView.frame.size.width = collectionView.frame.size.width
       item.contentView.frame.size.height = spot.computedHeight
       item.configure(&spot.component.items[indexPath.item], compositeSpots: spots)
-    case let item as ItemConfigurable:
+    case let item as ContentConfigurable:
       item.configure(&spot.component.items[indexPath.item])
     default:
       break

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -141,8 +141,8 @@ extension Delegate: NSTableViewDelegate {
         resolvedView = wrapper
       }
 
-      (customView as? ItemConfigurable)?.configure(&spot.component.items[row])
-    case let view as ItemConfigurable:
+      (customView as? ContentConfigurable)?.configure(&spot.component.items[row])
+    case let view as ContentConfigurable:
       view.configure(&spot.component.items[row])
     default:
       break

--- a/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
@@ -131,7 +131,7 @@ extension Gridable {
       : item.kind
 
     guard let (_, collectionItem) = Self.grids.make(kind),
-      let view = collectionItem as? ItemConfigurable else { return }
+      let view = collectionItem as? ContentConfigurable else { return }
 
     view.configure(&item)
 

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -28,7 +28,7 @@ extension NSTableView: UserInterface {
      - "For NSView-based table views, this method drops the view-cells in the table row, but not the NSTableRowView instances."
     */
     indexes.forEach { index in
-      if let view = rowView(atRow: index, makeIfNecessary: false) as? ItemConfigurable,
+      if let view = rowView(atRow: index, makeIfNecessary: false) as? ContentConfigurable,
       let adapter = dataSource as? Listable {
         var item = adapter.component.items[index]
         view.configure(&item)
@@ -62,7 +62,7 @@ extension NSTableView: UserInterface {
     insertRows(at: insertionsSets as IndexSet, withAnimation: animation.tableViewAnimation)
 
     for index in reloadSets {
-      guard let view = rowView(atRow: index, makeIfNecessary: false) as? ItemConfigurable,
+      guard let view = rowView(atRow: index, makeIfNecessary: false) as? ContentConfigurable,
         let adapter = dataSource as? Listable else {
           continue
       }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -219,9 +219,9 @@
 		BDAD858D1E3E7032008289AE /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853C1E3E7032008289AE /* Spotable+Mutation.swift */; };
 		BDAD858E1E3E7032008289AE /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853C1E3E7032008289AE /* Spotable+Mutation.swift */; };
 		BDAD858F1E3E7032008289AE /* Spotable+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853C1E3E7032008289AE /* Spotable+Mutation.swift */; };
-		BDAD85901E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */; };
-		BDAD85911E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */; };
-		BDAD85921E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */; };
+		BDAD85901E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ContentConfigurable+Extensions.swift */; };
+		BDAD85911E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ContentConfigurable+Extensions.swift */; };
+		BDAD85921E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853D1E3E7032008289AE /* ContentConfigurable+Extensions.swift */; };
 		BDAD85931E3E7032008289AE /* SpotsDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853E1E3E7032008289AE /* SpotsDelegate+Extensions.swift */; };
 		BDAD85941E3E7032008289AE /* SpotsDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853E1E3E7032008289AE /* SpotsDelegate+Extensions.swift */; };
 		BDAD85951E3E7032008289AE /* SpotsDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853E1E3E7032008289AE /* SpotsDelegate+Extensions.swift */; };
@@ -341,9 +341,9 @@
 		BDDCF6DB1E4DF91F004B38C4 /* Indexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DA1E4DF91F004B38C4 /* Indexable.swift */; };
 		BDDCF6DC1E4DF91F004B38C4 /* Indexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DA1E4DF91F004B38C4 /* Indexable.swift */; };
 		BDDCF6DD1E4DF91F004B38C4 /* Indexable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DA1E4DF91F004B38C4 /* Indexable.swift */; };
-		BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ItemConfigurable.swift */; };
-		BDDCF6E11E4DF927004B38C4 /* ItemConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ItemConfigurable.swift */; };
-		BDDCF6E21E4DF927004B38C4 /* ItemConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ItemConfigurable.swift */; };
+		BDDCF6E01E4DF927004B38C4 /* ContentConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ContentConfigurable.swift */; };
+		BDDCF6E11E4DF927004B38C4 /* ContentConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ContentConfigurable.swift */; };
+		BDDCF6E21E4DF927004B38C4 /* ContentConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6DF1E4DF927004B38C4 /* ContentConfigurable.swift */; };
 		BDDCF6E51E4DF92F004B38C4 /* StringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6E41E4DF92F004B38C4 /* StringConvertible.swift */; };
 		BDDCF6E61E4DF92F004B38C4 /* StringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6E41E4DF92F004B38C4 /* StringConvertible.swift */; };
 		BDDCF6E71E4DF92F004B38C4 /* StringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDCF6E41E4DF92F004B38C4 /* StringConvertible.swift */; };
@@ -546,7 +546,7 @@
 		BDAD853A1E3E7032008289AE /* ScrollDelegate+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScrollDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853B1E3E7032008289AE /* Spotable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Spotable+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853C1E3E7032008289AE /* Spotable+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Spotable+Mutation.swift"; sourceTree = "<group>"; };
-		BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ItemConfigurable+Extensions.swift"; sourceTree = "<group>"; };
+		BDAD853D1E3E7032008289AE /* ContentConfigurable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContentConfigurable+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853E1E3E7032008289AE /* SpotsDelegate+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+LiveEditing.swift"; sourceTree = "<group>"; };
@@ -591,7 +591,7 @@
 		BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCarouselComposite.swift; sourceTree = "<group>"; };
 		BDDCF6D51E4DF911004B38C4 /* Item.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 		BDDCF6DA1E4DF91F004B38C4 /* Indexable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Indexable.swift; sourceTree = "<group>"; };
-		BDDCF6DF1E4DF927004B38C4 /* ItemConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemConfigurable.swift; sourceTree = "<group>"; };
+		BDDCF6DF1E4DF927004B38C4 /* ContentConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentConfigurable.swift; sourceTree = "<group>"; };
 		BDDCF6E41E4DF92F004B38C4 /* StringConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringConvertible.swift; sourceTree = "<group>"; };
 		BDDCF6E91E4DF936004B38C4 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		BDDCF6EE1E4DF93D004B38C4 /* DictionaryConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryConvertible.swift; sourceTree = "<group>"; };
@@ -900,7 +900,7 @@
 				BDAD853A1E3E7032008289AE /* ScrollDelegate+Extensions.swift */,
 				BDAD853B1E3E7032008289AE /* Spotable+Extensions.swift */,
 				BDAD853C1E3E7032008289AE /* Spotable+Mutation.swift */,
-				BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */,
+				BDAD853D1E3E7032008289AE /* ContentConfigurable+Extensions.swift */,
 				BDAD853E1E3E7032008289AE /* SpotsDelegate+Extensions.swift */,
 				BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */,
 				BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */,
@@ -916,7 +916,7 @@
 			children = (
 				BDDCF6EE1E4DF93D004B38C4 /* DictionaryConvertible.swift */,
 				BDDCF6E41E4DF92F004B38C4 /* StringConvertible.swift */,
-				BDDCF6DF1E4DF927004B38C4 /* ItemConfigurable.swift */,
+				BDDCF6DF1E4DF927004B38C4 /* ContentConfigurable.swift */,
 				BDDCF6DA1E4DF91F004B38C4 /* Indexable.swift */,
 				BDAD85451E3E7032008289AE /* CarouselScrollDelegate.swift */,
 				BDAD85461E3E7032008289AE /* Componentable.swift */,
@@ -1580,7 +1580,7 @@
 				BDAD85C21E3E7032008289AE /* SpotsDelegate.swift in Sources */,
 				BDAD85EF1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDDCF6D81E4DF911004B38C4 /* Item.swift in Sources */,
-				BDDCF6E21E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
+				BDDCF6E21E4DF927004B38C4 /* ContentConfigurable.swift in Sources */,
 				BDB1F8B41E5D921F0064F64B /* Spotable+Extensions+iOS.swift in Sources */,
 				BDAD84AB1E3E701C008289AE /* Controller.swift in Sources */,
 				BDAD84C91E3E701C008289AE /* SpotsScrollView.swift in Sources */,
@@ -1591,7 +1591,7 @@
 				BDAD84B91E3E701C008289AE /* ListComposite.swift in Sources */,
 				BDAD85E01E3E7032008289AE /* Inset.swift in Sources */,
 				BDAD84CD1E3E701C008289AE /* Composable+iOS.swift in Sources */,
-				BDAD85921E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */,
+				BDAD85921E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */,
 				BDAD85AA1E3E7032008289AE /* Componentable.swift in Sources */,
 				BDAD84D51E3E701C008289AE /* Gridable+Extensions+iOS.swift in Sources */,
 				BDAD858C1E3E7032008289AE /* Spotable+Extensions.swift in Sources */,
@@ -1791,7 +1791,7 @@
 				BDAD85631E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85AB1E3E7032008289AE /* Composable.swift in Sources */,
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
-				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
+				BDDCF6E01E4DF927004B38C4 /* ContentConfigurable.swift in Sources */,
 				D5D2826B1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
 				D5D282671E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD857E1E3E7032008289AE /* Gridable+Extensions.swift in Sources */,
@@ -1824,7 +1824,7 @@
 				BDAD85E11E3E7032008289AE /* Interaction.swift in Sources */,
 				BDAD85E71E3E7032008289AE /* Parser.swift in Sources */,
 				BDAD84C01E3E701C008289AE /* ListWrapper.swift in Sources */,
-				BDAD85901E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */,
+				BDAD85901E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */,
 				BDAD84D41E3E701C008289AE /* Gridable+Extensions+iOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1877,7 +1877,7 @@
 				BDAD85101E3E7025008289AE /* GridSpotItem.swift in Sources */,
 				BDAD859D1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */,
 				BDDCF6D71E4DF911004B38C4 /* Item.swift in Sources */,
-				BDDCF6E11E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
+				BDDCF6E11E4DF927004B38C4 /* ContentConfigurable.swift in Sources */,
 				BDAD851F1E3E7025008289AE /* Gridable+macOS+Extensions.swift in Sources */,
 				BDAD85261E3E7025008289AE /* Viewable+macOS.swift in Sources */,
 				BDAD85D01E3E7032008289AE /* Wrappable.swift in Sources */,
@@ -1955,7 +1955,7 @@
 				BDAD850C1E3E7025008289AE /* Controller.swift in Sources */,
 				BDAD85D31E3E7032008289AE /* Component.swift in Sources */,
 				BDDCF6EB1E4DF936004B38C4 /* Extensions.swift in Sources */,
-				BDAD85911E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */,
+				BDAD85911E3E7032008289AE /* ContentConfigurable+Extensions.swift in Sources */,
 				BDAD85791E3E7032008289AE /* CarouselScrollDelegate+Extensions.swift in Sources */,
 				BDAD85211E3E7025008289AE /* Layout+macOS.swift in Sources */,
 				BDAD85671E3E7032008289AE /* Delegate.swift in Sources */,

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -52,7 +52,7 @@ extension Controller {
 }
 
 #if !os(OSX)
-  class HeaderView: UIView, ItemConfigurable, Componentable {
+  class HeaderView: UIView, ContentConfigurable, Componentable {
 
     public var preferredHeaderHeight: CGFloat = 50.0
 
@@ -92,7 +92,7 @@ extension Controller {
     }
   }
 
-  class FooterView: UIView, ItemConfigurable, Componentable {
+  class FooterView: UIView, ContentConfigurable, Componentable {
 
     var preferredHeaderHeight: CGFloat = 50
 
@@ -132,7 +132,7 @@ extension Controller {
     }
   }
 
-  class TextView: UIView, ItemConfigurable {
+  class TextView: UIView, ContentConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
 
@@ -168,7 +168,7 @@ extension Controller {
     }
   }
 
-  class CustomListCell: UITableViewCell, ItemConfigurable {
+  class CustomListCell: UITableViewCell, ContentConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
 
@@ -185,7 +185,7 @@ extension Controller {
     }
   }
 
-  class CustomGridCell: UICollectionViewCell, ItemConfigurable {
+  class CustomGridCell: UICollectionViewCell, ContentConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
 
@@ -204,7 +204,7 @@ extension Controller {
   }
 #endif
 
-class TestView: View, ItemConfigurable {
+class TestView: View, ContentConfigurable {
   var preferredViewSize: CGSize = CGSize(width: 50, height: 50)
 
   func configure(_ item: inout Item) {

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -99,7 +99,7 @@ class CompositionTests: XCTestCase {
     spot.view.layoutSubviews()
 
     var composite: Composable?
-    var itemConfigurable: ItemConfigurable?
+    var itemConfigurable: ContentConfigurable?
 
     composite = spot.ui(at: 0)
     itemConfigurable = spot.compositeSpots[0].spot.ui(at: 0)
@@ -217,7 +217,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var itemConfigurable: ItemConfigurable?
+    var itemConfigurable: ContentConfigurable?
 
     composite = spots[0].ui(at: 0)
     itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
@@ -409,7 +409,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 0)
 
     var composite: Composable?
-    var itemConfigurable: ItemConfigurable?
+    var itemConfigurable: ContentConfigurable?
 
     let newComponents: [Component] = [
       Component(kind: Component.Kind.grid.rawValue,
@@ -639,7 +639,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var itemConfigurable: ItemConfigurable?
+    var itemConfigurable: ContentConfigurable?
 
     composite = spots[0].ui(at: 0)
     itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)
@@ -958,7 +958,7 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(spots.count, 2)
 
     var composite: Composable?
-    var itemConfigurable: ItemConfigurable?
+    var itemConfigurable: ContentConfigurable?
 
     composite = spots[0].ui(at: 0)
     itemConfigurable = spots[0].compositeSpots[0].spot.ui(at: 0)

--- a/SpotsTests/macOS/HelperViews.swift
+++ b/SpotsTests/macOS/HelperViews.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import Spots
 
-class HeaderView: NSView, ItemConfigurable, Componentable {
+class HeaderView: NSView, ContentConfigurable, Componentable {
 
   var preferredHeaderHeight: CGFloat = 50
   var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
@@ -42,7 +42,7 @@ class HeaderView: NSView, ItemConfigurable, Componentable {
   }
 }
 
-class TextView: NSView, ItemConfigurable {
+class TextView: NSView, ContentConfigurable {
 
   var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
 
@@ -78,7 +78,7 @@ class TextView: NSView, ItemConfigurable {
   }
 }
 
-class FooterView: NSView, ItemConfigurable, Componentable {
+class FooterView: NSView, ContentConfigurable, Componentable {
 
   var preferredHeaderHeight: CGFloat = 50
   var preferredViewSize: CGSize = CGSize(width: 200, height: 50)


### PR DESCRIPTION
This PR is a breaking change, it renames Item to ContentModel.

I just ran a search and replace on the entire project and renamed Item.swift to ContentModel.swift

This will partially fix #511