### PR TITLE
⚠️Rename .component to .model⚠️

### DIFF
--- a/Playgrounds/Playground-iOS.playground/Contents.swift
+++ b/Playgrounds/Playground-iOS.playground/Contents.swift
@@ -88,10 +88,10 @@ public class ListHeaderView: UIView, Componentable {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func configure(component: ComponentModel) {
+  public func configure(model: ComponentModel) {
     backgroundColor = UIColor.whiteColor()
 
-    label.attributedText = NSAttributedString(string: component.title.uppercaseString,
+    label.attributedText = NSAttributedString(string: model.title.uppercaseString,
                                               attributes: [NSParagraphStyleAttributeName : paddedStyle])
   }
 }
@@ -215,12 +215,12 @@ let gridItems = ComponentModel(span: 6, items: [
   ])
 
 let controller = Controller(spots: [
-  ListSpot(component: ComponentModel(title: "Carousel Spot", meta: ["headerHeight" : 44])),
+  ListSpot(model: ComponentModel(title: "Carousel Spot", meta: ["headerHeight" : 44])),
   CarouselSpot(carouselItems, top: 5, left: 0, bottom: 5, right: 0, itemSpacing: 0),
-  ListSpot(component: ComponentModel(title: "Grid Spot", meta: ["headerHeight" : 44])),
+  ListSpot(model: ComponentModel(title: "Grid Spot", meta: ["headerHeight" : 44])),
   GridSpot(featuredOpensource, top: 10, left: 10, bottom: 20, right: 10, itemSpacing: -5),
-  ListSpot(component: listItems),
-  ListSpot(component: ComponentModel(title: "Grid Spot", meta: ["headerHeight" : 44])),
+  ListSpot(model: listItems),
+  ListSpot(model: ComponentModel(title: "Grid Spot", meta: ["headerHeight" : 44])),
   GridSpot(gridItems, top: 10, left: 10, bottom: 20, right: 10, itemSpacing: -5),
   ]
 )

--- a/Playgrounds/Playground-iOS.playground/timeline.xctimeline
+++ b/Playgrounds/Playground-iOS.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7240&amp;EndingColumnNumber=16&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=510579572.915624"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=7216&amp;EndingColumnNumber=16&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=510584114.101208"
          lockedSize = "{357, 436}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ let myContacts = ComponentModel(title: "My contacts", items: [
   Item(title: "Khoa Pham"),
   Item(title: "Christoffer Winterkvist")
 ])
-let listSpot = ListSpot(component: myContacts)
+let listSpot = ListSpot(model: myContacts)
 let controller = Controller(spots: [listSpot])
 
 navigationController?.pushViewController(controller, animated: true)
@@ -462,7 +462,7 @@ Custom data that you are free to use as you like in your implementation.
 ```
 
 - **.index**
-Calculated value to determine the index it has inside of the component.
+Calculated value to determine the index it has inside of the model.
 - **.title**
 The headline for your data, in a `UITableViewCell` it is normally used for `textLabel.text` but you are free to use it as you like.
 - **.subtitle**

--- a/Sources/Shared/Classes/SpotFactory.swift
+++ b/Sources/Shared/Classes/SpotFactory.swift
@@ -26,14 +26,14 @@ public struct Factory {
   /// - parameter component: A compontent struct used for crafting the spotable object.
   ///
   /// - returns: A spotable object.
-  public static func resolve(component: ComponentModel) -> Spotable {
-    var resolvedKind = component.kind
-    if component.isHybrid {
+  public static func resolve(model: ComponentModel) -> Spotable {
+    var resolvedKind = model.kind
+    if model.isHybrid {
       resolvedKind = ComponentModel.Kind.spot.string
     }
 
     let spot: Spotable.Type = spots[resolvedKind] ?? DefaultSpot
 
-    return spot.init(component: component)
+    return spot.init(model: model)
   }
 }

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -30,7 +30,7 @@ open class ViewSpot: NSObject, Spotable, Viewable {
   open static var defaultKind: StringConvertible = "view"
 
   open weak var delegate: SpotsDelegate?
-  open var component: ComponentModel
+  open var model: ComponentModel
   open var index = 0
   open var configure: ((ItemConfigurable) -> Void)?
 
@@ -46,11 +46,11 @@ open class ViewSpot: NSObject, Spotable, Viewable {
 
   public var userInterface: UserInterface?
 
-  public required init(component: ComponentModel) {
-    self.component = component
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     super.init()

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -33,9 +33,9 @@ public extension Spotable where Self : Gridable {
     #if !os(OSX)
       GridSpot.configure?(collectionView, layout)
 
-      if let resolve = type(of: self).headers.make(component.header),
+      if let resolve = type(of: self).headers.make(model.header),
         let view = resolve.view as? Componentable,
-        !component.header.isEmpty {
+        !model.header.isEmpty {
 
         layout.headerReferenceSize.width = collectionView.frame.size.width
         layout.headerReferenceSize.height = view.frame.size.height
@@ -52,7 +52,7 @@ public extension Spotable where Self : Gridable {
     #endif
     layout.prepare()
 
-    component.size = collectionView.frame.size
+    model.size = collectionView.frame.size
   }
 
   /// Layout with size

--- a/Sources/Shared/Extensions/Spotable+Extensions.swift
+++ b/Sources/Shared/Extensions/Spotable+Extensions.swift
@@ -9,15 +9,15 @@ public extension Spotable {
 
   /// A computed value for the current index
   public var index: Int {
-    return component.index
+    return model.index
   }
 
   public var usesDynamicHeight: Bool {
     get {
-      return component.layout?.dynamicHeight ?? true
+      return model.layout?.dynamicHeight ?? true
     }
     set {
-      component.layout?.dynamicHeight = newValue
+      model.layout?.dynamicHeight = newValue
     }
   }
 
@@ -32,13 +32,13 @@ public extension Spotable {
       let superViewHeight = self.view.superview?.frame.size.height ?? UIScreen.main.bounds.height
     #endif
 
-    for item in component.items {
+    for item in model.items {
       height += item.size.height
 
       #if !os(OSX)
         /// tvOS adds spacing between cells (it seems to be locked to 14 pixels in height).
         #if os(tvOS)
-          if component.kind == ComponentModel.Kind.list.string {
+          if model.kind == ComponentModel.Kind.list.string {
             height += 14
           }
         #endif
@@ -52,7 +52,7 @@ public extension Spotable {
 
     /// Add extra height to make room for focus shadow
     #if os(tvOS)
-      if component.kind == ComponentModel.Kind.list.string {
+      if model.kind == ComponentModel.Kind.list.string {
         height += 28
       }
     #endif
@@ -99,14 +99,14 @@ public extension Spotable {
 
   /// Prepare items in component
   func prepareItems() {
-    component.items = prepare(items: component.items)
+    model.items = prepare(items: model.items)
   }
 
   func prepare(items: [Item]) -> [Item] {
     var preparedItems = items
     var spanWidth: CGFloat?
 
-    if let layout = component.layout, layout.span > 0.0 {
+    if let layout = model.layout, layout.span > 0.0 {
       var spotWidth: CGFloat = view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
 
       #if !os(OSX)
@@ -139,11 +139,11 @@ public extension Spotable {
   ///
   /// - returns: An optional Item that corresponds to the index.
   public func item(at index: Int) -> Item? {
-    guard index < component.items.count && index > -1 else {
+    guard index < model.items.count && index > -1 else {
       return nil
     }
 
-    return component.items[index]
+    return model.items[index]
   }
 
   /// Resolve item at index path.
@@ -216,7 +216,7 @@ public extension Spotable {
         return
     }
 
-    component.items[index] = configuredItem
+    model.items[index] = configuredItem
   }
 
   func configure(item: Item, at index: Int, usesViewSize: Bool = false) -> Item? {
@@ -345,7 +345,7 @@ public extension Spotable {
                                         itemIndex: item.index)
 
       compositeSpot.spot.setup(size)
-      compositeSpot.spot.component.size = CGSize(
+      compositeSpot.spot.model.size = CGSize(
         width: width,
         height: ceil(compositeSpot.spot.view.frame.size.height))
       compositeSpot.spot.layout(size)
@@ -458,7 +458,7 @@ public extension Spotable {
     }
   }
 
-  /// Register a composite view for the Spotable component.
+  /// Register a composite view for the Spotable model.
   ///
   /// - parameter view: The view type that should be used as the composite view for the Spotable object.
   func registerComposite(view: View.Type) {

--- a/Sources/Shared/Extensions/Spotable+Mutation.swift
+++ b/Sources/Shared/Extensions/Spotable+Mutation.swift
@@ -19,8 +19,8 @@ public extension Spotable {
         return
       }
 
-      let numberOfItems = weakSelf.component.items.count
-      weakSelf.component.items.append(item)
+      let numberOfItems = weakSelf.model.items.count
+      weakSelf.model.items.append(item)
 
       if numberOfItems == 0 {
         weakSelf.userInterface?.reloadDataSource()
@@ -55,9 +55,9 @@ public extension Spotable {
       }
 
       var indexes = [Int]()
-      let numberOfItems = weakSelf.component.items.count
+      let numberOfItems = weakSelf.model.items.count
 
-      weakSelf.component.items.append(contentsOf: items)
+      weakSelf.model.items.append(contentsOf: items)
 
       items.enumerated().forEach {
         indexes.append(numberOfItems + $0.offset)
@@ -91,10 +91,10 @@ public extension Spotable {
         return
       }
 
-      let numberOfItems = weakSelf.component.items.count
+      let numberOfItems = weakSelf.model.items.count
       var indexes = [Int]()
 
-      weakSelf.component.items.insert(contentsOf: items, at: 0)
+      weakSelf.model.items.insert(contentsOf: items, at: 0)
 
       items.enumerated().forEach {
         if numberOfItems > 0 {
@@ -134,10 +134,10 @@ public extension Spotable {
         return
       }
 
-      let numberOfItems = weakSelf.component.items.count
+      let numberOfItems = weakSelf.model.items.count
       var indexes = [Int]()
 
-      weakSelf.component.items.insert(item, at: index)
+      weakSelf.model.items.insert(item, at: index)
 
       if numberOfItems > 0 {
         indexes.append(index)
@@ -165,12 +165,12 @@ public extension Spotable {
   func delete(_ item: Item, withAnimation animation: Animation = .automatic, completion: Completion) {
     Dispatch.main { [weak self] in
       guard let weakSelf = self,
-        let index = weakSelf.component.items.index(where: { $0 == item }) else {
+        let index = weakSelf.model.items.index(where: { $0 == item }) else {
           completion?()
           return
       }
 
-      weakSelf.component.items.remove(at: index)
+      weakSelf.model.items.remove(at: index)
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
@@ -201,7 +201,7 @@ public extension Spotable {
       }
 
       indexes.sorted(by: { $0 > $1 }).forEach {
-        weakSelf.component.items.remove(at: $0)
+        weakSelf.model.items.remove(at: $0)
       }
 
       weakSelf.userInterface?.delete(indexPaths, withAnimation: animation, completion: nil)
@@ -225,7 +225,7 @@ public extension Spotable {
         return
       }
 
-      weakSelf.component.items.remove(at: index)
+      weakSelf.model.items.remove(at: index)
       weakSelf.userInterface?.delete([index], withAnimation: animation, completion: nil)
       weakSelf.afterUpdate()
       weakSelf.sanitize {
@@ -248,7 +248,7 @@ public extension Spotable {
       }
 
       indexes.sorted(by: { $0 > $1 }).forEach {
-        weakSelf.component.items.remove(at: $0)
+        weakSelf.model.items.remove(at: $0)
       }
 
       weakSelf.userInterface?.delete(indexes, withAnimation: animation, completion: nil)
@@ -348,7 +348,7 @@ public extension Spotable {
             weakSelf.configureItem(at: index, usesViewSize: true)
           }
         } else {
-          for (index, _) in weakSelf.component.items.enumerated() {
+          for (index, _) in weakSelf.model.items.enumerated() {
             weakSelf.configureItem(at: index, usesViewSize: true)
           }
         }
@@ -427,16 +427,16 @@ public extension Spotable {
   /// A collection of view models
   var items: [Item] {
     set(items) {
-      component.items = items
+      model.items = items
     }
     get {
-      return component.items
+      return model.items
     }
   }
 
   /// Return a dictionary representation of Spotable object
   public var dictionary: [String : Any] {
-    return component.dictionary
+    return model.dictionary
   }
 
   /// Reloads a spot only if it changes
@@ -505,12 +505,12 @@ public extension Spotable {
 
       let newComponentModel = ComponentModel(json)
 
-      guard weakSelf.component != newComponentModel else {
+      guard weakSelf.model != newComponentModel else {
         weakSelf.cache()
         return
       }
 
-      weakSelf.component = newComponentModel
+      weakSelf.model = newComponentModel
       weakSelf.reload(nil, withAnimation: animation) { [weak self] in
         guard let weakSelf = self else {
           return

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -55,7 +55,7 @@ public extension SpotsProtocol {
     var result = [[String: Any]]()
 
     for spot in spots {
-      var spotJSON = spot.component.dictionary(amountOfItems)
+      var spotJSON = spot.model.dictionary(amountOfItems)
       for item in spot.items where item.kind == "composite" {
         let results = spot.compositeSpots
           .filter({ $0.itemIndex == item.index })
@@ -199,7 +199,7 @@ public extension SpotsProtocol {
   ///
   /// - returns: A ComponentModel object at index path.
   fileprivate func component(at indexPath: IndexPath) -> ComponentModel {
-    return spot(at: indexPath).component
+    return spot(at: indexPath).model
   }
 
   /**

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -59,7 +59,7 @@ extension SpotsProtocol {
       }
 
       let oldSpots = weakSelf.spots
-      let oldComponentModels = oldSpots.map { $0.component }
+      let oldComponentModels = oldSpots.map { $0.model }
       var newComponentModels = components
 
       /// Prepare default layouts for new components based of previous Spotable kind.
@@ -107,20 +107,20 @@ extension SpotsProtocol {
   /// - parameter oldComponentModels: A collection of components
   ///
   /// - returns: A ComponentModelDiff struct
-  func generateChanges(from components: [ComponentModel], and oldComponentModels: [ComponentModel]) -> [ComponentModelDiff] {
+  func generateChanges(from models: [ComponentModel], and oldComponentModels: [ComponentModel]) -> [ComponentModelDiff] {
     let oldComponentModelCount = oldComponentModels.count
     var changes = [ComponentModelDiff]()
-    for (index, component) in components.enumerated() {
+    for (index, model) in models.enumerated() {
       if index >= oldComponentModelCount {
         changes.append(.new)
         continue
       }
 
-      changes.append(component.diff(component: oldComponentModels[index]))
+      changes.append(model.diff(model: oldComponentModels[index]))
     }
 
-    if oldComponentModelCount > components.count {
-      oldComponentModels[components.count..<oldComponentModels.count].forEach { _ in
+    if oldComponentModelCount > models.count {
+      oldComponentModels[models.count..<oldComponentModels.count].forEach { _ in
         changes.append(.removed)
       }
     }
@@ -129,7 +129,7 @@ extension SpotsProtocol {
   }
 
   fileprivate func replaceSpot(_ index: Int, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let spot = Factory.resolve(component: newComponentModels[index])
+    let spot = Factory.resolve(model: newComponentModels[index])
     let oldSpot = spots[index]
 
     /// Remove old composite spots from superview and empty container
@@ -152,7 +152,7 @@ extension SpotsProtocol {
   }
 
   fileprivate func newSpot(_ index: Int, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let spot = Factory.resolve(component: newComponentModels[index])
+    let spot = Factory.resolve(model: newComponentModels[index])
     spots.append(spot)
     setupSpot(at: index, spot: spot)
     #if !os(OSX)
@@ -184,7 +184,7 @@ extension SpotsProtocol {
       return false
     }
 
-    let tempSpot = Factory.resolve(component: newComponentModels[index])
+    let tempSpot = Factory.resolve(model: newComponentModels[index])
     tempSpot.view.frame = spot.view.frame
     tempSpot.setup(tempSpot.view.frame.size)
     tempSpot.layout(tempSpot.view.frame.size)
@@ -192,7 +192,7 @@ extension SpotsProtocol {
     tempSpot.view.layoutIfNeeded()
     tempSpot.registerAndPrepare()
 
-    tempSpot.component.size = CGSize(
+    tempSpot.model.size = CGSize(
       width: view.frame.width,
       height: ceil(tempSpot.view.frame.height))
 
@@ -310,14 +310,14 @@ extension SpotsProtocol {
 
       let executeClosure = newItems.count - 1
       for (index, item) in newItems.enumerated() {
-        let components = Parser.parse(item.children).map { $0.component }
+        let components = Parser.parse(item.children).map { $0.model }
 
         let oldSpots = weakSelf.spots.flatMap({
           $0.compositeSpots
         })
 
         for removedSpot in oldSpots {
-          guard !components.contains(removedSpot.spot.component) else {
+          guard !components.contains(removedSpot.spot.model) else {
             continue
           }
 
@@ -450,8 +450,8 @@ extension SpotsProtocol {
       }
 
       let newSpots: [Spotable] = Parser.parse(json)
-      let newComponentModels = newSpots.map { $0.component }
-      let oldComponentModels = weakSelf.spots.map { $0.component }
+      let newComponentModels = newSpots.map { $0.model }
+      let oldComponentModels = weakSelf.spots.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
         if let controller = self as? Controller {
@@ -753,7 +753,7 @@ extension SpotsProtocol {
       spot.collectionView.frame.size.height = spot.layout.collectionViewContentSize.height
     default:
       spot.setup(scrollView.frame.size)
-      spot.component.size = CGSize(
+      spot.model.size = CGSize(
         width: spot.view.frame.size.width,
         height: ceil(spot.view.frame.size.height))
       spot.layout(scrollView.frame.size)

--- a/Sources/Shared/Protocols/Componentable.swift
+++ b/Sources/Shared/Protocols/Componentable.swift
@@ -15,5 +15,5 @@ public protocol Componentable {
   /// Configure object with ComponentModel struct.
   ///
   /// - parameter component: The component that should be used for configuration.
-  func configure(_ component: ComponentModel)
+  func configure(_ model: ComponentModel)
 }

--- a/Sources/Shared/Protocols/Spotable.swift
+++ b/Sources/Shared/Protocols/Spotable.swift
@@ -29,7 +29,7 @@ public protocol Spotable: class {
   /// A computed value for the size of the Spotable object
   var computedHeight: CGFloat { get }
   /// The component of a Spotable object
-  var component: ComponentModel { get set }
+  var model: ComponentModel { get set }
   /// A configuration closure for a ItemConfigurable object
   var configure: ((ItemConfigurable) -> Void)? { get set }
   /// A cache for a Spotable object
@@ -53,7 +53,7 @@ public protocol Spotable: class {
   /// - parameter component: The component that the Spotable object should be initialized with.
   ///
   /// - returns: An initialized Spotable object.
-  init(component: ComponentModel)
+  init(model: ComponentModel)
 
   /// Setup Spotable object with size
   func setup(_ size: CGSize)

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -206,12 +206,12 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   /// Initializes a component and configures it with the provided parameters
   ///
   /// - parameter identifier: A optional string
-  /// - parameter title: The title for your UI component.
-  /// - parameter header: Determines which header item that should be used for the component.
+  /// - parameter title: The title for your UI model.
+  /// - parameter header: Determines which header item that should be used for the model.
   /// - parameter kind: The type of ComponentModel that should be used.
-  /// - parameter layout: Configures the layout properties for the component.
-  /// - parameter interaction: Configures the interaction properties for the component.
-  /// - parameter span: Configures the layout span for the component.
+  /// - parameter layout: Configures the layout properties for the model.
+  /// - parameter interaction: Configures the interaction properties for the model.
+  /// - parameter span: Configures the layout span for the model.
   /// - parameter items: A collection of view models
   /// - parameter meta: A key-value dictionary for any additional information
   ///
@@ -288,26 +288,26 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   /// - parameter component: A ComponentModel used for comparison
   ///
   /// - returns: A ComponentModelDiff value, see ComponentModelDiff for values.
-  public func diff(component: ComponentModel) -> ComponentModelDiff {
+  public func diff(model: ComponentModel) -> ComponentModelDiff {
     // Determine if the UI component is the same, used when Controller needs to replace the entire UI component
-    if kind != component.kind { return .kind }
+    if kind != model.kind { return .kind }
     // Determine if the unqiue identifier for the component changed
-    if identifier != component.identifier { return .identifier }
+    if identifier != model.identifier { return .identifier }
     // Determine if the component layout changed, this can be used to trigger layout related processes
-    if layout != component.layout { return .layout }
+    if layout != model.layout { return .layout }
     // Determine if the header for the component has changed
-    if header != component.header { return .header }
+    if header != model.header { return .header }
     // Determine if the header for the component has changed
-    if footer != component.footer { return .footer }
+    if footer != model.footer { return .footer }
     // Check if meta data for the component changed, this can be up to the developer to decide what course of action to take.
-    if !(meta as NSDictionary).isEqual(to: component.meta) { return .meta }
+    if !(meta as NSDictionary).isEqual(to: model.meta) { return .meta }
     // Check if title changed
-    if title != component.title { return .title }
+    if title != model.title { return .title }
     // Check if the items have changed
-    if !(items === component.items) { return .items }
+    if !(items === model.items) { return .items }
     // Check children
     let lhsChildren = items.flatMap { $0.children }
-    let rhsChildren = component.items.flatMap { $0.children }
+    let rhsChildren = model.items.flatMap { $0.children }
 
     if !(lhsChildren as NSArray).isEqual(to: rhsChildren) {
       return .items

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -75,13 +75,13 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// Default initializer for creating a Layout struct.
   ///
   /// - Parameters:
-  ///   - span: The span that should be used for the component.
+  ///   - span: The span that should be used for the model.
   ///   - dynamicSpan: Enable or disable dynamic span.
   ///   - dynamicHeight: Enable or disable dynamic height.
-  ///   - pageIndicatorPlacement: Where any page indicator (if any) should be displayed in the component.
-  ///   - itemSpacing: Sets minimum item spacing for the component.
-  ///   - lineSpacing: Sets minimum lines spacing for items in component.
-  ///   - inset: An inset struct used to insert margins for the component.
+  ///   - pageIndicatorPlacement: Where any page indicator (if any) should be displayed in the model.
+  ///   - itemSpacing: Sets minimum item spacing for the model.
+  ///   - lineSpacing: Sets minimum lines spacing for items in model.
+  ///   - inset: An inset struct used to insert margins for the model.
   public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init()) {
     self.span = span
     self.dynamicSpan = dynamicSpan

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -15,7 +15,7 @@ public struct Parser {
     }
 
     return components.map {
-      Factory.resolve(component: $0)
+      Factory.resolve(model: $0)
     }
   }
 
@@ -28,15 +28,15 @@ public struct Parser {
   public static func parse(_ json: [String : Any], key: String = "components") -> [ComponentModel] {
     guard let payloads = json[key] as? [[String : Any]] else { return [] }
 
-    var components = [ComponentModel]()
+    var models = [ComponentModel]()
 
     for (index, payload) in payloads.enumerated() {
-      var component = ComponentModel(payload)
-      component.index = index
-      components.append(component)
+      var model = ComponentModel(payload)
+      model.index = index
+      models.append(model)
     }
 
-    return components
+    return models
   }
 
   /// Parse JSON into a collection of ComponentModels.
@@ -60,13 +60,13 @@ public struct Parser {
     guard let json = json else { return [] }
 
     return json.map {
-      Factory.resolve(component: ComponentModel($0))
+      Factory.resolve(model: ComponentModel($0))
     }
   }
 
-  public static func parse(_ components: [ComponentModel]) -> [Spotable] {
-    return components.map {
-      Factory.resolve(component: $0)
+  public static func parse(_ models: [ComponentModel]) -> [Spotable] {
+    return models.map {
+      Factory.resolve(model: $0)
     }
   }
 

--- a/Sources/iOS/Classes/CarouselSpot.swift
+++ b/Sources/iOS/Classes/CarouselSpot.swift
@@ -30,7 +30,7 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   open fileprivate(set) var stateCache: StateCache?
 
   /// A component struct used as configuration and data source for the CarouselSpot
-  open var component: ComponentModel {
+  open var model: ComponentModel {
     didSet {
       configurePageControl()
     }
@@ -74,14 +74,14 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   /// - returns: An initialized carousel spot.
   ///
   /// In case you want to use a default collection view & layout, use `init(component:)`.
-  public init(component: ComponentModel, collectionView: UICollectionView, layout: CollectionLayout) {
-    self.component = component
+  public init(model: ComponentModel, collectionView: UICollectionView, layout: CollectionLayout) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
-    self.component.interaction.scrollDirection = .horizontal
+    self.model.interaction.scrollDirection = .horizontal
 
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
@@ -94,13 +94,13 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
 
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
-    self.dynamicSpan = self.component.layout?.dynamicSpan ?? false
+    self.model.layout?.configure(spot: self)
+    self.dynamicSpan = self.model.layout?.dynamicSpan ?? false
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.carousel.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.carousel.string
     }
 
     registerDefault(view: CarouselSpotCell.self)
@@ -113,11 +113,11 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   /// Convenience initializer that creates an instance with a component
   ///
   /// - parameter component: The component model that the carousel should render
-  public required convenience init(component: ComponentModel) {
+  public required convenience init(model: ComponentModel) {
     let layout = GridableLayout()
     layout.scrollDirection = .horizontal
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-    self.init(component: component, collectionView: collectionView, layout: layout)
+    self.init(model: model, collectionView: collectionView, layout: layout)
   }
 
   /// A convenience initializer for CarouselSpot with base configuration.
@@ -131,8 +131,8 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   /// - parameter lineSpacing: The line spacing used in the flow layout.
   ///
   /// - returns: An initialized carousel spot with configured layout.
-  public convenience init(_ component: ComponentModel, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
-    self.init(component: component)
+  public convenience init(_ model: ComponentModel, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
+    self.init(model: model)
 
     layout.sectionInset = UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
     layout.minimumInteritemSpacing = itemSpacing
@@ -146,7 +146,7 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   /// - returns: An initialized carousel spot.
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -163,7 +163,7 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
     collectionView.delegate = spotDelegate
     collectionView.backgroundView = backgroundView
     #if os(iOS)
-      collectionView.isPagingEnabled = component.interaction.paginate == .page
+      collectionView.isPagingEnabled = model.interaction.paginate == .page
     #endif
   }
 
@@ -178,7 +178,7 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
     if collectionView.contentSize.height > 0 {
       collectionView.frame.size.height = collectionView.contentSize.height
     } else {
-      collectionView.frame.size.height = component.items.sorted(by: {
+      collectionView.frame.size.height = model.items.sorted(by: {
         $0.size.height > $1.size.height
       }).first?.size.height ?? 0
 
@@ -187,8 +187,8 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
       }
     }
 
-    if !component.header.isEmpty {
-      let resolve = type(of: self).headers.make(component.header)
+    if !model.header.isEmpty {
+      let resolve = type(of: self).headers.make(model.header)
       layout.headerReferenceSize.width = collectionView.frame.size.width
       layout.headerReferenceSize.height = resolve?.view?.frame.size.height ?? 0.0
     }
@@ -197,11 +197,11 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
 
     collectionView.frame.size.height += layout.headerReferenceSize.height
 
-    if let componentLayout = component.layout {
+    if let componentLayout = model.layout {
       collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
     }
 
-    if let pageIndicatorPlacement = component.layout?.pageIndicatorPlacement {
+    if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement {
       switch pageIndicatorPlacement {
       case .below:
         layout.sectionInset.bottom += pageControl.frame.height
@@ -214,12 +214,12 @@ open class CarouselSpot: NSObject, Gridable, SpotHorizontallyScrollable {
   }
 
   private func configurePageControl() {
-    guard let placement = component.layout?.pageIndicatorPlacement else {
+    guard let placement = model.layout?.pageIndicatorPlacement else {
       pageControl.removeFromSuperview()
       return
     }
 
-    pageControl.numberOfPages = component.items.count
+    pageControl.numberOfPages = model.items.count
     pageControl.frame.origin.x = 0
     pageControl.frame.size.height = 22
 

--- a/Sources/iOS/Classes/CarouselSpotHeader.swift
+++ b/Sources/iOS/Classes/CarouselSpotHeader.swift
@@ -30,7 +30,7 @@ public class CarouselSpotHeader: UICollectionReusableView, Componentable {
   /// Configure reusuable header view with ComponentModel.
   ///
   /// - parameter component: A ComponentModel struct used for configuring the view.
-  public func configure(_ component: ComponentModel) {
-    titleLabel.text = component.title
+  public func configure(_ model: ComponentModel) {
+    titleLabel.text = model.title
   }
 }

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -299,9 +299,9 @@ open class Controller: UIViewController, SpotsProtocol, SpotsFocusDelegate, UISc
     }
 
     spot.view.frame.origin.x = 0.0
-    spot.component.index = index
+    spot.model.index = index
     spot.setup(superview.frame.size)
-    spot.component.size = CGSize(
+    spot.model.size = CGSize(
       width: superview.frame.width,
       height: ceil(spot.view.frame.height))
     spot.focusDelegate = self
@@ -368,7 +368,7 @@ extension Controller {
   ///
   /// - returns: A ComponentModel object at index path.
   fileprivate func component(at indexPath: IndexPath) -> ComponentModel {
-    return spot(at: indexPath).component
+    return spot(at: indexPath).model
   }
 
   /// Resolve spot at index path.

--- a/Sources/iOS/Classes/GridSpot.swift
+++ b/Sources/iOS/Classes/GridSpot.swift
@@ -23,7 +23,7 @@ open class GridSpot: NSObject, Gridable {
   public var compositeSpots: [CompositeSpot] = []
 
   /// A component struct used as configuration and data source for the GridSpot
-  open var component: ComponentModel
+  open var model: ComponentModel
 
   /// A configuration closure
   open var configure: ((ItemConfigurable) -> Void)? {
@@ -54,26 +54,26 @@ open class GridSpot: NSObject, Gridable {
   var spotDataSource: DataSource?
   var spotDelegate: Delegate?
 
-  /// A required initializer to instantiate a GridSpot with a component.
+  /// A required initializer to instantiate a GridSpot with a model.
   ///
-  /// - parameter component: A component.
+  /// - parameter component: A model.
   ///
-  /// - returns: An initialized grid spot with component.
-  public required init(component: ComponentModel) {
-    self.component = component
+  /// - returns: An initialized grid spot with model.
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.grid.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.grid.string
     }
 
     registerDefault(view: GridSpotCell.self)
@@ -93,7 +93,7 @@ open class GridSpot: NSObject, Gridable {
   ///
   /// - returns: An initialized grid spot with computed component using title and kind.
   public convenience init(title: String = "", kind: String? = nil) {
-    self.init(component: ComponentModel(title: title, kind: kind ?? "", span: 0.0))
+    self.init(model: ComponentModel(title: title, kind: kind ?? "", span: 0.0))
   }
 
   /// Instantiate a GridSpot with a cache key.
@@ -104,7 +104,7 @@ open class GridSpot: NSObject, Gridable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -35,15 +35,15 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     var layoutAttributes = [UICollectionViewLayoutAttributes]()
 
-    if !spot.component.header.isEmpty {
+    if !spot.model.header.isEmpty {
 
       var view: View?
 
-      if let (_, header) = spot.type.headers.make(spot.component.header) {
+      if let (_, header) = spot.type.headers.make(spot.model.header) {
         view = header
       }
 
-      if view == nil, let (_, header) = Configuration.views.make(spot.component.header) {
+      if view == nil, let (_, header) = Configuration.views.make(spot.model.header) {
         view = header
       }
 
@@ -63,8 +63,8 @@ open class GridableLayout: UICollectionViewFlowLayout {
       }
     }
 
-    if !spot.component.footer.isEmpty,
-      let (_, view) = Configuration.views.make(spot.component.footer),
+    if !spot.model.footer.isEmpty,
+      let (_, view) = Configuration.views.make(spot.model.footer),
       let resolvedView = view {
 
       if let componentView = resolvedView as? Componentable {
@@ -86,7 +86,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
       contentSize.height = firstItem.size.height + headerReferenceSize.height + footerHeight
 
-      if let componentLayout = spot.component.layout {
+      if let componentLayout = spot.model.layout {
         contentSize.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
 
         #if os(iOS)

--- a/Sources/iOS/Classes/ListSpot.swift
+++ b/Sources/iOS/Classes/ListSpot.swift
@@ -25,7 +25,7 @@ open class ListSpot: NSObject, Listable {
   open static var headers = Registry()
 
   /// A component struct used as configuration and data source for the ListSpot
-  open var component: ComponentModel
+  open var model: ComponentModel
 
   /// A SpotsFocusDelegate object
   weak public var focusDelegate: SpotsFocusDelegate?
@@ -55,26 +55,26 @@ open class ListSpot: NSObject, Listable {
 
   // MARK: - Initializers
 
-  /// A required initializer to instantiate a ListSpot with a component.
+  /// A required initializer to instantiate a ListSpot with a model.
   ///
-  /// - parameter component: A component.
+  /// - parameter component: A model.
   ///
-  /// - returns: An initialized list spot with component.
-  public required init(component: ComponentModel) {
-    self.component = component
+  /// - returns: An initialized list spot with model.
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     super.init()
     self.userInterface = self.tableView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.list.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.list.string
     }
 
     registerDefault(view: ListSpotCell.self)
@@ -89,10 +89,10 @@ open class ListSpot: NSObject, Listable {
   /// - parameter kind:      An identifier to determine which kind should be set on the ComponentModel.
   /// - parameter kind:      An identifier to determine which kind should be set on the ComponentModel.
   ///
-  /// - returns: An initialized list spot with component.
+  /// - returns: An initialized list spot with model.
   public convenience init(tableView: UITableView? = nil, title: String = "",
                           kind: String = "list", header: String = "") {
-    self.init(component: ComponentModel(title: title, header: header, kind: kind, span: 1.0))
+    self.init(model: ComponentModel(title: title, header: header, kind: kind, span: 1.0))
 
     if let tableView = tableView {
       self.tableView = tableView
@@ -110,7 +110,7 @@ open class ListSpot: NSObject, Listable {
   public convenience init(cacheKey: String, tableView: UITableView? = nil) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
 
     if let tableView = tableView {
@@ -127,8 +127,8 @@ open class ListSpot: NSObject, Listable {
   ///
   /// - parameter size: The size of the superview.
   open func setup(_ size: CGSize) {
-    var height: CGFloat = component.meta(Key.headerHeight, 0.0)
-    for item in component.items {
+    var height: CGFloat = model.meta(Key.headerHeight, 0.0)
+    for item in model.items {
       height += item.size.height
     }
 
@@ -158,7 +158,7 @@ open class ListSpot: NSObject, Listable {
     tableView.rowHeight = UITableViewAutomaticDimension
 
     #if os(iOS)
-      if let separator = component.meta(Key.separator, type: Bool.self) {
+      if let separator = model.meta(Key.separator, type: Bool.self) {
         tableView.separatorStyle = separator
           ? .singleLine
           : .none

--- a/Sources/iOS/Classes/RowSpot.swift
+++ b/Sources/iOS/Classes/RowSpot.swift
@@ -23,7 +23,7 @@ open class RowSpot: NSObject, Gridable {
   public var compositeSpots: [CompositeSpot] = []
 
   /// A component struct used as configuration and data source for the RowSpot
-  open var component: ComponentModel
+  open var model: ComponentModel
 
   /// A configuration closure
   open var configure: ((ItemConfigurable) -> Void)? {
@@ -53,26 +53,26 @@ open class RowSpot: NSObject, Gridable {
   var spotDataSource: DataSource?
   var spotDelegate: Delegate?
 
-  /// A required initializer to instantiate a RowSpot with a component.
+  /// A required initializer to instantiate a RowSpot with a model.
   ///
-  /// - parameter component: A component.
+  /// - parameter component: A model.
   ///
-  /// - returns: An initialized row spot with component.
-  public required init(component: ComponentModel) {
-    self.component = component
+  /// - returns: An initialized row spot with model.
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.row.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.row.string
     }
 
     registerDefault(view: RowSpotCell.self)
@@ -93,7 +93,7 @@ open class RowSpot: NSObject, Gridable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 

--- a/Sources/iOS/Classes/Spot.swift
+++ b/Sources/iOS/Classes/Spot.swift
@@ -15,7 +15,7 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
   weak public var delegate: SpotsDelegate?
   weak public var carouselScrollDelegate: CarouselScrollDelegate?
 
-  public var component: ComponentModel
+  public var model: ComponentModel
   public var componentKind: ComponentModel.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
 
@@ -46,26 +46,26 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
     return userInterface as? CollectionView
   }
 
-  public required init(component: ComponentModel, view: ScrollView, kind: ComponentModel.Kind) {
-    self.component = component
+  public required init(model: ComponentModel, view: ScrollView, kind: ComponentModel.Kind) {
+    self.model = model
     self.componentKind = kind
     self.view = view
 
     super.init()
 
-    if component.layout == nil {
+    if model.layout == nil {
       switch kind {
       case .carousel:
-        self.component.layout = CarouselSpot.layout
+        self.model.layout = CarouselSpot.layout
         registerDefaultIfNeeded(view: CarouselSpotCell.self)
       case .grid:
-        self.component.layout = GridSpot.layout
+        self.model.layout = GridSpot.layout
         registerDefaultIfNeeded(view: GridSpotCell.self)
       case .list:
-        self.component.layout = ListSpot.layout
+        self.model.layout = ListSpot.layout
         registerDefaultIfNeeded(view: ListSpotCell.self)
       case .row:
-        self.component.layout = RowSpot.layout
+        self.model.layout = RowSpot.layout
       default:
         break
       }
@@ -73,7 +73,7 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
 
     userInterface?.register()
 
-    if let componentLayout = self.component.layout,
+    if let componentLayout = self.model.layout,
       let collectionViewLayout = collectionView?.collectionViewLayout as? GridableLayout {
       componentLayout.configure(collectionViewLayout: collectionViewLayout)
     }
@@ -82,24 +82,24 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
     self.spotDelegate = Delegate(spot: self)
   }
 
-  public required convenience init(component: ComponentModel) {
-    var component = component
-    if component.kind.isEmpty {
-      component.kind = Spot.defaultKind
+  public required convenience init(model: ComponentModel) {
+    var model = model
+    if model.kind.isEmpty {
+      model.kind = Spot.defaultKind
     }
 
-    let kind = ComponentModel.Kind(rawValue: component.kind) ?? .list
+    let kind = ComponentModel.Kind(rawValue: model.kind) ?? .list
     let view = kind == .list
       ? TableView()
       : CollectionView(frame: CGRect.zero, collectionViewLayout: CollectionLayout())
 
-    self.init(component: component, view: view, kind: kind)
+    self.init(model: model, view: view, kind: kind)
   }
 
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -137,10 +137,10 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
 
     if componentKind == .carousel {
       collectionView.showsHorizontalScrollIndicator = false
-      self.component.interaction.scrollDirection = .horizontal
+      self.model.interaction.scrollDirection = .horizontal
     }
 
-    switch component.interaction.scrollDirection {
+    switch model.interaction.scrollDirection {
     case .horizontal:
       setupHorizontalCollectionView(collectionView, with: size)
     case .vertical:
@@ -151,7 +151,7 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
   fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     prepareItems()
 
-    switch component.interaction.scrollDirection {
+    switch model.interaction.scrollDirection {
     case .horizontal:
       layoutHorizontalCollectionView(collectionView, with: size)
     case .vertical:
@@ -168,12 +168,12 @@ public class Spot: NSObject, Spotable, SpotHorizontallyScrollable {
   }
 
   func configurePageControl() {
-    guard let placement = component.layout?.pageIndicatorPlacement else {
+    guard let placement = model.layout?.pageIndicatorPlacement else {
       pageControl.removeFromSuperview()
       return
     }
 
-    pageControl.numberOfPages = component.items.count
+    pageControl.numberOfPages = model.items.count
     pageControl.frame.origin.x = 0
     pageControl.frame.size.height = 22
 

--- a/Sources/iOS/Extensions/Composable+iOS.swift
+++ b/Sources/iOS/Extensions/Composable+iOS.swift
@@ -24,7 +24,7 @@ public extension Composable where Self : View {
 
     compositeSpots.enumerated().forEach { _, compositeSpot in
       compositeSpot.spot.setup(size)
-      compositeSpot.spot.component.size = CGSize(
+      compositeSpot.spot.model.size = CGSize(
         width: width,
         height: ceil(compositeSpot.spot.view.frame.size.height))
       compositeSpot.spot.layout(size)

--- a/Sources/iOS/Extensions/Controller+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/Controller+UIScrollViewDelegate.swift
@@ -17,7 +17,7 @@ extension Controller {
       : 1
     let itemOffset = (size.height - scrollView.bounds.size.height * 2) > 0
       ? scrollView.bounds.size.height * 2
-      : (spots.last?.component.items.last?.size.height ?? 0) * 6
+      : (spots.last?.model.items.last?.size.height ?? 0) * 6
     let shouldFetch = !refreshing &&
       size.height > scrollView.bounds.height &&
       offset.y > size.height - scrollView.bounds.height * multiplier &&

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -3,34 +3,34 @@ import UIKit
 extension DataSource {
 
   func prepareWrappableView(_ view: Wrappable, atIndex index: Int, in spot: Spotable, parentFrame: CGRect = CGRect.zero) {
-    if let (_, customView) = Configuration.views.make(spot.component.items[index].kind, parentFrame: parentFrame),
+    if let (_, customView) = Configuration.views.make(spot.model.items[index].kind, parentFrame: parentFrame),
       let wrappedView = customView {
       view.configure(with: wrappedView)
 
       if let configurableView = customView as? ItemConfigurable {
-        configurableView.configure(&spot.component.items[index])
+        configurableView.configure(&spot.model.items[index])
 
-        if spot.component.items[index].size.height == 0.0 {
-          spot.component.items[index].size = configurableView.preferredViewSize
+        if spot.model.items[index].size.height == 0.0 {
+          spot.model.items[index].size = configurableView.preferredViewSize
         }
 
         spot.configure?(configurableView)
       } else {
-        spot.component.items[index].size.height = wrappedView.frame.size.height
+        spot.model.items[index].size.height = wrappedView.frame.size.height
       }
     }
   }
 
   func prepareComposableView(_ view: Composable, atIndex index: Int, in spot: Spotable) {
     let compositeSpots = spot.compositeSpots.filter({ $0.itemIndex == index })
-    view.configure(&spot.component.items[index], compositeSpots: compositeSpots)
+    view.configure(&spot.model.items[index], compositeSpots: compositeSpots)
   }
 
   func prepareItemConfigurableView(_ view: ItemConfigurable, atIndex index: Int, in spot: Spotable) {
-    view.configure(&spot.component.items[index])
+    view.configure(&spot.model.items[index])
 
-    if spot.component.items[index].size.height == 0.0 {
-      spot.component.items[index].size = view.preferredViewSize
+    if spot.model.items[index].size.height == 0.0 {
+      spot.model.items[index].size = view.preferredViewSize
     }
 
     spot.configure?(view)
@@ -51,7 +51,7 @@ extension DataSource: UICollectionViewDataSource {
       return 0
     }
 
-    return spot.component.items.count
+    return spot.model.items.count
   }
 
   /// Asks your data source object to provide a supplementary view to display in the collection view.
@@ -74,14 +74,14 @@ extension DataSource: UICollectionViewDataSource {
 
     switch kind {
     case UICollectionElementKindSectionHeader:
-      if spot.component.header.isEmpty {
+      if spot.model.header.isEmpty {
         identifier = spot.type.headers.defaultIdentifier
       } else {
-        identifier = spot.component.header
+        identifier = spot.model.header
       }
       viewHeight = collectionViewLayout.headerReferenceSize.height
     case UICollectionElementKindSectionFooter:
-      identifier = spot.component.footer
+      identifier = spot.model.footer
       viewHeight = collectionViewLayout.footerHeight
     default:
       return UICollectionReusableView()
@@ -99,10 +99,10 @@ extension DataSource: UICollectionViewDataSource {
         view.frame.size.height = viewHeight
         view.frame.size.width = collectionView.frame.size.width
 
-        (customView as? Componentable)?.configure(spot.component)
+        (customView as? Componentable)?.configure(spot.model)
       }
     case let view as Componentable:
-      view.configure(spot.component)
+      view.configure(spot.model)
     default:
       break
     }
@@ -117,11 +117,11 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let spot = spot, indexPath.item < spot.component.items.count else {
+    guard let spot = spot, indexPath.item < spot.model.items.count else {
       return UICollectionViewCell()
     }
 
-    spot.component.items[indexPath.item].index = indexPath.item
+    spot.model.items[indexPath.item].index = indexPath.item
 
     let reuseIdentifier = spot.identifier(at: indexPath)
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier,
@@ -155,7 +155,7 @@ extension DataSource: UITableViewDataSource {
       return 0
     }
 
-    return spot.component.items.count
+    return spot.model.items.count
   }
 
   /// Asks the data source for a cell to insert in a particular location of the table view. (required)
@@ -165,12 +165,12 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: An object inheriting from UITableViewCell that the table view can use for the specified row. Will return the default table view cell for the current component based of kind.
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard let spot = spot, indexPath.item < spot.component.items.count else {
+    guard let spot = spot, indexPath.item < spot.model.items.count else {
       return UITableViewCell()
     }
 
-    if indexPath.item < spot.component.items.count {
-      spot.component.items[indexPath.item].index = indexPath.row
+    if indexPath.item < spot.model.items.count {
+      spot.model.items[indexPath.item].index = indexPath.row
     }
 
     let reuseIdentifier = spot.identifier(at: indexPath)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -95,27 +95,27 @@ extension Delegate: UITableViewDelegate {
   /// - parameter tableView: The table-view object requesting this information.
   /// - parameter heightForHeaderInSection: An index number identifying a section of tableView.
   ///
-  /// - returns: Returns the `headerHeight` found in `component.meta`, otherwise 0.0.
+  /// - returns: Returns the `headerHeight` found in `model.meta`, otherwise 0.0.
   public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     guard let spot = spot else {
       return 0.0
     }
 
-    let header = spot.type.headers.make(spot.component.header)
+    let header = spot.type.headers.make(spot.model.header)
 
     if header == nil {
-      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.header)
-      view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
+      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.model.header)
+      view?.frame.size.height = spot.model.meta(ListSpot.Key.headerHeight, 0.0)
       view?.frame.size.width = tableView.frame.size.width
 
       switch view {
       case let view as ListHeaderFooterWrapper:
-        if let (_, resolvedView) = Configuration.views.make(spot.component.header),
+        if let (_, resolvedView) = Configuration.views.make(spot.model.header),
           let componentView = resolvedView as? Componentable {
           view.frame.size.height = componentView.preferredHeaderHeight
         }
       case let view as Componentable:
-        view.configure(spot.component)
+        view.configure(spot.model)
       default:
         break
       }
@@ -131,21 +131,21 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let header = spot.type.headers.make(spot.component.footer)
+    let header = spot.type.headers.make(spot.model.footer)
 
     if header == nil {
-      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.footer)
-      view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
+      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.model.footer)
+      view?.frame.size.height = spot.model.meta(ListSpot.Key.headerHeight, 0.0)
       view?.frame.size.width = tableView.frame.size.width
 
       switch view {
       case let view as ListHeaderFooterWrapper:
-        if let (_, resolvedView) = Configuration.views.make(spot.component.footer),
+        if let (_, resolvedView) = Configuration.views.make(spot.model.footer),
           let componentView = resolvedView as? Componentable {
             view.frame.size.height = componentView.preferredHeaderHeight
         }
       case let view as Componentable:
-        view.configure(spot.component)
+        view.configure(spot.model)
       default:
         break
       }
@@ -167,11 +167,11 @@ extension Delegate: UITableViewDelegate {
       return nil
     }
 
-    if let _ = spot.type.headers.make(spot.component.header) {
+    if let _ = spot.type.headers.make(spot.model.header) {
       return nil
     }
 
-    return !spot.component.title.isEmpty ? spot.component.title : nil
+    return !spot.model.title.isEmpty ? spot.model.title : nil
   }
 
   /// Tells the delegate that the specified row is now selected.
@@ -221,26 +221,26 @@ extension Delegate: UITableViewDelegate {
   ///
   /// - returns: A view object to be displayed in the header of section based on the kind of the ListSpot and registered headers.
   public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard let spot = spot, !spot.component.header.isEmpty else { return nil }
+    guard let spot = spot, !spot.model.header.isEmpty else { return nil }
 
-    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.header)
-    view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
+    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.model.header)
+    view?.frame.size.height = spot.model.meta(ListSpot.Key.headerHeight, 0.0)
     view?.frame.size.width = tableView.frame.size.width
 
     switch view {
       case let view as ListHeaderFooterWrapper:
-      if let (_, resolvedView) = Configuration.views.make(spot.component.header),
+      if let (_, resolvedView) = Configuration.views.make(spot.model.header),
         let customView = resolvedView {
         view.configure(with: customView)
 
         if let componentView = customView as? Componentable {
-          componentView.configure(spot.component)
+          componentView.configure(spot.model)
           customView.frame.size = view.frame.size
           customView.frame.size.height = componentView.preferredHeaderHeight
         }
       }
       case let view as Componentable:
-      view.configure(spot.component)
+      view.configure(spot.model)
       default:
         break
     }
@@ -249,26 +249,26 @@ extension Delegate: UITableViewDelegate {
   }
 
   public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-    guard let spot = spot, !spot.component.footer.isEmpty else { return nil }
+    guard let spot = spot, !spot.model.footer.isEmpty else { return nil }
 
-    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.component.footer)
-    view?.frame.size.height = spot.component.meta(ListSpot.Key.headerHeight, 0.0)
+    let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: spot.model.footer)
+    view?.frame.size.height = spot.model.meta(ListSpot.Key.headerHeight, 0.0)
     view?.frame.size.width = tableView.frame.size.width
 
     switch view {
     case let view as ListHeaderFooterWrapper:
-      if let (_, resolvedView) = Configuration.views.make(spot.component.footer),
+      if let (_, resolvedView) = Configuration.views.make(spot.model.footer),
         let customView = resolvedView {
         view.configure(with: customView)
 
         if let componentView = resolvedView as? Componentable {
-          componentView.configure(spot.component)
+          componentView.configure(spot.model)
           customView.frame.size = view.frame.size
           customView.frame.size.height = componentView.preferredHeaderHeight
         }
       }
     case let view as Componentable:
-      view.configure(spot.component)
+      view.configure(spot.model)
     default:
       break
     }
@@ -303,7 +303,7 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    spot.component.size = CGSize(
+    spot.model.size = CGSize(
       width: tableView.frame.size.width,
       height: tableView.frame.size.height)
 

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -14,12 +14,12 @@ extension Delegate: UIScrollViewDelegate {
       switch spot {
       case let spot as Spot:
         spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
-        if spot.component.layout?.pageIndicatorPlacement == .overlay {
+        if spot.model.layout?.pageIndicatorPlacement == .overlay {
           spot.pageControl.frame.origin.x = scrollView.contentOffset.x
         }
       case let spot as CarouselSpot:
         spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
-        if spot.component.layout?.pageIndicatorPlacement == .overlay {
+        if spot.model.layout?.pageIndicatorPlacement == .overlay {
           spot.pageControl.frame.origin.x = scrollView.contentOffset.x
         }
       default:
@@ -79,7 +79,7 @@ extension Delegate: UIScrollViewDelegate {
                                            contentSize: collectionViewLayout.contentSize,
                                            offset: collectionViewLayout.minimumInteritemSpacing)
 
-      if spot.component.interaction.paginate == .page {
+      if spot.model.interaction.paginate == .page {
         let widthBounds = scrollView.contentSize.width - scrollView.frame.size.width
         let isBeyondBounds = targetContentOffset.pointee.x >= widthBounds && centerIndexPath == nil
 

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension Gridable {
 
-  /// A computed CGFloat of the total height of all items inside of a component.
+  /// A computed CGFloat of the total height of all items inside of a model.
   public var computedHeight: CGFloat {
     guard usesDynamicHeight else {
       return self.view.frame.height
@@ -27,8 +27,8 @@ extension Gridable {
   /// - parameter bottom: The bottom UIEdgeInset for the layout.
   /// - parameter right: The right UIEdgeInset for the layout.
   /// - parameter itemSpacing: The minimumInteritemSpacing for the layout.
-  public init(_ component: ComponentModel, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0) {
-    self.init(component: component)
+  public init(_ model: ComponentModel, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0) {
+    self.init(model: model)
 
     layout.sectionInset = EdgeInsets(top: top, left: left, bottom: bottom, right: right)
     layout.minimumInteritemSpacing = itemSpacing
@@ -60,7 +60,7 @@ extension Gridable {
       prepareItems()
     }
 
-    component.layout?.configure(spot: self)
+    model.layout?.configure(spot: self)
     layout.prepare()
     layout.invalidateLayout()
 

--- a/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Listable+Extensions+iOS.swift
@@ -18,7 +18,7 @@ public extension Listable {
     tableView.frame.size.width = size.width - (tableView.contentInset.left)
     tableView.frame.origin.x = size.width / 2 - tableView.frame.width / 2
 
-    guard let componentSize = component.size else {
+    guard let componentSize = model.size else {
       return
     }
     tableView.frame.size.height = componentSize.height
@@ -39,7 +39,7 @@ public extension Listable {
   public func scrollTo(_ includeElement: (Item) -> Bool) -> CGFloat {
     guard let item = items.filter(includeElement).first else { return 0.0 }
 
-    return component.items[0...item.index]
+    return model.items[0...item.index]
       .reduce(0, { $0 + $1.size.height })
   }
 

--- a/Sources/iOS/Extensions/Spot+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Spot+iOS+Carousel.swift
@@ -11,7 +11,7 @@ extension Spot {
     collectionView.isScrollEnabled = true
     layout.scrollDirection = .horizontal
     #if os(iOS)
-      collectionView.isPagingEnabled = component.interaction.paginate == .page
+      collectionView.isPagingEnabled = model.interaction.paginate == .page
     #endif
     configurePageControl()
 
@@ -20,7 +20,7 @@ extension Spot {
     } else {
       var newCollectionViewHeight: CGFloat = 0.0
 
-      newCollectionViewHeight <- component.items.sorted(by: {
+      newCollectionViewHeight <- model.items.sorted(by: {
         $0.size.height > $1.size.height
       }).first?.size.height
 
@@ -37,11 +37,11 @@ extension Spot {
 
     collectionView.frame.size.height += layout.headerReferenceSize.height
 
-    if let componentLayout = component.layout {
+    if let componentLayout = model.layout {
       collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
     }
 
-    if let pageIndicatorPlacement = component.layout?.pageIndicatorPlacement {
+    if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement {
       switch pageIndicatorPlacement {
       case .below:
         layout.sectionInset.bottom += pageControl.frame.height

--- a/Sources/iOS/Extensions/Spot+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Spot+iOS+HeaderFooter.swift
@@ -7,11 +7,11 @@ extension Spot {
       return
     }
 
-    guard !component.header.isEmpty else {
+    guard !model.header.isEmpty else {
       return
     }
 
-    guard let view = Configuration.views.make(component.header)?.view as? Componentable else {
+    guard let view = Configuration.views.make(model.header)?.view as? Componentable else {
       return
     }
 

--- a/Sources/iOS/Extensions/Spot+iOS+List.swift
+++ b/Sources/iOS/Extensions/Spot+iOS+List.swift
@@ -13,7 +13,7 @@ extension Spot {
     prepareItems()
 
     var height: CGFloat = 0.0
-    for item in component.items {
+    for item in model.items {
       height += item.size.height
     }
 

--- a/Sources/iOS/Extensions/Spotable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Spotable+Extensions+iOS.swift
@@ -1,7 +1,7 @@
 extension Spotable {
   func didScrollHorizontally(handler: (SpotHorizontallyScrollable) -> Void) {
     guard let spot = self as? SpotHorizontallyScrollable,
-      component.interaction.scrollDirection == .horizontal else {
+      model.interaction.scrollDirection == .horizontal else {
         return
     }
 

--- a/Sources/macOS/Classes/CarouselSpot.swift
+++ b/Sources/macOS/Classes/CarouselSpot.swift
@@ -62,7 +62,7 @@ open class CarouselSpot: NSObject, Gridable {
   /// A SpotsDelegate that is used for the CarouselSpot
   open weak var delegate: SpotsDelegate?
 
-  open var component: ComponentModel
+  open var model: ComponentModel
   open var configure: ((ItemConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
@@ -105,27 +105,27 @@ open class CarouselSpot: NSObject, Gridable {
   var spotDataSource: DataSource?
   var spotDelegate: Delegate?
 
-  /// A required initializer to instantiate a CarouselSpot with a component.
+  /// A required initializer to instantiate a CarouselSpot with a model.
   ///
   /// - parameter component: A component
   ///
   /// - returns: An initialized carousel spot.
-  public required init(component: ComponentModel) {
-    self.component = component
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     self.collectionView = CollectionView()
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.carousel.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.carousel.string
     }
 
     registerDefault(view: CarouselSpotCell.self)
@@ -136,7 +136,7 @@ open class CarouselSpot: NSObject, Gridable {
     if let layout = layout as? FlowLayout {
       layout.scrollDirection = .horizontal
 
-      if !component.title.isEmpty {
+      if !model.title.isEmpty {
         configureTitleView(layout.sectionInset)
       }
     }
@@ -154,7 +154,7 @@ open class CarouselSpot: NSObject, Gridable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -182,29 +182,29 @@ open class CarouselSpot: NSObject, Gridable {
     var layoutInsets = EdgeInsets()
 
     if let layout = layout as? NSCollectionViewFlowLayout {
-      layout.sectionInset.top = component.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
+      layout.sectionInset.top = model.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
       layoutInsets = layout.sectionInset
     }
 
-    scrollView.frame.size.height = (component.items.first?.size.height ?? layoutInsets.top) + layoutInsets.top + layoutInsets.bottom
+    scrollView.frame.size.height = (model.items.first?.size.height ?? layoutInsets.top) + layoutInsets.top + layoutInsets.bottom
     collectionView.frame.size.height = scrollView.frame.size.height
     gradientLayer?.frame.size.height = scrollView.frame.size.height
 
-    if !component.title.isEmpty {
+    if !model.title.isEmpty {
       configureTitleView(layoutInsets)
     }
 
-    if let componentLayout = component.layout {
+    if let componentLayout = model.layout {
       if componentLayout.span > 0 {
-        component.items.enumerated().forEach {
-          component.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
+        model.items.enumerated().forEach {
+          model.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
         }
       } else if componentLayout.span == 1 {
         scrollView.frame.size.width = size.width - layoutInsets.right
-        scrollView.scrollingEnabled = (component.items.count > 1)
-        scrollView.hasHorizontalScroller = (component.items.count > 1)
-        component.items.enumerated().forEach {
-          component.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
+        scrollView.scrollingEnabled = (model.items.count > 1)
+        scrollView.hasHorizontalScroller = (model.items.count > 1)
+        model.items.enumerated().forEach {
+          model.items[$0.offset].size.width = size.width / CGFloat(componentLayout.span)
         }
         layout.invalidateLayout()
       }
@@ -215,10 +215,10 @@ open class CarouselSpot: NSObject, Gridable {
   ///
   /// - parameter size: The size of the superview
   open func setup(_ size: CGSize) {
-    if let layout = component.layout {
+    if let layout = model.layout {
       if layout.span > 0 {
-        component.items.enumerated().forEach {
-          component.items[$0.offset].size.width = size.width / CGFloat(layout.span)
+        model.items.enumerated().forEach {
+          model.items[$0.offset].size.width = size.width / CGFloat(layout.span)
         }
       }
     }
@@ -228,16 +228,16 @@ open class CarouselSpot: NSObject, Gridable {
   }
 
   fileprivate func configureTitleView(_ layoutInsets: EdgeInsets) {
-    titleView.stringValue = component.title
+    titleView.stringValue = model.title
     titleView.sizeToFit()
-    titleView.font = NSFont.systemFont(ofSize: component.meta(Key.titleFontSize, Default.titleFontSize))
+    titleView.font = NSFont.systemFont(ofSize: model.meta(Key.titleFontSize, Default.titleFontSize))
     titleView.sizeToFit()
     titleView.frame.size.width = collectionView.frame.width - layoutInsets.right - layoutInsets.left
-    lineView.frame.size.width = scrollView.frame.size.width - (component.meta(Key.titleLeftMargin, titleView.frame.origin.x) * 2)
-    lineView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
-    titleView.frame.origin.x = collectionView.frame.origin.x + component.meta(Key.titleLeftInset, Default.titleLeftInset)
-    titleView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
-    titleView.frame.origin.y = component.meta(Key.titleTopInset, Default.titleTopInset) - component.meta(Key.titleBottomInset, Default.titleBottomInset)
+    lineView.frame.size.width = scrollView.frame.size.width - (model.meta(Key.titleLeftMargin, titleView.frame.origin.x) * 2)
+    lineView.frame.origin.x = model.meta(Key.titleLeftMargin, titleView.frame.origin.x)
+    titleView.frame.origin.x = collectionView.frame.origin.x + model.meta(Key.titleLeftInset, Default.titleLeftInset)
+    titleView.frame.origin.x = model.meta(Key.titleLeftMargin, titleView.frame.origin.x)
+    titleView.frame.origin.y = model.meta(Key.titleTopInset, Default.titleTopInset) - model.meta(Key.titleBottomInset, Default.titleBottomInset)
     lineView.frame.origin.y = titleView.frame.maxY + 5
     collectionView.frame.size.height = scrollView.frame.size.height + titleView.frame.size.height
   }
@@ -246,7 +246,7 @@ open class CarouselSpot: NSObject, Gridable {
 
     var width: CGFloat
 
-    if let layout = component.layout {
+    if let layout = model.layout {
       width = layout.span > 0
         ? collectionView.frame.width / CGFloat(layout.span)
         : collectionView.frame.width
@@ -260,12 +260,12 @@ open class CarouselSpot: NSObject, Gridable {
       width -= layout.minimumLineSpacing
     }
 
-    if component.items[indexPath.item].size.width == 0.0 {
-      component.items[indexPath.item].size.width = width
+    if model.items[indexPath.item].size.width == 0.0 {
+      model.items[indexPath.item].size.width = width
     }
 
     return CGSize(
-      width: ceil(component.items[indexPath.item].size.width),
-      height: ceil(component.items[indexPath.item].size.height))
+      width: ceil(model.items[indexPath.item].size.width),
+      height: ceil(model.items[indexPath.item].size.height))
   }
 }

--- a/Sources/macOS/Classes/Controller.swift
+++ b/Sources/macOS/Classes/Controller.swift
@@ -224,16 +224,16 @@ open class Controller: NSViewController, SpotsProtocol {
       scrollView.spotsContentView.addSubview(spot.view)
     }
 
-    spots[index].component.index = index
+    spots[index].model.index = index
     spot.registerAndPrepare()
 
     var height = spot.computedHeight
-    if let componentSize = spot.component.size, componentSize.height > height {
+    if let componentSize = spot.model.size, componentSize.height > height {
       height = componentSize.height
     }
 
     spot.setup(CGSize(width: view.frame.width, height: height))
-    spot.component.size = CGSize(
+    spot.model.size = CGSize(
       width: view.frame.width,
       height: ceil(spot.view.frame.height))
 
@@ -264,7 +264,7 @@ open class Controller: NSViewController, SpotsProtocol {
 
   public func windowDidResize(_ notification: Notification) {
     for case let spot as Gridable in spots {
-      guard let layout = spot.component.layout, layout.span > 1 else {
+      guard let layout = spot.model.layout, layout.span > 1 else {
         continue
       }
 
@@ -275,7 +275,7 @@ open class Controller: NSViewController, SpotsProtocol {
 
   public func windowDidEndLiveResize(_ notification: Notification) {
     for case let spot as Gridable in spots {
-      guard let layout = spot.component.layout, layout.span > 1 else {
+      guard let layout = spot.model.layout, layout.span > 1 else {
         continue
       }
 

--- a/Sources/macOS/Classes/GridSpot.swift
+++ b/Sources/macOS/Classes/GridSpot.swift
@@ -91,7 +91,7 @@ open class GridSpot: NSObject, Gridable {
 
   open weak var delegate: SpotsDelegate?
 
-  open var component: ComponentModel
+  open var model: ComponentModel
   open var configure: ((ItemConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
@@ -144,23 +144,23 @@ open class GridSpot: NSObject, Gridable {
 
    - parameter component: A component struct
    */
-  public required init(component: ComponentModel) {
-    self.component = component
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     self.collectionView = CollectionView()
-    self.layout = GridSpot.setupLayout(component)
+    self.layout = GridSpot.setupLayout(model)
     super.init()
     self.userInterface = collectionView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.grid.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.grid.string
     }
 
     registerDefault(view: GridSpotCell.self)
@@ -171,7 +171,7 @@ open class GridSpot: NSObject, Gridable {
     scrollView.addSubview(lineView)
     scrollView.contentView.addSubview(collectionView)
 
-    if let layout = layout as? NSCollectionViewFlowLayout, !component.title.isEmpty {
+    if let layout = layout as? NSCollectionViewFlowLayout, !model.title.isEmpty {
       configureTitleView(layout.sectionInset)
     }
   }
@@ -184,7 +184,7 @@ open class GridSpot: NSObject, Gridable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -203,17 +203,17 @@ open class GridSpot: NSObject, Gridable {
 
    - returns: A NSCollectionView layout determined by the ComponentModel
    */
-  fileprivate static func setupLayout(_ component: ComponentModel) -> NSCollectionViewLayout {
+  fileprivate static func setupLayout(_ model: ComponentModel) -> NSCollectionViewLayout {
     let layout: NSCollectionViewLayout
 
-    switch LayoutType(rawValue: component.meta(Key.layout, Default.defaultLayout)) ?? LayoutType.flow {
+    switch LayoutType(rawValue: model.meta(Key.layout, Default.defaultLayout)) ?? LayoutType.flow {
     case .grid:
       let gridLayout = NSCollectionViewGridLayout()
 
-      gridLayout.maximumItemSize = CGSize(width: component.meta(Key.gridLayoutMaximumItemWidth, Default.gridLayoutMaximumItemWidth),
-                                          height: component.meta(Key.gridLayoutMaximumItemHeight, Default.gridLayoutMaximumItemHeight))
-      gridLayout.minimumItemSize = CGSize(width: component.meta(Key.gridLayoutMinimumItemWidth, Default.gridLayoutMinimumItemWidth),
-                                          height: component.meta(Key.gridLayoutMinimumItemHeight, Default.gridLayoutMinimumItemHeight))
+      gridLayout.maximumItemSize = CGSize(width: model.meta(Key.gridLayoutMaximumItemWidth, Default.gridLayoutMaximumItemWidth),
+                                          height: model.meta(Key.gridLayoutMaximumItemHeight, Default.gridLayoutMaximumItemHeight))
+      gridLayout.minimumItemSize = CGSize(width: model.meta(Key.gridLayoutMinimumItemWidth, Default.gridLayoutMinimumItemWidth),
+                                          height: model.meta(Key.gridLayoutMinimumItemHeight, Default.gridLayoutMinimumItemHeight))
       layout = gridLayout
     case .left:
       let leftLayout = CollectionViewLeftLayout()
@@ -255,13 +255,13 @@ open class GridSpot: NSObject, Gridable {
     layout.prepareForTransition(to: layout)
     var layoutInsets = EdgeInsets()
     if let layout = layout as? NSCollectionViewFlowLayout {
-      layout.sectionInset.top = component.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
+      layout.sectionInset.top = model.meta(GridableMeta.Key.sectionInsetTop, Default.sectionInsetTop) + titleView.frame.size.height + 8
       layoutInsets = layout.sectionInset
     }
 
     var layoutHeight = layout.collectionViewContentSize.height + layoutInsets.top + layoutInsets.bottom
 
-    if component.items.isEmpty {
+    if model.items.isEmpty {
       layoutHeight = size.height + layoutInsets.top + layoutInsets.bottom
     }
 
@@ -270,7 +270,7 @@ open class GridSpot: NSObject, Gridable {
     collectionView.frame.size.height = scrollView.frame.size.height - layoutInsets.top + layoutInsets.bottom
     collectionView.frame.size.width = size.width - layoutInsets.right
 
-    if !component.title.isEmpty {
+    if !model.title.isEmpty {
       configureTitleView(layoutInsets)
     }
   }
@@ -294,14 +294,14 @@ open class GridSpot: NSObject, Gridable {
    - parameter layoutInsets: EdgeInsets used to configure the title and line view size and origin
    */
   fileprivate func configureTitleView(_ layoutInsets: EdgeInsets) {
-    titleView.stringValue = component.title
-    titleView.font = NSFont.systemFont(ofSize: component.meta(Key.titleFontSize, Default.titleFontSize))
+    titleView.stringValue = model.title
+    titleView.font = NSFont.systemFont(ofSize: model.meta(Key.titleFontSize, Default.titleFontSize))
     titleView.sizeToFit()
     titleView.frame.size.width = collectionView.frame.width - layoutInsets.right - layoutInsets.left
-    lineView.frame.size.width = scrollView.frame.size.width - (component.meta(Key.titleLeftMargin, Default.titleLeftInset) * 2)
-    lineView.frame.origin.x = component.meta(Key.titleLeftMargin, Default.titleLeftInset)
+    lineView.frame.size.width = scrollView.frame.size.width - (model.meta(Key.titleLeftMargin, Default.titleLeftInset) * 2)
+    lineView.frame.origin.x = model.meta(Key.titleLeftMargin, Default.titleLeftInset)
     titleView.frame.origin.x = layoutInsets.left
-    titleView.frame.origin.x = component.meta(Key.titleLeftMargin, titleView.frame.origin.x)
+    titleView.frame.origin.x = model.meta(Key.titleLeftMargin, titleView.frame.origin.x)
     titleView.frame.origin.y = titleView.frame.size.height / 2
     lineView.frame.origin.y = titleView.frame.maxY + 8
   }

--- a/Sources/macOS/Classes/ListSpot.swift
+++ b/Sources/macOS/Classes/ListSpot.swift
@@ -49,7 +49,7 @@ open class ListSpot: NSObject, Listable {
   open weak var delegate: SpotsDelegate?
 
   /// A component struct used as configuration and data source for the ListSpot
-  open var component: ComponentModel
+  open var model: ComponentModel
   open var configure: ((ItemConfigurable) -> Void)? {
     didSet {
       guard let configure = configure else { return }
@@ -120,25 +120,25 @@ open class ListSpot: NSObject, Listable {
   var spotDataSource: DataSource?
   var spotDelegate: Delegate?
 
-  public required init(component: ComponentModel) {
-    self.component = component
+  public required init(model: ComponentModel) {
+    self.model = model
 
-    if self.component.layout == nil {
-      self.component.layout = type(of: self).layout
+    if self.model.layout == nil {
+      self.model.layout = type(of: self).layout
     }
 
     super.init()
     self.userInterface = tableView
-    self.component.layout?.configure(spot: self)
+    self.model.layout?.configure(spot: self)
     self.spotDataSource = DataSource(spot: self)
     self.spotDelegate = Delegate(spot: self)
 
-    if component.kind.isEmpty {
-      self.component.kind = ComponentModel.Kind.list.string
+    if model.kind.isEmpty {
+      self.model.kind = ComponentModel.Kind.list.string
     }
 
     scrollView.contentView.addSubview(tableView)
-    configureLayout(component)
+    configureLayout(model)
     registerDefault(view: ListSpotItem.self)
     registerComposite(view: ListComposite.self)
   }
@@ -146,7 +146,7 @@ open class ListSpot: NSObject, Listable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -159,22 +159,22 @@ open class ListSpot: NSObject, Listable {
   }
 
   open func doubleAction(_ sender: Any?) {
-    guard let item = item(at: tableView.clickedRow), component.meta(Key.doubleAction, type: Bool.self) == true else { return }
+    guard let item = item(at: tableView.clickedRow), model.meta(Key.doubleAction, type: Bool.self) == true else { return }
     delegate?.spotable(self, itemSelected: item)
   }
 
   open func action(_ sender: Any?) {
-    guard let item = item(at: tableView.clickedRow), component.meta(Key.doubleAction, false) == false else { return }
+    guard let item = item(at: tableView.clickedRow), model.meta(Key.doubleAction, false) == false else { return }
     delegate?.spotable(self, itemSelected: item)
   }
 
   open func layout(_ size: CGSize) {
-    scrollView.contentInsets.top = component.meta(Key.contentInsetsTop, Default.contentInsetsTop)
-    scrollView.contentInsets.left = component.meta(Key.contentInsetsLeft, Default.contentInsetsLeft)
-    scrollView.contentInsets.bottom = component.meta(Key.contentInsetsBottom, Default.contentInsetsBottom)
-    scrollView.contentInsets.right = component.meta(Key.contentInsetsRight, Default.contentInsetsRight)
+    scrollView.contentInsets.top = model.meta(Key.contentInsetsTop, Default.contentInsetsTop)
+    scrollView.contentInsets.left = model.meta(Key.contentInsetsLeft, Default.contentInsetsLeft)
+    scrollView.contentInsets.bottom = model.meta(Key.contentInsetsBottom, Default.contentInsetsBottom)
+    scrollView.contentInsets.right = model.meta(Key.contentInsetsRight, Default.contentInsetsRight)
 
-    if !component.title.isEmpty {
+    if !model.title.isEmpty {
       configureTitleView()
     }
 
@@ -184,8 +184,8 @@ open class ListSpot: NSObject, Listable {
   }
 
   open func setup(_ size: CGSize) {
-    component.items.enumerated().forEach {
-      component.items[$0.offset].size.width = size.width
+    model.items.enumerated().forEach {
+      model.items[$0.offset].size.width = size.width
     }
 
     tableView.frame.size = size
@@ -198,9 +198,9 @@ open class ListSpot: NSObject, Listable {
     tableView.doubleAction = #selector(self.doubleAction(_:))
     tableView.sizeToFit()
 
-    if !component.title.isEmpty {
+    if !model.title.isEmpty {
       scrollView.addSubview(titleView)
-      if component.meta(Key.titleSeparator, Default.titleSeparator) {
+      if model.meta(Key.titleSeparator, Default.titleSeparator) {
         scrollView.addSubview(lineView)
       }
       configureTitleView()
@@ -211,16 +211,16 @@ open class ListSpot: NSObject, Listable {
   }
 
   fileprivate func configureTitleView() {
-    titleView.stringValue = component.title
-    titleView.font = NSFont.systemFont(ofSize: component.meta(Key.titleFontSize, Default.titleFontSize))
+    titleView.stringValue = model.title
+    titleView.font = NSFont.systemFont(ofSize: model.meta(Key.titleFontSize, Default.titleFontSize))
     titleView.sizeToFit()
     titleView.isEnabled = false
-    titleView.frame.origin.x = tableView.frame.origin.x + component.meta(Key.titleLeftInset, Default.titleLeftInset)
+    titleView.frame.origin.x = tableView.frame.origin.x + model.meta(Key.titleLeftInset, Default.titleLeftInset)
     scrollView.contentInsets.top += titleView.frame.size.height * 2
     titleView.frame.origin.y = titleView.frame.size.height / 2
 
-    lineView.frame.size.width = scrollView.frame.size.width - (component.meta(Key.titleLeftInset, Default.titleLeftInset) * 2)
-    lineView.frame.origin.x = component.meta(Key.titleLeftInset, Default.titleLeftInset)
+    lineView.frame.size.width = scrollView.frame.size.width - (model.meta(Key.titleLeftInset, Default.titleLeftInset) * 2)
+    lineView.frame.origin.x = model.meta(Key.titleLeftInset, Default.titleLeftInset)
     lineView.frame.origin.y = titleView.frame.maxY + 8
   }
 

--- a/Sources/macOS/Classes/Spot.swift
+++ b/Sources/macOS/Classes/Spot.swift
@@ -18,7 +18,7 @@ public class Spot: NSObject, Spotable {
   var headerView: View?
   var footerView: View?
 
-  public var component: ComponentModel
+  public var model: ComponentModel
   public var componentKind: ComponentModel.Kind = .list
   public var compositeSpots: [CompositeSpot] = []
   public var configure: ((ItemConfigurable) -> Void)?
@@ -103,24 +103,24 @@ public class Spot: NSObject, Spotable {
     return userInterface as? CollectionView
   }
 
-  public required init(component: ComponentModel, userInterface: UserInterface, kind: ComponentModel.Kind) {
-    self.component = component
+  public required init(model: ComponentModel, userInterface: UserInterface, kind: ComponentModel.Kind) {
+    self.model = model
     self.componentKind = kind
     self.userInterface = userInterface
 
     super.init()
 
-    if component.layout == nil {
+    if model.layout == nil {
       switch kind {
       case .carousel:
-        self.component.layout = CarouselSpot.layout
+        self.model.layout = CarouselSpot.layout
       case .grid:
-        self.component.layout = GridSpot.layout
+        self.model.layout = GridSpot.layout
       case .list:
-        self.component.layout = ListSpot.layout
+        self.model.layout = ListSpot.layout
         registerDefaultIfNeeded(view: ListSpotItem.self)
       case .row:
-        self.component.layout = RowSpot.layout
+        self.model.layout = RowSpot.layout
       default:
         break
       }
@@ -132,13 +132,13 @@ public class Spot: NSObject, Spotable {
     self.spotDelegate = Delegate(spot: self)
   }
 
-  public required convenience init(component: ComponentModel) {
-    var component = component
-    if component.kind.isEmpty {
-      component.kind = Spot.defaultKind
+  public required convenience init(model: ComponentModel) {
+    var model = model
+    if model.kind.isEmpty {
+      model.kind = Spot.defaultKind
     }
 
-    let kind = ComponentModel.Kind(rawValue: component.kind) ?? .list
+    let kind = ComponentModel.Kind(rawValue: model.kind) ?? .list
     let userInterface: UserInterface
 
     if kind == .list {
@@ -149,10 +149,10 @@ public class Spot: NSObject, Spotable {
       userInterface = collectionView
     }
 
-    self.init(component: component, userInterface: userInterface, kind: kind)
+    self.init(model: model, userInterface: userInterface, kind: kind)
 
     if componentKind == .carousel {
-      self.component.interaction.scrollDirection = .horizontal
+      self.model.interaction.scrollDirection = .horizontal
       (collectionView?.collectionViewLayout as? FlowLayout)?.scrollDirection = .horizontal
     }
   }
@@ -160,7 +160,7 @@ public class Spot: NSObject, Spotable {
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(component: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()))
     self.stateCache = stateCache
   }
 
@@ -189,8 +189,8 @@ public class Spot: NSObject, Spotable {
 
     scrollView.frame.size = size
 
-    setupHeader(kind: component.header)
-    setupFooter(kind: component.footer)
+    setupHeader(kind: model.header)
+    setupFooter(kind: model.footer)
 
     if let tableView = self.tableView {
       documentView.addSubview(tableView)
@@ -216,7 +216,7 @@ public class Spot: NSObject, Spotable {
   }
 
   fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    if let componentLayout = self.component.layout,
+    if let componentLayout = self.model.layout,
       let collectionViewLayout = collectionView.collectionViewLayout as? FlowLayout {
       componentLayout.configure(collectionViewLayout: collectionViewLayout)
     }
@@ -280,10 +280,10 @@ public class Spot: NSObject, Spotable {
 
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
     if let collectionView = collectionView,
-      component.interaction.scrollDirection == .horizontal {
+      model.interaction.scrollDirection == .horizontal {
       var width: CGFloat
 
-      if let layout = component.layout {
+      if let layout = model.layout {
         width = layout.span > 0
           ? collectionView.frame.width / CGFloat(layout.span)
           : collectionView.frame.width
@@ -297,13 +297,13 @@ public class Spot: NSObject, Spotable {
         width -= layout.minimumLineSpacing
       }
 
-      if component.items[indexPath.item].size.width == 0.0 {
-        component.items[indexPath.item].size.width = width
+      if model.items[indexPath.item].size.width == 0.0 {
+        model.items[indexPath.item].size.width = width
       }
 
       return CGSize(
-        width: ceil(component.items[indexPath.item].size.width),
-        height: ceil(component.items[indexPath.item].size.height))
+        width: ceil(model.items[indexPath.item].size.width),
+        height: ceil(model.items[indexPath.item].size.height))
     } else {
       return CGSize(
         width:  item(at: indexPath)?.size.width  ?? 0.0,

--- a/Sources/macOS/Extensions/Composable+macOS.swift
+++ b/Sources/macOS/Extensions/Composable+macOS.swift
@@ -20,7 +20,7 @@ public extension Composable {
       compositeSpot.spot.setup(size)
       compositeSpot.spot.layout(size)
 
-      compositeSpot.spot.component.size = CGSize(
+      compositeSpot.spot.model.size = CGSize(
         width: width,
         height: ceil(compositeSpot.spot.view.frame.size.height))
 

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -18,7 +18,7 @@ extension DataSource: NSCollectionViewDataSource {
       return 0
     }
 
-    return spot.component.items.count
+    return spot.model.items.count
   }
 
   /// Asks your data source object to provide the item at the specified location in the collection view.
@@ -49,15 +49,15 @@ extension DataSource: NSCollectionViewDataSource {
     case let item as GridWrapper:
       if let (_, resolvedView) = Configuration.views.make(reuseIdentifier), let view = resolvedView {
         item.configure(with: view)
-        (view as? ItemConfigurable)?.configure(&spot.component.items[indexPath.item])
+        (view as? ItemConfigurable)?.configure(&spot.model.items[indexPath.item])
       }
     case let item as Composable:
       let spots = spot.compositeSpots.filter { $0.itemIndex == indexPath.item }
       item.contentView.frame.size.width = collectionView.frame.size.width
       item.contentView.frame.size.height = spot.computedHeight
-      item.configure(&spot.component.items[indexPath.item], compositeSpots: spots)
+      item.configure(&spot.model.items[indexPath.item], compositeSpots: spots)
     case let item as ItemConfigurable:
-      item.configure(&spot.component.items[indexPath.item])
+      item.configure(&spot.model.items[indexPath.item])
     default:
       break
     }
@@ -76,7 +76,7 @@ extension DataSource: NSTableViewDataSource {
       return 0
     }
 
-    return spot.component.items.count
+    return spot.model.items.count
   }
 
   /// Called by aTableView when the mouse button is released over a table view that previously decided to allow a drop.

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -70,12 +70,12 @@ extension Delegate: NSTableViewDelegate {
   public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
     guard let spot = spot,
       let item = spot.item(at: row),
-      row > -1 && row < spot.component.items.count
+      row > -1 && row < spot.model.items.count
       else {
         return false
     }
 
-    if spot.component.meta(ListSpot.Key.doubleAction, type: Bool.self) != true {
+    if spot.model.meta(ListSpot.Key.doubleAction, type: Bool.self) != true {
       spot.delegate?.spotable(spot, itemSelected: item)
     }
 
@@ -87,11 +87,11 @@ extension Delegate: NSTableViewDelegate {
       return 1.0
     }
 
-    spot.component.size = CGSize(
+    spot.model.size = CGSize(
       width: tableView.frame.width,
       height: tableView.frame.height)
 
-    let height = row < spot.component.items.count
+    let height = row < spot.model.items.count
       ? spot.item(at: row)?.size.height ?? 0
       : 1.0
 
@@ -101,7 +101,7 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    guard let spot = spot, row >= 0 && row < spot.component.items.count else {
+    guard let spot = spot, row >= 0 && row < spot.model.items.count else {
       return nil
     }
 
@@ -131,7 +131,7 @@ extension Delegate: NSTableViewDelegate {
       let spots = spot.compositeSpots.filter { $0.itemIndex == row }
       view.contentView.frame.size.width = tableView.frame.size.width
       view.contentView.frame.size.height = spot.computedHeight
-      view.configure(&spot.component.items[row], compositeSpots: spots)
+      view.configure(&spot.model.items[row], compositeSpots: spots)
     case let view as View:
       let customView = view
 
@@ -141,9 +141,9 @@ extension Delegate: NSTableViewDelegate {
         resolvedView = wrapper
       }
 
-      (customView as? ItemConfigurable)?.configure(&spot.component.items[row])
+      (customView as? ItemConfigurable)?.configure(&spot.model.items[row])
     case let view as ItemConfigurable:
-      view.configure(&spot.component.items[row])
+      view.configure(&spot.model.items[row])
     default:
       break
     }

--- a/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
@@ -82,9 +82,9 @@ extension Gridable {
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
     var sectionInsets: CGFloat = 0.0
     if let layout = layout as? NSCollectionViewFlowLayout,
-    let componentLayout = component.layout,
+    let componentLayout = model.layout,
       componentLayout.span > 0 {
-      component.items[indexPath.item].size.width = (collectionView.frame.width / CGFloat(componentLayout.span)) - layout.sectionInset.left - layout.sectionInset.right
+      model.items[indexPath.item].size.width = (collectionView.frame.width / CGFloat(componentLayout.span)) - layout.sectionInset.left - layout.sectionInset.right
       sectionInsets = layout.sectionInset.left + layout.sectionInset.right
     }
 
@@ -145,8 +145,8 @@ extension Gridable {
       }
     }
 
-    if index < component.items.count {
-      component.items[index] = item
+    if index < model.items.count {
+      model.items[index] = item
     }
   }
 

--- a/Sources/macOS/Extensions/Listable+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Listable+macOS+Extensions.swift
@@ -15,11 +15,11 @@ extension Listable {
     }
   }
 
-  func configureLayout(_ component: ComponentModel) {
-    let top: CGFloat = component.meta("inset-top", 0.0)
-    let left: CGFloat = component.meta("inset-left", 0.0)
-    let bottom: CGFloat = component.meta("inset-bottom", 0.0)
-    let right: CGFloat = component.meta("inset-right", 0.0)
+  func configureLayout(_ model: ComponentModel) {
+    let top: CGFloat = model.meta("inset-top", 0.0)
+    let left: CGFloat = model.meta("inset-left", 0.0)
+    let bottom: CGFloat = model.meta("inset-bottom", 0.0)
+    let right: CGFloat = model.meta("inset-right", 0.0)
 
     view.contentInsets = EdgeInsets(top: top, left: left, bottom: bottom, right: right)
   }
@@ -29,7 +29,7 @@ extension Listable {
   }
 
   @discardableResult public func selectFirst() -> Self {
-    guard let item = item(at: 0), !component.items.isEmpty else { return self }
+    guard let item = item(at: 0), !model.items.isEmpty else { return self }
     tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
     delegate?.spotable(self, itemSelected: item)
 

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -30,7 +30,7 @@ extension NSTableView: UserInterface {
     indexes.forEach { index in
       if let view = rowView(atRow: index, makeIfNecessary: false) as? ItemConfigurable,
       let adapter = dataSource as? Listable {
-        var item = adapter.component.items[index]
+        var item = adapter.model.items[index]
         view.configure(&item)
       }
     }
@@ -67,7 +67,7 @@ extension NSTableView: UserInterface {
           continue
       }
 
-      var item = adapter.component.items[index]
+      var item = adapter.model.items[index]
       view.configure(&item)
     }
 

--- a/Sources/macOS/Extensions/Spot+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Spot+macOS+Carousel.swift
@@ -6,12 +6,12 @@ extension Spot {
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     var newCollectionViewHeight: CGFloat = 0.0
 
-    newCollectionViewHeight <- component.items.sorted(by: {
+    newCollectionViewHeight <- model.items.sorted(by: {
       $0.size.height > $1.size.height
     }).first?.size.height
 
-    scrollView.scrollingEnabled = (component.items.count > 1)
-    scrollView.hasHorizontalScroller = (component.items.count > 1)
+    scrollView.scrollingEnabled = (model.items.count > 1)
+    scrollView.hasHorizontalScroller = (model.items.count > 1)
 
     collectionView.frame.size.height = newCollectionViewHeight
     CarouselSpot.configure?(collectionView)
@@ -28,13 +28,13 @@ extension Spot {
     if let collectionViewContentSize = collectionView.collectionViewLayout?.collectionViewContentSize {
       var newCollectionViewHeight: CGFloat = 0.0
 
-      newCollectionViewHeight <- component.items.sorted(by: {
+      newCollectionViewHeight <- model.items.sorted(by: {
         $0.size.height > $1.size.height
       }).first?.size.height
 
       var collectionViewContentSize = collectionViewContentSize
 
-      if let layout = component.layout {
+      if let layout = model.layout {
         collectionViewContentSize.width += CGFloat(layout.inset.left)
       }
 
@@ -44,7 +44,7 @@ extension Spot {
 
       documentView.frame.size = collectionView.frame.size
 
-      if let layout = component.layout {
+      if let layout = model.layout {
         documentView.frame.size.width += CGFloat(layout.inset.right)
       }
 

--- a/Sources/macOS/Extensions/Spot+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Spot+macOS+HeaderFooter.swift
@@ -3,16 +3,16 @@ import Cocoa
 extension Spot {
 
   func setupHeader(kind: String) {
-    guard !component.header.isEmpty, headerView == nil else {
+    guard !model.header.isEmpty, headerView == nil else {
       return
     }
 
-    if let (_, headerView) = Configuration.views.make(component.header) {
+    if let (_, headerView) = Configuration.views.make(model.header) {
       if let headerView = headerView,
         let componentable = headerView as? Componentable {
         let size = CGSize(width: view.frame.width,
                           height: componentable.preferredHeaderHeight)
-        componentable.configure(component)
+        componentable.configure(model)
         headerView.frame.size = size
         self.headerView = headerView
         scrollView.addSubview(headerView)
@@ -21,16 +21,16 @@ extension Spot {
   }
 
   func setupFooter(kind: String) {
-    guard !component.footer.isEmpty, footerView == nil else {
+    guard !model.footer.isEmpty, footerView == nil else {
       return
     }
 
-    if let (_, footerView) = Configuration.views.make(component.footer) {
+    if let (_, footerView) = Configuration.views.make(model.footer) {
       if let footerView = footerView,
         let componentable = footerView as? Componentable {
         let size = CGSize(width: view.frame.width,
                           height: componentable.preferredHeaderHeight)
-        componentable.configure(component)
+        componentable.configure(model)
         footerView.frame.size = size
         self.footerView = footerView
         scrollView.addSubview(footerView)
@@ -43,7 +43,7 @@ extension Spot {
     footerView?.frame.size.width = size.width
     footerView?.frame.origin.y = scrollView.frame.height - footerHeight
 
-    if let layout = component.layout {
+    if let layout = model.layout {
       headerView?.frame.origin.x = CGFloat(layout.inset.left)
       footerView?.frame.origin.x = CGFloat(layout.inset.left)
       headerView?.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)

--- a/Sources/macOS/Extensions/Spot+macOS+List.swift
+++ b/Sources/macOS/Extensions/Spot+macOS+List.swift
@@ -5,8 +5,8 @@ extension Spot {
   func setupTableView(_ tableView: TableView, with size: CGSize) {
     scrollView.addSubview(tableView)
 
-    component.items.enumerated().forEach {
-      component.items[$0.offset].size.width = size.width
+    model.items.enumerated().forEach {
+      model.items[$0.offset].size.width = size.width
     }
 
     tableView.frame.size = size
@@ -47,7 +47,7 @@ extension Spot {
     tableView.sizeToFit()
     tableView.frame.size.width = size.width
 
-    if let layout = component.layout {
+    if let layout = model.layout {
       tableView.frame.origin.x = CGFloat(layout.inset.left)
       tableView.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
     }

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -87,8 +87,8 @@ extension Controller {
       titleLabel.text = item.title
     }
 
-    func configure(_ component: ComponentModel) {
-      titleLabel.text = component.title
+    func configure(_ model: ComponentModel) {
+      titleLabel.text = model.title
     }
   }
 
@@ -127,7 +127,7 @@ extension Controller {
       titleLabel.text = item.title
     }
 
-    func configure(_ component: ComponentModel) {
+    func configure(_ model: ComponentModel) {
       titleLabel.text = "This is a footer"
     }
   }
@@ -180,8 +180,8 @@ extension Controller {
   class CustomListHeaderView: UITableViewHeaderFooterView, Componentable {
     var preferredHeaderHeight: CGFloat = 88
 
-    func configure(_ component: ComponentModel) {
-      textLabel?.text = component.title
+    func configure(_ model: ComponentModel) {
+      textLabel?.text = model.title
     }
   }
 
@@ -198,8 +198,8 @@ extension Controller {
 
     lazy var textLabel = UILabel()
 
-    func configure(_ component: ComponentModel) {
-      textLabel.text = component.title
+    func configure(_ model: ComponentModel) {
+      textLabel.text = model.title
     }
   }
 #endif

--- a/SpotsTests/Shared/TestComponent.swift
+++ b/SpotsTests/Shared/TestComponent.swift
@@ -107,8 +107,8 @@ class ComponentModelTests: XCTestCase {
     let lhs: [ComponentModel] = Parser.parse(initialJSON)
     let rhs: [ComponentModel] = Parser.parse(newJSON)
 
-    XCTAssertTrue(lhs.first?.diff(component: rhs.first!) == .items)
-    XCTAssertTrue(lhs[1].diff(component: rhs[1]) == .kind)
+    XCTAssertTrue(lhs.first?.diff(model: rhs.first!) == .items)
+    XCTAssertTrue(lhs[1].diff(model: rhs[1]) == .kind)
   }
 
   func testComponentModelExtensions() {

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -13,29 +13,29 @@ class CompositionTests: XCTestCase {
   #endif
 
   func testComponentModelCreation() {
-    var component = ComponentModel(
+    var model = ComponentModel(
       kind: ComponentModel.Kind.grid.rawValue,
       span: 1.0
     )
 
-    component.add(child: ComponentModel(kind: ComponentModel.Kind.list.rawValue, span: 1.0))
+    model.add(child: ComponentModel(kind: ComponentModel.Kind.list.rawValue, span: 1.0))
 
-    XCTAssertEqual(component.items.count, 1)
+    XCTAssertEqual(model.items.count, 1)
 
-    component.add(children: [
+    model.add(children: [
       ComponentModel(kind: ComponentModel.Kind.list.rawValue, span: 1.0),
       ComponentModel(kind: ComponentModel.Kind.list.rawValue, span: 1.0)
       ]
     )
 
-    XCTAssertEqual(component.items.count, 3)
+    XCTAssertEqual(model.items.count, 3)
   }
 
   func testSpotableCreation() {
     let layout = Layout().mutate { $0.span = 2.0 }
-    var component = ComponentModel(kind: ComponentModel.Kind.grid.rawValue, layout: layout)
+    var model = ComponentModel(kind: ComponentModel.Kind.grid.rawValue, layout: layout)
 
-    component.add(children: [
+    model.add(children: [
       ComponentModel(
         kind: ComponentModel.Kind.list.rawValue,
         span: 1.0,
@@ -55,25 +55,25 @@ class CompositionTests: XCTestCase {
       ]
     )
 
-    let spot = GridSpot(component: component)
+    let spot = GridSpot(model: model)
 
     XCTAssertEqual(spot.items.count, 2)
     XCTAssertEqual(spot.compositeSpots.count, 2)
-    XCTAssertEqual(spot.compositeSpots[0].spot.component.kind, ComponentModel.Kind.list.rawValue)
+    XCTAssertEqual(spot.compositeSpots[0].spot.model.kind, ComponentModel.Kind.list.rawValue)
     XCTAssertEqual(spot.compositeSpots[0].spot.items.count, 2)
     XCTAssertEqual(spot.compositeSpots[0].spot.items[0].title, "foo")
     XCTAssertEqual(spot.compositeSpots[0].spot.items[1].title, "bar")
 
-    XCTAssertEqual(spot.compositeSpots[1].spot.component.kind, ComponentModel.Kind.list.rawValue)
+    XCTAssertEqual(spot.compositeSpots[1].spot.model.kind, ComponentModel.Kind.list.rawValue)
     XCTAssertEqual(spot.compositeSpots[1].spot.items.count, 2)
     XCTAssertEqual(spot.compositeSpots[1].spot.items[0].title, "baz")
     XCTAssertEqual(spot.compositeSpots[1].spot.items[1].title, "bal")
   }
 
   func testUICreation() {
-    var component = ComponentModel(kind: ComponentModel.Kind.grid.rawValue, span: 2.0)
+    var model = ComponentModel(kind: ComponentModel.Kind.grid.rawValue, span: 2.0)
 
-    component.add(children: [
+    model.add(children: [
       ComponentModel(
         kind: ComponentModel.Kind.list.rawValue,
         span: 1,
@@ -93,7 +93,7 @@ class CompositionTests: XCTestCase {
       ]
     )
 
-    let spot = GridSpot(component: component)
+    let spot = GridSpot(model: model)
     spot.setup(CGSize(width: 200, height: 200))
     spot.layout(CGSize(width: 200, height: 200))
     spot.view.layoutSubviews()
@@ -107,7 +107,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spot.compositeSpots[0].parentSpot!.component == spot.component)
+    XCTAssertTrue(spot.compositeSpots[0].parentSpot!.model == spot.model)
     XCTAssertTrue(spot.compositeSpots[0].spot is Listable)
     XCTAssertEqual(spot.compositeSpots[0].spot.view.frame.size.height,
                    (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[0].spot.items.count))
@@ -117,7 +117,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(composite)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spot.compositeSpots[1].parentSpot!.component == spot.component)
+    XCTAssertTrue(spot.compositeSpots[1].parentSpot!.model == spot.model)
     XCTAssertTrue(spot.compositeSpots[1].spot is Listable)
     XCTAssertEqual(spot.compositeSpots[1].spot.view.frame.size.height,
                    (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(spot.compositeSpots[1].spot.items.count))
@@ -225,7 +225,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -235,7 +235,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -244,7 +244,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -254,7 +254,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -356,7 +356,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(itemConfigurable)
       XCTAssertNotNil(composite?.contentView)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -366,7 +366,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -375,7 +375,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -385,7 +385,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -506,7 +506,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -516,7 +516,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -525,7 +525,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -535,7 +535,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -647,7 +647,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -657,7 +657,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -666,7 +666,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -676,7 +676,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -823,7 +823,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot?.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot?.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 11)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -833,7 +833,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -844,7 +844,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot?.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[0].parentSpot?.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 11)
       XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -854,7 +854,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+      XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
       XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 11)
       XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -966,7 +966,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -976,7 +976,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+    XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
     XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,
@@ -985,7 +985,7 @@ class CompositionTests: XCTestCase {
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[0].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[0].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[0].spot.view.frame.size.height,
@@ -995,7 +995,7 @@ class CompositionTests: XCTestCase {
 
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
-    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.component == spots[1].component)
+    XCTAssertTrue(spots[1].compositeSpots[1].parentSpot!.model == spots[1].model)
     XCTAssertTrue(spots[1].compositeSpots[1].spot is Listable)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.items.count, 10)
     XCTAssertEqual(spots[1].compositeSpots[1].spot.view.frame.size.height,
@@ -1059,7 +1059,7 @@ class CompositionTests: XCTestCase {
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[0].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[0].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[0].spot.view.frame.size.height,
@@ -1069,7 +1069,7 @@ class CompositionTests: XCTestCase {
 
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
-      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.component == spots[0].component)
+      XCTAssertTrue(spots[0].compositeSpots[1].parentSpot!.model == spots[0].model)
       XCTAssertTrue(spots[0].compositeSpots[1].spot is Listable)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.items.count, 10)
       XCTAssertEqual(spots[0].compositeSpots[1].spot.view.frame.size.height,

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -5,8 +5,8 @@ import XCTest
 class ControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
-    let component = ComponentModel(title: "ComponentModel", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
 
@@ -14,32 +14,32 @@ class ControllerTests: XCTestCase {
   }
 
   func testUpdateSpotAtIndex() {
-    let component = ComponentModel(title: "ComponentModel", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
     let items = [Item(title: "item1")]
 
     controller.update { spot in
-      spot.component.items = items
+      spot.model.items = items
     }
 
-    XCTAssert(controller.spot!.component.items == items)
+    XCTAssert(controller.spot!.model.items == items)
   }
 
   func testAppendItemInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
 
-    XCTAssertEqual(controller.spot!.component.items.count, 0)
+    XCTAssertEqual(controller.spot!.model.items.count, 0)
 
     let item = Item(title: "title1", kind: "list")
     let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 1)
-      XCTAssert(controller.spot!.component.items.first! == item)
+      XCTAssertEqual(controller.spot!.model.items.count, 1)
+      XCTAssert(controller.spot!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -47,18 +47,18 @@ class ControllerTests: XCTestCase {
   }
 
   func testAppendOneMoreItemInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [Item(title: "title1")])
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [Item(title: "title1")])
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
 
-    XCTAssertEqual(controller.spot!.component.items.count, 1)
+    XCTAssertEqual(controller.spot!.model.items.count, 1)
 
     let item = Item(title: "title2", kind: "list")
     let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 2)
-      XCTAssert(controller.spot!.component.items.last! == item)
+      XCTAssertEqual(controller.spot!.model.items.count, 2)
+      XCTAssert(controller.spot!.model.items.last! == item)
       expectation.fulfill()
     }
 
@@ -66,8 +66,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testAppendItemsInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
 
@@ -77,8 +77,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.component.items.count > 0)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssert(controller.spot!.model.items.count > 0)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -86,8 +86,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testPrependItemsInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
     controller.preloadView()
 
@@ -97,8 +97,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 2)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssertEqual(controller.spot!.model.items.count, 2)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -106,12 +106,12 @@ class ControllerTests: XCTestCase {
   }
 
   func testPrependMoreItemsInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ]
     )
-    let listSpot = ListSpot(component: component)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
@@ -122,11 +122,11 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 4)
-      XCTAssertEqual(controller.spot!.component.items[0].title, "title3")
-      XCTAssertEqual(controller.spot!.component.items[1].title, "title4")
-      XCTAssertEqual(controller.spot!.component.items[2].title, "title1")
-      XCTAssertEqual(controller.spot!.component.items[3].title, "title2")
+      XCTAssertEqual(controller.spot!.model.items.count, 4)
+      XCTAssertEqual(controller.spot!.model.items[0].title, "title3")
+      XCTAssertEqual(controller.spot!.model.items[1].title, "title4")
+      XCTAssertEqual(controller.spot!.model.items[2].title, "title1")
+      XCTAssertEqual(controller.spot!.model.items[3].title, "title2")
       expectation.fulfill()
     }
 
@@ -134,40 +134,40 @@ class ControllerTests: XCTestCase {
   }
 
   func testDeleteItemInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.component.items.first
+    let firstItem = controller.spot!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
-    listSpot.delete(component.items.first!) {
-      let lastItem = controller.spot!.component.items.first
+    listSpot.delete(model.items.first!) {
+      let lastItem = controller.spot!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.component.items.count, 1)
+      XCTAssertEqual(controller.spot!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemsInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
     ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
@@ -176,20 +176,20 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete(items, withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.component.items.count, 0)
+      XCTAssertEqual(controller.spot!.model.items.count, 0)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemAtIndexInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
       Item(title: "title4", kind: "list")
       ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
@@ -197,23 +197,23 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete(1, withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.component.items.count, 3)
-      XCTAssertEqual(controller.spot!.component.items[0].title, "title1")
-      XCTAssertEqual(controller.spot!.component.items[1].title, "title3")
-      XCTAssertEqual(controller.spot!.component.items[2].title, "title4")
+      XCTAssertEqual(controller.spot!.model.items.count, 3)
+      XCTAssertEqual(controller.spot!.model.items[0].title, "title1")
+      XCTAssertEqual(controller.spot!.model.items[1].title, "title3")
+      XCTAssertEqual(controller.spot!.model.items[2].title, "title4")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testDeleteItemsWithIndexesInListSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
       Item(title: "title4", kind: "list")
       ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
@@ -221,29 +221,29 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test delete items")
 
     controller.spots[0].delete([1, 2], withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.component.items.count, 2)
-      XCTAssertEqual(controller.spot!.component.items[0].title, "title1")
-      XCTAssertEqual(controller.spot!.component.items[1].title, "title4")
+      XCTAssertEqual(controller.spot!.model.items.count, 2)
+      XCTAssertEqual(controller.spot!.model.items[0].title, "title1")
+      XCTAssertEqual(controller.spot!.model.items[1].title, "title4")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemInGridSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
 
-    XCTAssert(controller.spot!.component.items.count == 0)
+    XCTAssert(controller.spot!.model.items.count == 0)
 
     let item = Item(title: "title1", kind: "grid")
     let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
-      XCTAssert(controller.spot!.component.items.count == 1)
-      XCTAssert(controller.spot!.component.items.first! == item)
+      XCTAssert(controller.spot!.model.items.count == 1)
+      XCTAssert(controller.spot!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -251,8 +251,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testAppendItemsInGridSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
@@ -263,8 +263,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.component.items.count > 0)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssert(controller.spot!.model.items.count > 0)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -272,8 +272,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testPrependItemsInGridSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
@@ -284,8 +284,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 2)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssertEqual(controller.spot!.model.items.count, 2)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -293,49 +293,49 @@ class ControllerTests: XCTestCase {
   }
 
   func testDeleteItemInGridSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0, items: [
       Item(title: "title1", kind: "grid"),
       Item(title: "title2", kind: "grid")
       ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.component.items.first
+    let firstItem = controller.spot!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
-    listSpot.delete(component.items.first!) {
-      let lastItem = controller.spot!.component.items.first
+    listSpot.delete(model.items.first!) {
+      let lastItem = controller.spot!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.component.items.count, 1)
+      XCTAssertEqual(controller.spot!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testAppendItemInCarouselSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = GridSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
+    let listSpot = GridSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
 
-    XCTAssert(controller.spot!.component.items.count == 0)
+    XCTAssert(controller.spot!.model.items.count == 0)
 
     let item = Item(title: "title1", kind: "carousel")
     let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
-      XCTAssert(controller.spot!.component.items.count == 1)
-      XCTAssert(controller.spot!.component.items.first! == item)
+      XCTAssert(controller.spot!.model.items.count == 1)
+      XCTAssert(controller.spot!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -343,8 +343,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testAppendItemsInCarouselSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = GridSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
+    let listSpot = GridSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
@@ -356,8 +356,8 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test append items")
 
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.component.items.count > 0)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssert(controller.spot!.model.items.count > 0)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -365,8 +365,8 @@ class ControllerTests: XCTestCase {
   }
 
   func testPrependItemsInCarouselSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
+    let listSpot = ListSpot(model: model)
     let controller = Controller(spot: listSpot)
 
     controller.preloadView()
@@ -377,8 +377,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.component.items.count, 2)
-      XCTAssert(controller.spot!.component.items == items)
+      XCTAssertEqual(controller.spot!.model.items.count, 2)
+      XCTAssert(controller.spot!.model.items == items)
       expectation.fulfill()
     }
 
@@ -386,69 +386,69 @@ class ControllerTests: XCTestCase {
   }
 
   func testDeleteItemInCarouselSpot() {
-    let component = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0, items: [
       Item(title: "title1", kind: "carousel"),
       Item(title: "title2", kind: "carousel")
       ])
-    let initialListSpot = ListSpot(component: component)
+    let initialListSpot = ListSpot(model: model)
     let controller = Controller(spot: initialListSpot)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.component.items.first
+    let firstItem = controller.spot!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
     let listSpot = (controller.spot as! ListSpot)
-    listSpot.delete(component.items.first!) {
-      let lastItem = controller.spot!.component.items.first
+    listSpot.delete(model.items.first!) {
+      let lastItem = controller.spot!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.component.items.count, 1)
+      XCTAssertEqual(controller.spot!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
   func testComputedPropertiesOnSpotable() {
-    let component = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
+    let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
-    let spot = ListSpot(component: component)
+    let spot = ListSpot(model: model)
 
-    XCTAssert(spot.items == component.items)
+    XCTAssert(spot.items == model.items)
 
     let newItems = [Item(title: "title3", kind: "list")]
     spot.items = newItems
-    XCTAssertFalse(spot.items == component.items)
+    XCTAssertFalse(spot.items == model.items)
     XCTAssert(spot.items == newItems)
   }
 
   func testFindAndFilterSpotWithClosure() {
-    let listSpot = ListSpot(component: ComponentModel(title: "ListSpot", span: 1.0))
-    let listSpot2 = ListSpot(component: ComponentModel(title: "ListSpot2", span: 1.0))
-    let gridSpot = GridSpot(component: ComponentModel(title: "GridSpot", span: 1.0, items: [Item(title: "Item")]))
+    let listSpot = ListSpot(model: ComponentModel(title: "ListSpot", span: 1.0))
+    let listSpot2 = ListSpot(model: ComponentModel(title: "ListSpot2", span: 1.0))
+    let gridSpot = GridSpot(model: ComponentModel(title: "GridSpot", span: 1.0, items: [Item(title: "Item")]))
     let controller = Controller(spots: [listSpot, listSpot2, gridSpot])
 
-    XCTAssertNotNil(controller.resolve(spot: { $1.component.title == "ListSpot" }))
-    XCTAssertNotNil(controller.resolve(spot: { $1.component.title == "GridSpot" }))
+    XCTAssertNotNil(controller.resolve(spot: { $1.model.title == "ListSpot" }))
+    XCTAssertNotNil(controller.resolve(spot: { $1.model.title == "GridSpot" }))
     XCTAssertNotNil(controller.resolve(spot: { $1 is Listable }))
     XCTAssertNotNil(controller.resolve(spot: { $1 is Gridable }))
     XCTAssertNotNil(controller.resolve(spot: { $1.items.filter { $0.title == "Item" }.first != nil }))
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 0 })?.component.title, "ListSpot")
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 1 })?.component.title, "ListSpot2")
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 2 })?.component.title, "GridSpot")
+    XCTAssertEqual(controller.resolve(spot: { $0.0 == 0 })?.model.title, "ListSpot")
+    XCTAssertEqual(controller.resolve(spot: { $0.0 == 1 })?.model.title, "ListSpot2")
+    XCTAssertEqual(controller.resolve(spot: { $0.0 == 2 })?.model.title, "GridSpot")
 
     XCTAssert(controller.filter(spots: { $0 is Listable }).count == 2)
   }
 
   func testJSONInitialiser() {
-    let spot = ListSpot(component: ComponentModel(span: 1.0))
+    let spot = ListSpot(model: ComponentModel(span: 1.0))
     spot.items = [Item(title: "First item")]
     let sourceController = Controller(spot: spot)
     let jsonController = Controller([
@@ -462,7 +462,7 @@ class ControllerTests: XCTestCase {
       ]
       ])
 
-    XCTAssert(sourceController.spot!.component == jsonController.spot!.component)
+    XCTAssert(sourceController.spot!.model == jsonController.spot!.model)
   }
 
   func testJSONReload() {
@@ -477,9 +477,9 @@ class ControllerTests: XCTestCase {
     ]
     let jsonController = Controller(initialJSON)
 
-    XCTAssert(jsonController.spot!.component.kind == "list")
-    XCTAssert(jsonController.spot!.component.items.count == 1)
-    XCTAssert(jsonController.spot!.component.items.first?.title == "First list item")
+    XCTAssert(jsonController.spot!.model.kind == "list")
+    XCTAssert(jsonController.spot!.model.items.count == 1)
+    XCTAssert(jsonController.spot!.model.items.first?.title == "First list item")
 
     let updateJSON = [
       "components": [
@@ -494,9 +494,9 @@ class ControllerTests: XCTestCase {
 
     let expectation = self.expectation(description: "Reload with JSON")
     jsonController.reload(updateJSON) {
-      XCTAssert(jsonController.spot!.component.kind == "grid")
-      XCTAssert(jsonController.spot!.component.items.count == 2)
-      XCTAssert(jsonController.spot!.component.items.first?.title == "First grid item")
+      XCTAssert(jsonController.spot!.model.kind == "grid")
+      XCTAssert(jsonController.spot!.model.items.count == 2)
+      XCTAssert(jsonController.spot!.model.items.first?.title == "First grid item")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -515,7 +515,7 @@ class ControllerTests: XCTestCase {
     let firstController = Controller(initialJSON)
     let secondController = Controller(firstController.dictionary)
 
-    XCTAssertTrue(firstController.spots.first!.component == secondController.spots.first!.component)
+    XCTAssertTrue(firstController.spots.first!.model == secondController.spots.first!.model)
   }
 
   func testReloadIfNeededWithJSON() {
@@ -623,10 +623,10 @@ class ControllerTests: XCTestCase {
       )
     ]
 
-    let spots = initialComponentModels.map { Factory.resolve(component: $0) }
+    let spots = initialComponentModels.map { Factory.resolve(model: $0) }
     let controller = Controller(spots: spots)
 
-    let oldComponentModels: [ComponentModel] = controller.spots.map { $0.component }
+    let oldComponentModels: [ComponentModel] = controller.spots.map { $0.model }
 
     let changes = controller.generateChanges(from: newComponentModels, and: oldComponentModels)
     XCTAssertEqual(changes.count, 1)
@@ -676,18 +676,18 @@ class ControllerTests: XCTestCase {
       )
     ]
 
-    let spots = initialComponentModels.map { Factory.resolve(component: $0) }
+    let spots = initialComponentModels.map { Factory.resolve(model: $0) }
 
     /// Validate setting up a controller
     let controller = Controller(spots: spots)
     XCTAssertEqual(controller.spots.count, 1)
 
     /// Test first item in the first component of the first spot inside of the controller
-    XCTAssertEqual(controller.spots.first!.component.kind, spots.first!.component.kind)
-    XCTAssertEqual(controller.spots.first!.component.items[0].title, spots.first!.component.items[0].title)
-    XCTAssertEqual(controller.spots.first!.component.items[0].subtitle, spots.first!.component.items[0].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[0].kind, spots.first!.component.items[0].kind)
-    XCTAssertEqual(controller.spots.first!.component.items[0].size, spots.first!.component.items[0].size)
+    XCTAssertEqual(controller.spots.first!.model.kind, spots.first!.model.kind)
+    XCTAssertEqual(controller.spots.first!.model.items[0].title, spots.first!.model.items[0].title)
+    XCTAssertEqual(controller.spots.first!.model.items[0].subtitle, spots.first!.model.items[0].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[0].kind, spots.first!.model.items[0].kind)
+    XCTAssertEqual(controller.spots.first!.model.items[0].size, spots.first!.model.items[0].size)
 
     XCTAssertTrue(initialComponentModels !== newComponentModels)
     XCTAssertEqual(initialComponentModels.count, newComponentModels.count)
@@ -711,130 +711,130 @@ class ControllerTests: XCTestCase {
       XCTAssertNotNil(view)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[0].title, initialComponentModels.first!.items[0].title)
-    XCTAssertEqual(controller.spots.first!.component.items[0].subtitle, initialComponentModels.first!.items[0].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[0].action, initialComponentModels.first!.items[0].action)
-    XCTAssertEqual(controller.spots.first!.component.items[0].kind, initialComponentModels.first!.items[0].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[0].size, initialComponentModels.first!.items[0].size)
+    XCTAssertEqual(controller.spots.first!.model.items[0].title, initialComponentModels.first!.items[0].title)
+    XCTAssertEqual(controller.spots.first!.model.items[0].subtitle, initialComponentModels.first!.items[0].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[0].action, initialComponentModels.first!.items[0].action)
+    XCTAssertEqual(controller.spots.first!.model.items[0].kind, initialComponentModels.first!.items[0].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[0].size, initialComponentModels.first!.items[0].size)
 
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[0].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[0].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[0].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[0].size, view!.frame.size)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[1].title, initialComponentModels.first!.items[1].title)
-    XCTAssertEqual(controller.spots.first!.component.items[1].subtitle, initialComponentModels.first!.items[1].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[1].action, initialComponentModels.first!.items[1].action)
-    XCTAssertEqual(controller.spots.first!.component.items[1].kind, initialComponentModels.first!.items[1].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[1].size, initialComponentModels.first!.items[1].size)
+    XCTAssertEqual(controller.spots.first!.model.items[1].title, initialComponentModels.first!.items[1].title)
+    XCTAssertEqual(controller.spots.first!.model.items[1].subtitle, initialComponentModels.first!.items[1].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[1].action, initialComponentModels.first!.items[1].action)
+    XCTAssertEqual(controller.spots.first!.model.items[1].kind, initialComponentModels.first!.items[1].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[1].size, initialComponentModels.first!.items[1].size)
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[1].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[1].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[1].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[1].size, view!.frame.size)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[2].title, initialComponentModels.first!.items[2].title)
-    XCTAssertEqual(controller.spots.first!.component.items[2].subtitle, initialComponentModels.first!.items[2].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[2].action, initialComponentModels.first!.items[2].action)
-    XCTAssertEqual(controller.spots.first!.component.items[2].kind, initialComponentModels.first!.items[2].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[2].size, initialComponentModels.first!.items[2].size)
+    XCTAssertEqual(controller.spots.first!.model.items[2].title, initialComponentModels.first!.items[2].title)
+    XCTAssertEqual(controller.spots.first!.model.items[2].subtitle, initialComponentModels.first!.items[2].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[2].action, initialComponentModels.first!.items[2].action)
+    XCTAssertEqual(controller.spots.first!.model.items[2].kind, initialComponentModels.first!.items[2].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[2].size, initialComponentModels.first!.items[2].size)
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[2].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[2].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[2].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[2].size, view!.frame.size)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[3].title, initialComponentModels.first!.items[3].title)
-    XCTAssertEqual(controller.spots.first!.component.items[3].subtitle, initialComponentModels.first!.items[3].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[3].action, initialComponentModels.first!.items[3].action)
-    XCTAssertEqual(controller.spots.first!.component.items[3].kind, initialComponentModels.first!.items[3].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[3].size, initialComponentModels.first!.items[3].size)
+    XCTAssertEqual(controller.spots.first!.model.items[3].title, initialComponentModels.first!.items[3].title)
+    XCTAssertEqual(controller.spots.first!.model.items[3].subtitle, initialComponentModels.first!.items[3].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[3].action, initialComponentModels.first!.items[3].action)
+    XCTAssertEqual(controller.spots.first!.model.items[3].kind, initialComponentModels.first!.items[3].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[3].size, initialComponentModels.first!.items[3].size)
 
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[3].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[3].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[3].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[3].size, view!.frame.size)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[4].title, initialComponentModels.first!.items[4].title)
-    XCTAssertEqual(controller.spots.first!.component.items[4].subtitle, initialComponentModels.first!.items[4].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[4].action, initialComponentModels.first!.items[4].action)
-    XCTAssertEqual(controller.spots.first!.component.items[4].kind, initialComponentModels.first!.items[4].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[4].size, initialComponentModels.first!.items[4].size)
+    XCTAssertEqual(controller.spots.first!.model.items[4].title, initialComponentModels.first!.items[4].title)
+    XCTAssertEqual(controller.spots.first!.model.items[4].subtitle, initialComponentModels.first!.items[4].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[4].action, initialComponentModels.first!.items[4].action)
+    XCTAssertEqual(controller.spots.first!.model.items[4].kind, initialComponentModels.first!.items[4].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[4].size, initialComponentModels.first!.items[4].size)
 
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[4].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[4].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[4].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[4].size, view!.frame.size)
     #endif
 
-    XCTAssertEqual(controller.spots.first!.component.items[5].title, initialComponentModels.first!.items[5].title)
-    XCTAssertEqual(controller.spots.first!.component.items[5].subtitle, initialComponentModels.first!.items[5].subtitle)
-    XCTAssertEqual(controller.spots.first!.component.items[5].action, initialComponentModels.first!.items[5].action)
-    XCTAssertEqual(controller.spots.first!.component.items[5].kind, initialComponentModels.first!.items[5].kind)
-    XCTAssertNotEqual(controller.spots.first!.component.items[5].size, initialComponentModels.first!.items[5].size)
+    XCTAssertEqual(controller.spots.first!.model.items[5].title, initialComponentModels.first!.items[5].title)
+    XCTAssertEqual(controller.spots.first!.model.items[5].subtitle, initialComponentModels.first!.items[5].subtitle)
+    XCTAssertEqual(controller.spots.first!.model.items[5].action, initialComponentModels.first!.items[5].action)
+    XCTAssertEqual(controller.spots.first!.model.items[5].kind, initialComponentModels.first!.items[5].kind)
+    XCTAssertNotEqual(controller.spots.first!.model.items[5].size, initialComponentModels.first!.items[5].size)
 
     #if !os(OSX)
-      XCTAssertEqual(controller.spots.first!.component.items[5].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-      XCTAssertEqual(controller.spots.first!.component.items[5].size, view!.frame.size)
+      XCTAssertEqual(controller.spots.first!.model.items[5].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+      XCTAssertEqual(controller.spots.first!.model.items[5].size, view!.frame.size)
     #endif
 
     let expectation = self.expectation(description: "Reload controller with components")
     controller.reloadIfNeeded(newComponentModels) {
-      XCTAssertEqual(controller.spots.first!.component.items[0].title, newComponentModels.first!.items[0].title)
-      XCTAssertEqual(controller.spots.first!.component.items[0].subtitle, newComponentModels.first!.items[0].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[0].action, newComponentModels.first!.items[0].action)
-      XCTAssertEqual(controller.spots.first!.component.items[0].kind, newComponentModels.first!.items[0].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[0].size, newComponentModels.first!.items[0].size)
+      XCTAssertEqual(controller.spots.first!.model.items[0].title, newComponentModels.first!.items[0].title)
+      XCTAssertEqual(controller.spots.first!.model.items[0].subtitle, newComponentModels.first!.items[0].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[0].action, newComponentModels.first!.items[0].action)
+      XCTAssertEqual(controller.spots.first!.model.items[0].kind, newComponentModels.first!.items[0].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[0].size, newComponentModels.first!.items[0].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[0].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[0].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[0].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[0].size, view!.frame.size)
       #endif
 
-      XCTAssertEqual(controller.spots.first!.component.items[1].title, newComponentModels.first!.items[1].title)
-      XCTAssertEqual(controller.spots.first!.component.items[1].subtitle, newComponentModels.first!.items[1].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[1].action, newComponentModels.first!.items[1].action)
-      XCTAssertEqual(controller.spots.first!.component.items[1].kind, newComponentModels.first!.items[1].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[1].size, newComponentModels.first!.items[1].size)
+      XCTAssertEqual(controller.spots.first!.model.items[1].title, newComponentModels.first!.items[1].title)
+      XCTAssertEqual(controller.spots.first!.model.items[1].subtitle, newComponentModels.first!.items[1].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[1].action, newComponentModels.first!.items[1].action)
+      XCTAssertEqual(controller.spots.first!.model.items[1].kind, newComponentModels.first!.items[1].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[1].size, newComponentModels.first!.items[1].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[1].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[1].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[1].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[1].size, view!.frame.size)
       #endif
 
-      XCTAssertEqual(controller.spots.first!.component.items[2].title, newComponentModels.first!.items[2].title)
-      XCTAssertEqual(controller.spots.first!.component.items[2].subtitle, newComponentModels.first!.items[2].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[2].action, newComponentModels.first!.items[2].action)
-      XCTAssertEqual(controller.spots.first!.component.items[2].kind, newComponentModels.first!.items[2].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[2].size, newComponentModels.first!.items[2].size)
+      XCTAssertEqual(controller.spots.first!.model.items[2].title, newComponentModels.first!.items[2].title)
+      XCTAssertEqual(controller.spots.first!.model.items[2].subtitle, newComponentModels.first!.items[2].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[2].action, newComponentModels.first!.items[2].action)
+      XCTAssertEqual(controller.spots.first!.model.items[2].kind, newComponentModels.first!.items[2].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[2].size, newComponentModels.first!.items[2].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[2].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[2].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[2].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[2].size, view!.frame.size)
       #endif
 
-      XCTAssertEqual(controller.spots.first!.component.items[3].title, newComponentModels.first!.items[3].title)
-      XCTAssertEqual(controller.spots.first!.component.items[3].subtitle, newComponentModels.first!.items[3].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[3].action, newComponentModels.first!.items[3].action)
-      XCTAssertEqual(controller.spots.first!.component.items[3].kind, newComponentModels.first!.items[3].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[3].size, newComponentModels.first!.items[3].size)
+      XCTAssertEqual(controller.spots.first!.model.items[3].title, newComponentModels.first!.items[3].title)
+      XCTAssertEqual(controller.spots.first!.model.items[3].subtitle, newComponentModels.first!.items[3].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[3].action, newComponentModels.first!.items[3].action)
+      XCTAssertEqual(controller.spots.first!.model.items[3].kind, newComponentModels.first!.items[3].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[3].size, newComponentModels.first!.items[3].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[3].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[3].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[3].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[3].size, view!.frame.size)
       #endif
 
-      XCTAssertEqual(controller.spots.first!.component.items[4].title, newComponentModels.first!.items[4].title)
-      XCTAssertEqual(controller.spots.first!.component.items[4].subtitle, newComponentModels.first!.items[4].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[4].action, newComponentModels.first!.items[4].action)
-      XCTAssertEqual(controller.spots.first!.component.items[4].kind, newComponentModels.first!.items[4].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[4].size, newComponentModels.first!.items[4].size)
+      XCTAssertEqual(controller.spots.first!.model.items[4].title, newComponentModels.first!.items[4].title)
+      XCTAssertEqual(controller.spots.first!.model.items[4].subtitle, newComponentModels.first!.items[4].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[4].action, newComponentModels.first!.items[4].action)
+      XCTAssertEqual(controller.spots.first!.model.items[4].kind, newComponentModels.first!.items[4].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[4].size, newComponentModels.first!.items[4].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[4].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[4].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[4].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[4].size, view!.frame.size)
       #endif
 
-      XCTAssertEqual(controller.spots.first!.component.items[5].title, newComponentModels.first!.items[5].title)
-      XCTAssertEqual(controller.spots.first!.component.items[5].subtitle, newComponentModels.first!.items[5].subtitle)
-      XCTAssertEqual(controller.spots.first!.component.items[5].action, newComponentModels.first!.items[5].action)
-      XCTAssertEqual(controller.spots.first!.component.items[5].kind, newComponentModels.first!.items[5].kind)
-      XCTAssertNotEqual(controller.spots.first!.component.items[5].size, newComponentModels.first!.items[5].size)
+      XCTAssertEqual(controller.spots.first!.model.items[5].title, newComponentModels.first!.items[5].title)
+      XCTAssertEqual(controller.spots.first!.model.items[5].subtitle, newComponentModels.first!.items[5].subtitle)
+      XCTAssertEqual(controller.spots.first!.model.items[5].action, newComponentModels.first!.items[5].action)
+      XCTAssertEqual(controller.spots.first!.model.items[5].kind, newComponentModels.first!.items[5].kind)
+      XCTAssertNotEqual(controller.spots.first!.model.items[5].size, newComponentModels.first!.items[5].size)
       #if !os(OSX)
-        XCTAssertEqual(controller.spots.first!.component.items[5].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
-        XCTAssertEqual(controller.spots.first!.component.items[5].size, view!.frame.size)
+        XCTAssertEqual(controller.spots.first!.model.items[5].size, CGSize(width: controller.view.frame.width, height: view!.preferredViewSize.height))
+        XCTAssertEqual(controller.spots.first!.model.items[5].size, view!.frame.size)
       #endif
 
       expectation.fulfill()
@@ -881,7 +881,7 @@ class ControllerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    let spots = initialComponentModels.map { Factory.resolve(component: $0) }
+    let spots = initialComponentModels.map { Factory.resolve(model: $0) }
     let controller = Controller(spots: spots)
 
     controller.prepareController()

--- a/SpotsTests/Shared/TestSpotable.swift
+++ b/SpotsTests/Shared/TestSpotable.swift
@@ -5,7 +5,7 @@ import XCTest
 class SpotableTests: XCTestCase {
 
   func testAppendingMultipleItemsToSpot() {
-    let listSpot = ListSpot(component: ComponentModel(title: "ComponentModel", span: 1.0))
+    let listSpot = ListSpot(model: ComponentModel(title: "ComponentModel", span: 1.0))
     listSpot.setup(CGSize(width: 100, height: 100))
     var items: [Item] = []
 
@@ -29,7 +29,7 @@ class SpotableTests: XCTestCase {
   }
 
   func testAppendingMultipleItemsToSpotInController() {
-    let controller = Controller(spots: [ListSpot(component: ComponentModel(title: "ComponentModel", span: 1.0))])
+    let controller = Controller(spots: [ListSpot(model: ComponentModel(title: "ComponentModel", span: 1.0))])
     controller.prepareController()
     var items: [Item] = []
 
@@ -58,8 +58,8 @@ class SpotableTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: kind)
 
     let parentSize = CGSize(width: 100, height: 100)
-    let component = ComponentModel(items: [Item(title: "foo", kind: kind)])
-    let spot = GridSpot(component: component)
+    let model = ComponentModel(items: [Item(title: "foo", kind: kind)])
+    let spot = GridSpot(model: model)
     spot.view.frame.size = parentSize
     spot.setup(parentSize)
     spot.layout(parentSize)
@@ -80,8 +80,8 @@ class SpotableTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: kind)
 
     let parentSize = CGSize(width: 100, height: 100)
-    let component = ComponentModel(items: [Item(title: "foo", kind: kind)])
-    let spot = ListSpot(component: component)
+    let model = ComponentModel(items: [Item(title: "foo", kind: kind)])
+    let spot = ListSpot(model: model)
 
     spot.setup(parentSize)
     spot.layout(parentSize)

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -26,7 +26,7 @@ class StateCacheTests: XCTestCase {
     /// Check that cache is empty
     XCTAssertEqual(controller.stateCache!.load().count, 0)
 
-    controller.spots = [ListSpot(component: ComponentModel(span: 1.0))]
+    controller.spots = [ListSpot(model: ComponentModel(span: 1.0))]
 
     let expectation = self.expectation(description: "Append item to Spotable object")
     controller.append(Item(title: "foo"), spotIndex: 0, withAnimation: .automatic) {

--- a/SpotsTests/iOS/TestCarouselComposite.swift
+++ b/SpotsTests/iOS/TestCarouselComposite.swift
@@ -7,13 +7,13 @@ class CarouselCompositeTests: XCTestCase {
   func testCarouselComposite() {
     let view = CarouselComposite()
     var item = Item()
-    let gridSpot = CompositeSpot(spot: GridSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let gridSpot = CompositeSpot(spot: GridSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [gridSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeSpot(spot: CarouselSpot(component: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeSpot(spot: ListSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let carouselSpot = CompositeSpot(spot: CarouselSpot(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listSpot = CompositeSpot(spot: ListSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [carouselSpot, listSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -8,7 +8,7 @@ class CarouselSpotTests: XCTestCase {
   var cachedSpot: CarouselSpot!
 
   override func setUp() {
-    spot = CarouselSpot(component: ComponentModel(span: 1.0))
+    spot = CarouselSpot(model: ComponentModel(span: 1.0))
     cachedSpot = CarouselSpot(cacheKey: "cached-carousel-spot")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
@@ -20,8 +20,8 @@ class CarouselSpotTests: XCTestCase {
   }
 
   func testConvenienceInitWithSectionInsets() {
-    let component = ComponentModel(span: 1.0)
-    let spot = CarouselSpot(component,
+    let model = ComponentModel(span: 1.0)
+    let spot = CarouselSpot(model,
                         top: 5, left: 10, bottom: 5, right: 10, itemSpacing: 5)
 
     XCTAssertEqual(spot.layout.sectionInset, UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10))
@@ -29,21 +29,21 @@ class CarouselSpotTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let component = ComponentModel(title: "CarouselSpot", kind: "carousel", span: 3, meta: ["headerHeight": 44.0])
-    let spot = CarouselSpot(component: component)
-    XCTAssertEqual(component.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
-    XCTAssertEqual(component.dictionary["title"] as? String, spot.dictionary["title"] as? String)
-    XCTAssertEqual(component.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
-    XCTAssertEqual(component.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
+    let model = ComponentModel(title: "CarouselSpot", kind: "carousel", span: 3, meta: ["headerHeight": 44.0])
+    let spot = CarouselSpot(model: model)
+    XCTAssertEqual(model.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
+    XCTAssertEqual(model.dictionary["title"] as? String, spot.dictionary["title"] as? String)
+    XCTAssertEqual(model.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
+    XCTAssertEqual(model.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
     XCTAssertEqual(
-      (component.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
+      (model.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
       (spot.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat
     )
   }
 
   func testSafelyResolveKind() {
-    let component = ComponentModel(title: "CarouselSpot", kind: "custom-carousel", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let carouselSpot = CarouselSpot(component: component)
+    let model = ComponentModel(title: "CarouselSpot", kind: "custom-carousel", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let carouselSpot = CarouselSpot(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
     XCTAssertEqual(carouselSpot.identifier(at: indexPath), CarouselSpot.views.defaultIdentifier)
@@ -72,8 +72,8 @@ class CarouselSpotTests: XCTestCase {
 
     ComponentModel.legacyMapping = true
 
-    var component = ComponentModel(json)
-    var spot = CarouselSpot(component: component)
+    var model = ComponentModel(json)
+    var spot = CarouselSpot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.layout.minimumInteritemSpacing, 25.0)
@@ -88,8 +88,8 @@ class CarouselSpotTests: XCTestCase {
       ]
     ]
 
-    component = ComponentModel(json)
-    spot = CarouselSpot(component: component)
+    model = ComponentModel(json)
+    spot = CarouselSpot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.layout.minimumInteritemSpacing, 12.5)
@@ -124,8 +124,8 @@ class CarouselSpotTests: XCTestCase {
       ]
     ]
 
-    let component = ComponentModel(json)
-    let spot = CarouselSpot(component: component)
+    let model = ComponentModel(json)
+    let spot = CarouselSpot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     // Test that spot height is equal to first item in the list
@@ -162,12 +162,12 @@ class CarouselSpotTests: XCTestCase {
       ).dictionary
     ]
 
-    let component = ComponentModel(json)
-    let spot = CarouselSpot(component: component)
+    let model = ComponentModel(json)
+    let spot = CarouselSpot(model: model)
     let parentSize = CGSize(width: 667, height: 225)
 
     // Check `span` mapping
-    XCTAssertEqual(spot.component.layout!.span, 4.0)
+    XCTAssertEqual(spot.model.layout!.span, 4.0)
 
     spot.setup(parentSize)
     spot.layout(parentSize)
@@ -220,8 +220,8 @@ class CarouselSpotTests: XCTestCase {
       ).dictionary
     ]
 
-    let component = ComponentModel(json)
-    let spot = CarouselSpot(component: component)
+    let model = ComponentModel(json)
+    let spot = CarouselSpot(model: model)
     let parentSize = CGSize(width: 667, height: 225)
 
     spot.setup(parentSize)
@@ -230,7 +230,7 @@ class CarouselSpotTests: XCTestCase {
     spot.view.layoutSubviews()
 
     // Sanity check, to make sure we have our page indicator in overlay mode
-    XCTAssertEqual(component.layout!.pageIndicatorPlacement, .overlay)
+    XCTAssertEqual(model.layout!.pageIndicatorPlacement, .overlay)
 
     // Assert item layout (derived from preferred view size)
     XCTAssertEqual(spot.items[0].size.height, 88)
@@ -299,8 +299,8 @@ class CarouselSpotTests: XCTestCase {
     let collectionView = CollectionViewMock(frame: .zero, collectionViewLayout: layout)
     collectionView.itemSize = CGSize(width: 200, height: 100)
 
-    let component = ComponentModel(json)
-    let spot = CarouselSpot(component: component, collectionView: collectionView, layout: layout)
+    let model = ComponentModel(json)
+    let spot = CarouselSpot(model: model, collectionView: collectionView, layout: layout)
     let parentSize = CGSize(width: 300, height: 100)
 
     spot.setup(parentSize)
@@ -332,10 +332,10 @@ class CarouselSpotTests: XCTestCase {
 
   func testAppendItem() {
     let item = Item(title: "test")
-    let spot = CarouselSpot(component: ComponentModel(span: 1))
+    let spot = CarouselSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Append item")
     spot.append(item) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -343,10 +343,10 @@ class CarouselSpotTests: XCTestCase {
 
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = CarouselSpot(component: ComponentModel(span: 1))
+    let spot = CarouselSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Append items")
     spot.append(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -354,10 +354,10 @@ class CarouselSpotTests: XCTestCase {
 
   func testInsertItem() {
     let item = Item(title: "test")
-    let spot = CarouselSpot(component: ComponentModel(span: 1))
+    let spot = CarouselSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -365,10 +365,10 @@ class CarouselSpotTests: XCTestCase {
 
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = CarouselSpot(component: ComponentModel(span: 1))
+    let spot = CarouselSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -377,7 +377,7 @@ class CarouselSpotTests: XCTestCase {
   func testSpotCache() {
     let item = Item(title: "test")
 
-    XCTAssertEqual(cachedSpot.component.items.count, 0)
+    XCTAssertEqual(cachedSpot.model.items.count, 0)
     cachedSpot.append(item) {
       self.cachedSpot.cache()
     }
@@ -386,7 +386,7 @@ class CarouselSpotTests: XCTestCase {
     Dispatch.after(seconds: 0.25) { [weak self] in
       guard let weakSelf = self else { return }
       let cachedSpot = CarouselSpot(cacheKey: weakSelf.cachedSpot.stateCache!.key)
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
@@ -397,7 +397,7 @@ class CarouselSpotTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let spot = CarouselSpot(component: ComponentModel(span: 0.0, items: items))
+    let spot = CarouselSpot(model: ComponentModel(span: 0.0, items: items))
     spot.setup(CGSize(width: 100, height: 100))
     spot.layout(CGSize(width: 100, height: 100))
     spot.view.layoutSubviews()

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -6,7 +6,7 @@ class DataSourceTests: XCTestCase {
 
   func testDataSourceForListableObject() {
     ListSpot.register(view: CustomListCell.self, identifier: "custom")
-    let spot = ListSpot(component: ComponentModel(span: 1.0, items: [
+    let spot = ListSpot(model: ComponentModel(span: 1.0, items: [
       Item(title: "title 1"),
       Item(title: "title 2")
       ]))
@@ -16,24 +16,24 @@ class DataSourceTests: XCTestCase {
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
-    XCTAssertEqual(itemCell1.textLabel?.text, spot.component.items[0].title)
-    XCTAssertEqual(itemCell2.textLabel?.text, spot.component.items[1].title)
+    XCTAssertEqual(itemCell1.textLabel?.text, spot.model.items[0].title)
+    XCTAssertEqual(itemCell2.textLabel?.text, spot.model.items[1].title)
 
     /// Check that data source always returns a cell
     let itemCell3 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
-    spot.component.items[0].kind = "custom"
-    spot.component.items[0].size.height = 0.0
+    spot.model.items[0].kind = "custom"
+    spot.model.items[0].size.height = 0.0
     itemCell1 = spot.spotDataSource!.tableView(spot.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
     let itemConfigurable = itemCell1 as! CustomListCell
-    XCTAssertEqual(spot.component.items[0].size.height, itemConfigurable.preferredViewSize.height)
+    XCTAssertEqual(spot.model.items[0].size.height, itemConfigurable.preferredViewSize.height)
   }
 
   func testDataSourceForGridableObject() {
     GridSpot.register(view: CustomGridCell.self, identifier: "custom")
-    let spot = GridSpot(component: ComponentModel(span: 1.0, items: [
+    let spot = GridSpot(model: ComponentModel(span: 1.0, items: [
       Item(title: "title 1"),
       Item(title: "title 2")
       ]))
@@ -49,16 +49,16 @@ class DataSourceTests: XCTestCase {
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
-    spot.component.items[0].kind = "custom"
-    spot.component.items[0].size.height = 0.0
+    spot.model.items[0].kind = "custom"
+    spot.model.items[0].size.height = 0.0
     itemCell1 = spot.spotDataSource!.collectionView(spot.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
     let itemConfigurable = itemCell1 as! CustomGridCell
-    XCTAssertEqual(spot.component.items[0].size.height, itemConfigurable.preferredViewSize.height)
+    XCTAssertEqual(spot.model.items[0].size.height, itemConfigurable.preferredViewSize.height)
   }
 
   func testDataSourceForGridableDefaultHeader() {
     GridSpot.register(defaultHeader: CustomGridHeaderView.self)
-    let spot = GridSpot(component: ComponentModel(
+    let spot = GridSpot(model: ComponentModel(
       header: "",
       span: 1.0,
       items: [
@@ -76,7 +76,7 @@ class DataSourceTests: XCTestCase {
 
   func testDataSourceForGridableCustomHeader() {
     GridSpot.register(header: CustomGridHeaderView.self, identifier: "custom-header")
-    let spot = GridSpot(component: ComponentModel(
+    let spot = GridSpot(model: ComponentModel(
       header: "custom-header",
       span: 1.0,
       items: [

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -6,7 +6,7 @@ class TestDelegate: SpotsDelegate {
   var countsInvoked = 0
 
   func spotable(_ spot: Spotable, itemSelected item: Item) {
-    spot.component.items[item.index].meta["selected"] = true
+    spot.model.items[item.index].meta["selected"] = true
     countsInvoked += 1
   }
 }
@@ -17,13 +17,13 @@ class DelegateTests: XCTestCase {
 
   func testCollectionViewDelegateSelection() {
     let delegate = TestDelegate()
-    let spot = GridSpot(component: ComponentModel(span: 1, items: [
+    let spot = GridSpot(model: ComponentModel(span: 1, items: [
       Item(title: "title 1")
       ]))
     spot.delegate = delegate
     spot.spotDelegate?.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
 
-    XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
+    XCTAssertEqual(spot.model.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
     spot.spotDelegate?.collectionView(spot.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
@@ -31,7 +31,7 @@ class DelegateTests: XCTestCase {
   }
 
   func testCollectionViewCanFocus() {
-    let spot = GridSpot(component: ComponentModel(span: 1, items: [Item(title: "title 1")]))
+    let spot = GridSpot(model: ComponentModel(span: 1, items: [Item(title: "title 1")]))
     XCTAssertEqual(spot.spotDelegate?.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
     XCTAssertEqual(spot.spotDelegate?.collectionView(spot.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
   }
@@ -40,13 +40,13 @@ class DelegateTests: XCTestCase {
 
   func testTableViewDelegateSelection() {
     let delegate = TestDelegate()
-    let spot = ListSpot(component: ComponentModel(span: 1, items: [
+    let spot = ListSpot(model: ComponentModel(span: 1, items: [
       Item(title: "title 1")
       ]))
     spot.delegate = delegate
     spot.spotDelegate?.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
 
-    XCTAssertEqual(spot.component.items[0].meta["selected"] as? Bool, true)
+    XCTAssertEqual(spot.model.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
     spot.spotDelegate?.tableView(spot.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
@@ -54,7 +54,7 @@ class DelegateTests: XCTestCase {
   }
 
   func testTableViewHeightForRowOnListable() {
-    let spot = ListSpot(component: ComponentModel(span: 1, items: [Item(title: "title 1")]))
+    let spot = ListSpot(model: ComponentModel(span: 1, items: [Item(title: "title 1")]))
     spot.setup(CGSize(width: 100, height: 100))
     XCTAssertEqual(spot.spotDelegate?.tableView(spot.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
     XCTAssertEqual(spot.spotDelegate?.tableView(spot.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
@@ -62,7 +62,7 @@ class DelegateTests: XCTestCase {
 
   func testDelegateTitleForHeader() {
     ListSpot.register(header: CustomListHeaderView.self, identifier: "list")
-    let spot = ListSpot(component: ComponentModel(
+    let spot = ListSpot(model: ComponentModel(
       title: "title",
       header: "list",
       span: 1,
@@ -81,12 +81,12 @@ class DelegateTests: XCTestCase {
     XCTAssertEqual(title, nil)
 
     /// Expect to return title if header is empty.
-    spot.component.header = ""
+    spot.model.header = ""
     title = spot.spotDelegate?.tableView(spot.tableView, titleForHeaderInSection: 0)
-    XCTAssertEqual(title, spot.component.title)
+    XCTAssertEqual(title, spot.model.title)
 
     /// Expect to return nil if title and header is empty.
-    spot.component.title = ""
+    spot.model.title = ""
     title = spot.spotDelegate?.tableView(spot.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, nil)
 

--- a/SpotsTests/iOS/TestFactory.swift
+++ b/SpotsTests/iOS/TestFactory.swift
@@ -15,16 +15,16 @@ class FactoryTests: XCTestCase {
   func testRegisterAndResolve() {
     Factory.register(kind: "merry-go-round", spot: CarouselSpot.self)
 
-    let component = ComponentModel(json)
-    var spot = Factory.resolve(component: component)
+    let model = ComponentModel(json)
+    var spot = Factory.resolve(model: model)
 
-    XCTAssertTrue(spot.component == component)
+    XCTAssertTrue(spot.model == model)
     XCTAssertTrue(spot is CarouselSpot)
 
     Factory.register(kind: "merry-go-round", spot: GridSpot.self)
-    spot = Factory.resolve(component: component)
+    spot = Factory.resolve(model: model)
 
-    XCTAssertTrue(spot.component == component)
+    XCTAssertTrue(spot.model == model)
     XCTAssertTrue(spot is GridSpot)
   }
 
@@ -32,10 +32,10 @@ class FactoryTests: XCTestCase {
     var newJson = json
     newJson["type"] = "weirdo" as AnyObject?
 
-    let component = ComponentModel(newJson)
-    let spot = Factory.resolve(component: component)
+    let model = ComponentModel(newJson)
+    let spot = Factory.resolve(model: model)
 
-    XCTAssertTrue(spot.component == component)
+    XCTAssertTrue(spot.model == model)
     XCTAssertTrue(spot is GridSpot)
   }
 
@@ -56,7 +56,7 @@ class FactoryTests: XCTestCase {
     ]
 
     let spots: [Spotable] = initialComponentModels.map {
-      let spot = Factory.resolve(component: $0)
+      let spot = Factory.resolve(model: $0)
       spot.setup(CGSize(width: 100, height: 100))
       return spot
     }
@@ -66,10 +66,10 @@ class FactoryTests: XCTestCase {
     XCTAssert(spots.first is ListSpot)
 
     /// Test first item in the first component of the first spot
-    XCTAssertEqual(spots.first!.component.kind, "list")
-    XCTAssertEqual(spots.first!.component.items[0].title, "Fullname")
-    XCTAssertEqual(spots.first!.component.items[0].subtitle, "Job title")
-    XCTAssertEqual(spots.first!.component.items[0].kind, "image")
-    XCTAssertEqual(spots.first!.component.items[0].size, CGSize(width: 100, height: 44))
+    XCTAssertEqual(spots.first!.model.kind, "list")
+    XCTAssertEqual(spots.first!.model.items[0].title, "Fullname")
+    XCTAssertEqual(spots.first!.model.items[0].subtitle, "Job title")
+    XCTAssertEqual(spots.first!.model.items[0].kind, "image")
+    XCTAssertEqual(spots.first!.model.items[0].size, CGSize(width: 100, height: 44))
   }
 }

--- a/SpotsTests/iOS/TestGridComposite.swift
+++ b/SpotsTests/iOS/TestGridComposite.swift
@@ -7,13 +7,13 @@ class GridCompositeTests: XCTestCase {
   func testGridComposite() {
     let view = GridComposite()
     var item = Item()
-    let gridSpot = CompositeSpot(spot: GridSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let gridSpot = CompositeSpot(spot: GridSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [gridSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeSpot(spot: CarouselSpot(component: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeSpot(spot: ListSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let carouselSpot = CompositeSpot(spot: CarouselSpot(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listSpot = CompositeSpot(spot: ListSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [carouselSpot, listSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -8,7 +8,7 @@ class GridSpotTests: XCTestCase {
   var cachedSpot: GridSpot!
 
   override func setUp() {
-    spot = GridSpot(component: ComponentModel(span: 1.0))
+    spot = GridSpot(model: ComponentModel(span: 1.0))
     cachedSpot = GridSpot(cacheKey: "cached-grid-spot")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
@@ -20,8 +20,8 @@ class GridSpotTests: XCTestCase {
   }
 
   func testConvenienceInitWithSectionInsets() {
-    let component = ComponentModel(span: 1.0)
-    let spot = GridSpot(component,
+    let model = ComponentModel(span: 1.0)
+    let spot = GridSpot(model,
                        top: 5, left: 10, bottom: 5, right: 10, itemSpacing: 5)
 
     XCTAssertEqual(spot.layout.sectionInset, UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10))
@@ -29,21 +29,21 @@ class GridSpotTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let component = ComponentModel(title: "GridSpot", kind: "row", span: 3, meta: ["headerHeight": 44.0])
-    let spot = GridSpot(component: component)
-    XCTAssertEqual(component.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
-    XCTAssertEqual(component.dictionary["title"] as? String, spot.dictionary["title"] as? String)
-    XCTAssertEqual(component.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
-    XCTAssertEqual(component.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
+    let model = ComponentModel(title: "GridSpot", kind: "row", span: 3, meta: ["headerHeight": 44.0])
+    let spot = GridSpot(model: model)
+    XCTAssertEqual(model.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
+    XCTAssertEqual(model.dictionary["title"] as? String, spot.dictionary["title"] as? String)
+    XCTAssertEqual(model.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
+    XCTAssertEqual(model.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
     XCTAssertEqual(
-      (component.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
+      (model.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
       (spot.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat
     )
   }
 
   func testSafelyResolveKind() {
-    let component = ComponentModel(title: "GridSpot", kind: "custom-grid", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let rowSpot = GridSpot(component: component)
+    let model = ComponentModel(title: "GridSpot", kind: "custom-grid", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let rowSpot = GridSpot(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
     XCTAssertEqual(rowSpot.identifier(at: indexPath), GridSpot.views.defaultIdentifier)
@@ -62,10 +62,10 @@ class GridSpotTests: XCTestCase {
 
   func testAppendItem() {
     let item = Item(title: "test")
-    let spot = GridSpot(component: ComponentModel(span: 1.0))
+    let spot = GridSpot(model: ComponentModel(span: 1.0))
     let expectation = self.expectation(description: "Append item")
     spot.append(item) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -73,10 +73,10 @@ class GridSpotTests: XCTestCase {
 
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = GridSpot(component: ComponentModel(span: 1.0))
+    let spot = GridSpot(model: ComponentModel(span: 1.0))
     let expectation = self.expectation(description: "Append items")
     spot.append(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -84,10 +84,10 @@ class GridSpotTests: XCTestCase {
 
   func testInsertItem() {
     let item = Item(title: "test")
-    let spot = GridSpot(component: ComponentModel(span: 1.0))
+    let spot = GridSpot(model: ComponentModel(span: 1.0))
     let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -95,10 +95,10 @@ class GridSpotTests: XCTestCase {
 
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = GridSpot(component: ComponentModel(span: 1.0))
+    let spot = GridSpot(model: ComponentModel(span: 1.0))
     let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -106,7 +106,7 @@ class GridSpotTests: XCTestCase {
 
   func testSpotCollectionDelegate() {
     let items = [Item(title: "Test item")]
-    let spot = GridSpot(component: ComponentModel(span: 0.0, items: items))
+    let spot = GridSpot(model: ComponentModel(span: 0.0, items: items))
     spot.view.frame.size = CGSize(width: 100, height: 100)
     spot.view.layoutSubviews()
 
@@ -117,7 +117,7 @@ class GridSpotTests: XCTestCase {
   func testSpotCache() {
     let item = Item(title: "test")
 
-    XCTAssertEqual(cachedSpot.component.items.count, 0)
+    XCTAssertEqual(cachedSpot.model.items.count, 0)
     cachedSpot.append(item) { [weak self] in
       self?.cachedSpot.cache()
     }
@@ -125,7 +125,7 @@ class GridSpotTests: XCTestCase {
     let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = GridSpot(cacheKey: self.cachedSpot.stateCache!.key)
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
@@ -136,7 +136,7 @@ class GridSpotTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let spot = GridSpot(component: ComponentModel(span: 0.0, items: items))
+    let spot = GridSpot(model: ComponentModel(span: 0.0, items: items))
     spot.setup(CGSize(width: 100, height: 100))
     spot.layout(CGSize(width: 100, height: 100))
     spot.view.layoutSubviews()

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -7,13 +7,13 @@ class TestGridableLayout: XCTestCase {
   let parentSize = CGSize(width: 100, height: 100)
 
   func testContentSizeForHorizontalLayoutsWithoutInsets() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       items: [
         Item(title: "foo", size: CGSize(width: 50, height: 50)),
         Item(title: "bar", size: CGSize(width: 50, height: 50))
       ]
     )
-    let carouselSpot = CarouselSpot(component: component)
+    let carouselSpot = CarouselSpot(model: model)
     carouselSpot.setup(parentSize)
     carouselSpot.layout(parentSize)
     carouselSpot.view.layoutSubviews()
@@ -23,7 +23,7 @@ class TestGridableLayout: XCTestCase {
   }
 
   func testContentSizeForHorizontalLayoutsWithInsets() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       layout: Layout(
         inset: Inset(top: 25, left: 25, bottom: 25, right: 25)
       ),
@@ -32,7 +32,7 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: CGSize(width: 50, height: 100))
       ]
     )
-    let carouselSpot = CarouselSpot(component: component)
+    let carouselSpot = CarouselSpot(model: model)
     carouselSpot.setup(parentSize)
     carouselSpot.layout(parentSize)
     carouselSpot.view.layoutSubviews()
@@ -43,7 +43,7 @@ class TestGridableLayout: XCTestCase {
 
   func testLayoutAttributesForElementInHorizontalLayoutWithInsets() {
     let itemSize = CGSize(width: 50, height: 100)
-    let component = ComponentModel(
+    let model = ComponentModel(
       layout: Layout(
         inset: Inset(top: 25, left: 25, bottom: 25, right: 25)
       ),
@@ -52,7 +52,7 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: itemSize)
       ]
     )
-    let carouselSpot = CarouselSpot(component: component)
+    let carouselSpot = CarouselSpot(model: model)
     carouselSpot.setup(parentSize)
     carouselSpot.layout(parentSize)
     carouselSpot.view.layoutSubviews()
@@ -61,16 +61,16 @@ class TestGridableLayout: XCTestCase {
 
     let expectedFrameA = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left,
-        y: component.layout!.inset.top
+        x: model.layout!.inset.left,
+        y: model.layout!.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameB = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left + Double(itemSize.width),
-        y: component.layout!.inset.top
+        x: model.layout!.inset.left + Double(itemSize.width),
+        y: model.layout!.inset.top
       ),
       size: itemSize
     )
@@ -82,7 +82,7 @@ class TestGridableLayout: XCTestCase {
 
   func testLayoutAttributesForElementInHorizontalLayoutWithItemSpacing() {
     let itemSize = CGSize(width: 50, height: 100)
-    let component = ComponentModel(
+    let model = ComponentModel(
       layout: Layout(
         itemSpacing: 10.0
       ),
@@ -91,7 +91,7 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: itemSize)
       ]
     )
-    let carouselSpot = CarouselSpot(component: component)
+    let carouselSpot = CarouselSpot(model: model)
     carouselSpot.setup(parentSize)
     carouselSpot.layout(parentSize)
     carouselSpot.view.layoutSubviews()
@@ -99,13 +99,13 @@ class TestGridableLayout: XCTestCase {
     let layoutAttributes = carouselSpot.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
 
     XCTAssertEqual(layoutAttributes?.count, 2)
-    XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: component.layout!.inset.top), size: itemSize))
-    XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width) + component.layout!.itemSpacing, y: component.layout!.inset.top), size: itemSize))
+    XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: model.layout!.inset.top), size: itemSize))
+    XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width) + model.layout!.itemSpacing, y: model.layout!.inset.top), size: itemSize))
   }
 
   func testLayoutAttributesForElementInVerticalLayoutWithInsets() {
     let itemSize = CGSize(width: 25, height: 25)
-    let component = ComponentModel(
+    let model = ComponentModel(
       layout: Layout(
         itemSpacing: 0,
         inset: Inset(top: 10, left: 30, bottom: 40, right: 20)
@@ -118,7 +118,7 @@ class TestGridableLayout: XCTestCase {
       ]
     )
 
-    let spot = GridSpot(component: component)
+    let spot = GridSpot(model: model)
     spot.setup(parentSize)
     spot.layout(parentSize)
     spot.view.layoutSubviews()
@@ -127,32 +127,32 @@ class TestGridableLayout: XCTestCase {
 
     let expectedFrameA = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left,
-        y: component.layout!.inset.top
+        x: model.layout!.inset.left,
+        y: model.layout!.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameB = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left + Double(itemSize.width),
-        y: component.layout!.inset.top
+        x: model.layout!.inset.left + Double(itemSize.width),
+        y: model.layout!.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameC = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left,
-        y: component.layout!.inset.top + Double(itemSize.height)
+        x: model.layout!.inset.left,
+        y: model.layout!.inset.top + Double(itemSize.height)
       ),
       size: itemSize
     )
 
     let expectedFrameD = CGRect(
       origin: CGPoint(
-        x: component.layout!.inset.left + Double(itemSize.width),
-        y: component.layout!.inset.top + Double(itemSize.height)
+        x: model.layout!.inset.left + Double(itemSize.width),
+        y: model.layout!.inset.top + Double(itemSize.height)
       ),
       size: itemSize
     )
@@ -164,8 +164,8 @@ class TestGridableLayout: XCTestCase {
     XCTAssertEqual(layoutAttributes?[3].frame, expectedFrameD)
 
     let expectedContentSize = CGSize(
-      width: component.layout!.inset.left + component.layout!.inset.right + Double(itemSize.width) * 2,
-      height: component.layout!.inset.top + component.layout!.inset.bottom + Double(itemSize.height) * 2
+      width: model.layout!.inset.left + model.layout!.inset.right + Double(itemSize.width) * 2,
+      height: model.layout!.inset.top + model.layout!.inset.bottom + Double(itemSize.height) * 2
     )
 
     XCTAssertEqual(spot.layout.collectionViewContentSize, expectedContentSize)

--- a/SpotsTests/iOS/TestLayoutExtensions.swift
+++ b/SpotsTests/iOS/TestLayoutExtensions.swift
@@ -21,7 +21,7 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableSpot() {
-    let gridSpot = GridSpot(component: ComponentModel(span: 1))
+    let gridSpot = GridSpot(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
     layout.configure(spot: gridSpot)
@@ -36,7 +36,7 @@ class LayoutExtensionsTests: XCTestCase {
   }
 
   func testConfigureListableSpot() {
-    let listSpot = ListSpot(component: ComponentModel(span: 1))
+    let listSpot = ListSpot(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
     layout.configure(spot: listSpot)

--- a/SpotsTests/iOS/TestListComposite.swift
+++ b/SpotsTests/iOS/TestListComposite.swift
@@ -7,13 +7,13 @@ class ListCompositeTests: XCTestCase {
   func testListComposite() {
     let view = ListComposite()
     var item = Item()
-    let gridSpot = CompositeSpot(spot: GridSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let gridSpot = CompositeSpot(spot: GridSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [gridSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeSpot(spot: CarouselSpot(component: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeSpot(spot: ListSpot(component: ComponentModel(span: 1)), itemIndex: 0)
+    let carouselSpot = CompositeSpot(spot: CarouselSpot(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listSpot = CompositeSpot(spot: ListSpot(model: ComponentModel(span: 1)), itemIndex: 0)
     view.configure(&item, compositeSpots: [carouselSpot, listSpot])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -17,21 +17,21 @@ class ListSpotTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let component = ComponentModel(title: "ListSpot", kind: "list", span: 3, meta: ["headerHeight": 44.0])
-    let spot = ListSpot(component: component)
-    XCTAssertEqual(component.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
-    XCTAssertEqual(component.dictionary["title"] as? String, spot.dictionary["title"] as? String)
-    XCTAssertEqual(component.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
-    XCTAssertEqual(component.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
+    let model = ComponentModel(title: "ListSpot", kind: "list", span: 3, meta: ["headerHeight": 44.0])
+    let spot = ListSpot(model: model)
+    XCTAssertEqual(model.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
+    XCTAssertEqual(model.dictionary["title"] as? String, spot.dictionary["title"] as? String)
+    XCTAssertEqual(model.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
+    XCTAssertEqual(model.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
     XCTAssertEqual(
-      (component.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
+      (model.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
       (spot.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat
     )
   }
 
   func testSafelyResolveKind() {
-    let component = ComponentModel(title: "ListSpot", kind: "custom-list", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let listSpot = ListSpot(component: component)
+    let model = ComponentModel(title: "ListSpot", kind: "custom-list", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let listSpot = ListSpot(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
     XCTAssertEqual(listSpot.identifier(at: indexPath), ListSpot.views.defaultIdentifier)
@@ -51,7 +51,7 @@ class ListSpotTests: XCTestCase {
   func testSpotCache() {
     let item = Item(title: "test")
 
-    XCTAssertEqual(cachedSpot.component.items.count, 0)
+    XCTAssertEqual(cachedSpot.model.items.count, 0)
     cachedSpot.append(item) {
       self.cachedSpot.cache()
     }
@@ -59,7 +59,7 @@ class ListSpotTests: XCTestCase {
     let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = ListSpot(cacheKey: self.cachedSpot.stateCache!.key)
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
@@ -70,7 +70,7 @@ class ListSpotTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let spot = ListSpot(component: ComponentModel(span: 0.0, items: items))
+    let spot = ListSpot(model: ComponentModel(span: 0.0, items: items))
     spot.setup(CGSize(width: 100, height: 100))
     spot.layout(CGSize(width: 100, height: 100))
     spot.view.layoutSubviews()

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -8,7 +8,7 @@ class RowSpotTests: XCTestCase {
   var cachedSpot: RowSpot!
 
   override func setUp() {
-    spot = RowSpot(component: ComponentModel(span: 1))
+    spot = RowSpot(model: ComponentModel(span: 1))
     cachedSpot = RowSpot(cacheKey: "cached-row-spot")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
@@ -20,8 +20,8 @@ class RowSpotTests: XCTestCase {
   }
 
   func testConvenienceInitWithSectionInsets() {
-    let component = ComponentModel(span: 1)
-    let spot = RowSpot(component,
+    let model = ComponentModel(span: 1)
+    let spot = RowSpot(model,
                         top: 5, left: 10, bottom: 5, right: 10, itemSpacing: 5)
 
     XCTAssertEqual(spot.layout.sectionInset, UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10))
@@ -29,21 +29,21 @@ class RowSpotTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let component = ComponentModel(title: "RowSpot", kind: "row", span: 3, meta: ["headerHeight": 44.0])
-    let spot = RowSpot(component: component)
-    XCTAssertEqual(component.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
-    XCTAssertEqual(component.dictionary["title"] as? String, spot.dictionary["title"] as? String)
-    XCTAssertEqual(component.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
-    XCTAssertEqual(component.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
+    let model = ComponentModel(title: "RowSpot", kind: "row", span: 3, meta: ["headerHeight": 44.0])
+    let spot = RowSpot(model: model)
+    XCTAssertEqual(model.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
+    XCTAssertEqual(model.dictionary["title"] as? String, spot.dictionary["title"] as? String)
+    XCTAssertEqual(model.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
+    XCTAssertEqual(model.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
     XCTAssertEqual(
-      (component.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
+      (model.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
       (spot.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat
     )
   }
 
   func testSafelyResolveKind() {
-    let component = ComponentModel(title: "RowSpot", kind: "custom-grid", span: 1, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let rowSpot = RowSpot(component: component)
+    let model = ComponentModel(title: "RowSpot", kind: "custom-grid", span: 1, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let rowSpot = RowSpot(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
     XCTAssertEqual(rowSpot.identifier(at: indexPath), RowSpot.views.defaultIdentifier)
@@ -62,10 +62,10 @@ class RowSpotTests: XCTestCase {
 
   func testAppendItem() {
     let item = Item(title: "test")
-    let spot = RowSpot(component: ComponentModel(span: 1))
+    let spot = RowSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Append item")
     spot.append(item) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -73,10 +73,10 @@ class RowSpotTests: XCTestCase {
 
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = RowSpot(component: ComponentModel(span: 1))
+    let spot = RowSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Append items")
     spot.append(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -84,10 +84,10 @@ class RowSpotTests: XCTestCase {
 
   func testInsertItem() {
     let item = Item(title: "test")
-    let spot = RowSpot(component: ComponentModel(span: 1))
+    let spot = RowSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Insert item")
     spot.insert(item, index: 0) {
-      XCTAssert(spot.component.items.first! == item)
+      XCTAssert(spot.model.items.first! == item)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -95,10 +95,10 @@ class RowSpotTests: XCTestCase {
 
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let spot = RowSpot(component: ComponentModel(span: 1))
+    let spot = RowSpot(model: ComponentModel(span: 1))
     let expectation = self.expectation(description: "Prepend items")
     spot.prepend(items) {
-      XCTAssert(spot.component.items == items)
+      XCTAssert(spot.model.items == items)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -106,7 +106,7 @@ class RowSpotTests: XCTestCase {
 
   func testSpotCollectionDelegate() {
     let items = [Item(title: "Test item")]
-    let spot = RowSpot(component: ComponentModel(span: 1, items: items))
+    let spot = RowSpot(model: ComponentModel(span: 1, items: items))
     spot.view.frame.size = CGSize(width: 100, height: 100)
     spot.view.layoutSubviews()
 
@@ -117,7 +117,7 @@ class RowSpotTests: XCTestCase {
   func testSpotCache() {
     let item = Item(title: "test")
 
-    XCTAssertEqual(cachedSpot.component.items.count, 0)
+    XCTAssertEqual(cachedSpot.model.items.count, 0)
     cachedSpot.append(item) {
       self.cachedSpot.cache()
     }
@@ -125,7 +125,7 @@ class RowSpotTests: XCTestCase {
     let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) {
       let cachedSpot = RowSpot(cacheKey: self.cachedSpot.stateCache!.key)
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
     }
@@ -136,7 +136,7 @@ class RowSpotTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let spot = RowSpot(component: ComponentModel(span: 0.0, items: items))
+    let spot = RowSpot(model: ComponentModel(span: 0.0, items: items))
     spot.setup(CGSize(width: 100, height: 100))
     spot.layout(CGSize(width: 100, height: 100))
     spot.view.layoutSubviews()

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -13,8 +13,8 @@ class TestSpot: XCTestCase {
 
   func testDefaultValues() {
     let items = [Item(title: "A"), Item(title: "B")]
-    let component = ComponentModel(items: items, hybrid: true)
-    let spot = Spot(component: component)
+    let model = ComponentModel(items: items, hybrid: true)
+    let spot = Spot(model: model)
 
     spot.setup(CGSize(width: 100, height: 100))
 
@@ -39,7 +39,7 @@ class TestSpot: XCTestCase {
     let item = Item(title: "test")
     let spot = Spot(cacheKey: "test-spot-cache")
 
-    XCTAssertEqual(spot.component.items.count, 0)
+    XCTAssertEqual(spot.model.items.count, 0)
     spot.append(item) {
       spot.cache()
     }
@@ -52,8 +52,8 @@ class TestSpot: XCTestCase {
       }
 
       let cachedSpot = Spot(cacheKey: cacheKey)
-      XCTAssertEqual(cachedSpot.component.items[0].title, "test")
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items[0].title, "test")
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
 
@@ -64,10 +64,10 @@ class TestSpot: XCTestCase {
 
   func testCompareHybridListSpotWithCoreType() {
     let items = [Item(title: "A"), Item(title: "B")]
-    let component = ComponentModel(kind: ComponentModel.Kind.list.string, items: items, hybrid: true)
+    let model = ComponentModel(kind: ComponentModel.Kind.list.string, items: items, hybrid: true)
     let listComponentModel = ComponentModel(kind: ComponentModel.Kind.list.string, items: items)
-    let spot = Spot(component: component)
-    let listSpot = ListSpot(component: listComponentModel)
+    let spot = Spot(model: model)
+    let listSpot = ListSpot(model: listComponentModel)
 
     XCTAssertTrue(type(of: spot.view) == type(of: listSpot.view))
 
@@ -76,7 +76,7 @@ class TestSpot: XCTestCase {
     listSpot.layout(CGSize(width: 100, height: 100))
     listSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollDirection, listSpot.component.interaction.scrollDirection)
+    XCTAssertEqual(spot.model.interaction.scrollDirection, listSpot.model.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, listSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, listSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), listSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -87,10 +87,10 @@ class TestSpot: XCTestCase {
 
   func testCompareHybridGridSpotWithCoreType() {
     let items = [Item(title: "A"), Item(title: "B")]
-    let component = ComponentModel(kind: ComponentModel.Kind.grid.string, items: items, hybrid: true)
+    let model = ComponentModel(kind: ComponentModel.Kind.grid.string, items: items, hybrid: true)
     let gridComponentModel = ComponentModel(kind: ComponentModel.Kind.grid.string, items: items)
-    let spot = Spot(component: component)
-    let gridSpot = GridSpot(component: gridComponentModel)
+    let spot = Spot(model: model)
+    let gridSpot = GridSpot(model: gridComponentModel)
 
     XCTAssertTrue(type(of: spot.view) == type(of: gridSpot.view))
 
@@ -99,7 +99,7 @@ class TestSpot: XCTestCase {
     gridSpot.layout(CGSize(width: 100, height: 100))
     gridSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollDirection, gridSpot.component.interaction.scrollDirection)
+    XCTAssertEqual(spot.model.interaction.scrollDirection, gridSpot.model.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, gridSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), gridSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -110,10 +110,10 @@ class TestSpot: XCTestCase {
 
   func testCompareHybridCarouselSpotWithCoreType() {
     let items = [Item(title: "A"), Item(title: "B")]
-    let component = ComponentModel(kind: ComponentModel.Kind.carousel.string, items: items, hybrid: true)
+    let model = ComponentModel(kind: ComponentModel.Kind.carousel.string, items: items, hybrid: true)
     let carouselComponentModel = ComponentModel(kind: ComponentModel.Kind.carousel.string, items: items)
-    let spot = Spot(component: component)
-    let carouselSpot = CarouselSpot(component: carouselComponentModel)
+    let spot = Spot(model: model)
+    let carouselSpot = CarouselSpot(model: carouselComponentModel)
 
     XCTAssertTrue(type(of: spot.view) == type(of: carouselSpot.view))
 
@@ -122,7 +122,7 @@ class TestSpot: XCTestCase {
     carouselSpot.layout(CGSize(width: 100, height: 100))
     carouselSpot.view.layoutSubviews()
 
-    XCTAssertEqual(spot.component.interaction.scrollDirection, carouselSpot.component.interaction.scrollDirection)
+    XCTAssertEqual(spot.model.interaction.scrollDirection, carouselSpot.model.interaction.scrollDirection)
     XCTAssertEqual(spot.items[0].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.items[1].size, carouselSpot.items[0].size)
     XCTAssertEqual(spot.sizeForItem(at: IndexPath(item: 0, section: 0)), carouselSpot.sizeForItem(at: IndexPath(item: 0, section: 0)))
@@ -132,7 +132,7 @@ class TestSpot: XCTestCase {
   }
 
   func testHybridListSpotWithHeaderAndFooter() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       header: "Header",
       footer: "Footer",
       kind: ComponentModel.Kind.list.string,
@@ -144,7 +144,7 @@ class TestSpot: XCTestCase {
       ],
       hybrid: true
     )
-    let spot = Spot(component: component)
+    let spot = Spot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 100))
@@ -161,7 +161,7 @@ class TestSpot: XCTestCase {
   }
 
   func testHybridCarouselSpotWithHeaderAndFooter() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       header: "Header",
       footer: "Footer",
       kind: ComponentModel.Kind.carousel.string,
@@ -173,7 +173,7 @@ class TestSpot: XCTestCase {
       ],
       hybrid: true
     )
-    let spot = Spot(component: component)
+    let spot = Spot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 188))

--- a/SpotsTests/iOS/TestViewSpot.swift
+++ b/SpotsTests/iOS/TestViewSpot.swift
@@ -5,14 +5,14 @@ import XCTest
 class ViewSpotTests: XCTestCase {
 
   func testDictionaryRepresentation() {
-    let component = ComponentModel(title: "ViewSpot", kind: "view", span: 3, meta: ["headerHeight": 44.0])
-    let spot = ViewSpot(component: component)
-    XCTAssertEqual(component.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
-    XCTAssertEqual(component.dictionary["title"] as? String, spot.dictionary["title"] as? String)
-    XCTAssertEqual(component.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
-    XCTAssertEqual(component.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
+    let model = ComponentModel(title: "ViewSpot", kind: "view", span: 3, meta: ["headerHeight": 44.0])
+    let spot = ViewSpot(model: model)
+    XCTAssertEqual(model.dictionary["index"] as? Int, spot.dictionary["index"] as? Int)
+    XCTAssertEqual(model.dictionary["title"] as? String, spot.dictionary["title"] as? String)
+    XCTAssertEqual(model.dictionary["kind"] as? String, spot.dictionary["kind"] as? String)
+    XCTAssertEqual(model.dictionary["span"] as? Int, spot.dictionary["span"] as? Int)
     XCTAssertEqual(
-      (component.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
+      (model.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat,
       (spot.dictionary["meta"] as! [String : Any])["headerHeight"] as? CGFloat
     )
   }

--- a/SpotsTests/macOS/HelperViews.swift
+++ b/SpotsTests/macOS/HelperViews.swift
@@ -37,8 +37,8 @@ class HeaderView: NSView, ItemConfigurable, Componentable {
     titleLabel.stringValue = item.title
   }
 
-  func configure(_ component: ComponentModel) {
-    titleLabel.stringValue = component.title
+  func configure(_ model: ComponentModel) {
+    titleLabel.stringValue = model.title
   }
 }
 
@@ -114,7 +114,7 @@ class FooterView: NSView, ItemConfigurable, Componentable {
     titleLabel.stringValue = item.title
   }
 
-  func configure(_ component: ComponentModel) {
-    titleLabel.stringValue = component.title
+  func configure(_ model: ComponentModel) {
+    titleLabel.stringValue = model.title
   }
 }

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -15,7 +15,7 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableSpot() {
-    let gridSpot = GridSpot(component: ComponentModel(span: 1))
+    let gridSpot = GridSpot(model: ComponentModel(span: 1))
     let gridableLayout = gridSpot.layout as? FlowLayout
     let layout = Layout(json)
 
@@ -31,7 +31,7 @@ class LayoutExtensionsTests: XCTestCase {
   }
 
   func testConfigureListableSpot() {
-    let listSpot = ListSpot(component: ComponentModel(span: 1))
+    let listSpot = ListSpot(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
     layout.configure(spot: listSpot)

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -13,8 +13,8 @@ class TestSpot: XCTestCase {
 
   func testDefaultValues() {
     let items = [Item(title: "A"), Item(title: "B")]
-    let component = ComponentModel(items: items, hybrid: true)
-    let spot = Spot(component: component)
+    let model = ComponentModel(items: items, hybrid: true)
+    let spot = Spot(model: model)
 
     spot.setup(CGSize(width: 100, height: 100))
 
@@ -31,7 +31,7 @@ class TestSpot: XCTestCase {
     let item = Item(title: "test")
     let spot = Spot(cacheKey: "test-spot-cache")
 
-    XCTAssertEqual(spot.component.items.count, 0)
+    XCTAssertEqual(spot.model.items.count, 0)
     spot.append(item) {
       spot.cache()
     }
@@ -44,8 +44,8 @@ class TestSpot: XCTestCase {
       }
 
       let cachedSpot = Spot(cacheKey: cacheKey)
-      XCTAssertEqual(cachedSpot.component.items[0].title, "test")
-      XCTAssertEqual(cachedSpot.component.items.count, 1)
+      XCTAssertEqual(cachedSpot.model.items[0].title, "test")
+      XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()
       expectation.fulfill()
 
@@ -55,7 +55,7 @@ class TestSpot: XCTestCase {
   }
 
   func testHybridListSpotWithHeaderAndFooter() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       header: "Header",
       footer: "Footer",
       kind: ComponentModel.Kind.list.string,
@@ -67,7 +67,7 @@ class TestSpot: XCTestCase {
       ],
       hybrid: true
     )
-    let spot = Spot(component: component)
+    let spot = Spot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 460))
@@ -75,7 +75,7 @@ class TestSpot: XCTestCase {
   }
 
   func testHybridGridSpotWithHeaderAndFooter() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       header: "Header",
       footer: "Footer",
       kind: ComponentModel.Kind.grid.string,
@@ -87,7 +87,7 @@ class TestSpot: XCTestCase {
       ],
       hybrid: true
     )
-    let spot = Spot(component: component)
+    let spot = Spot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.collectionView?.collectionViewLayout?.collectionViewContentSize, CGSize(width: 100, height: 200))
@@ -96,7 +96,7 @@ class TestSpot: XCTestCase {
   }
 
   func testHybridCarouselSpotWithHeaderAndFooter() {
-    let component = ComponentModel(
+    let model = ComponentModel(
       header: "Header",
       footer: "Footer",
       kind: ComponentModel.Kind.carousel.string,
@@ -108,7 +108,7 @@ class TestSpot: XCTestCase {
       ],
       hybrid: true
     )
-    let spot = Spot(component: component)
+    let spot = Spot(model: model)
     spot.setup(CGSize(width: 100, height: 100))
 
     XCTAssertEqual(spot.view.frame.size, CGSize(width: 100, height: 150))


### PR DESCRIPTION
This PR is a breaking change, it renames .component to .model on `Spotable`.

This will partially fix #511