### PR TITLE
⚠️ Improve naming by search and replacing more references to spot and spots⚠️

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ let myContacts = ComponentModel(title: "My contacts", items: [
   Item(title: "Khoa Pham"),
   Item(title: "Christoffer Winterkvist")
 ])
-let listSpot = ListComponent(model: myContacts)
-let controller = Controller(components: [listSpot])
+let listComponent = ListComponent(model: myContacts)
+let controller = Controller(components: [listComponent])
 
 navigationController?.pushViewController(controller, animated: true)
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ setup delegates that conform to the public protocols on `Controller`.
 own set of `Item`’s.
 which is maintained internally and is there at your disposable if you decide to
 make changes to them.
-- Easy configuration of collection views, table views and any custom spot
+- Easy configuration of collection views, table views and any custom component
 implementation that you add.
 This improves code reuse and helps to theme your app and ultimately keep your application consistent.
 - Support custom Spots, all you need to do is to conform to `CoreComponent`
@@ -227,7 +227,7 @@ A **Controller** can also be reloaded using JSON. It behaves a bit differently t
 
 The difference between `reload` and `reloadIfNeeded` methods is that they will only run if change is needed, just like the naming implies.
 
-If you need more fine-grained control by pinpointing an individual spot, we got you covered on this as well. **Controller** has an update method that takes the spot index as its first argument, followed by an animation label to specify which animation to use when doing the update.
+If you need more fine-grained control by pinpointing an individual component, we got you covered on this as well. **Controller** has an update method that takes the component index as its first argument, followed by an animation label to specify which animation to use when doing the update.
 The remaining arguments are one mutation closure where you get the **CoreComponent** object and can perform your updates, and finally one completion closure that will run when your update is performed both on the data source and the UI component.
 This method has a corresponding method called `updateIfNeeded`, which applies the update if needed.
 
@@ -305,12 +305,12 @@ The `Controller` inherits from `UIViewController` and `NSViewController` but it 
 
 ```swift
 public protocol ComponentDelegate: class {
-  func spotDidSelectItem(spot: CoreComponent, item: Item)
+  func componentDidSelectItem(component: CoreComponent, item: Item)
   func componentsDidChange(components: [CoreComponent])
 }
 ```
 
-`spotDidSelectItem` is triggered when a user taps on an item inside of a `CoreComponent` object. It returns both the `spot` and the `item` to add context to what UI element was touched.
+`componentDidSelectItem` is triggered when a user taps on an item inside of a `CoreComponent` object. It returns both the `component` and the `item` to add context to what UI element was touched.
 
 `componentsDidChange` notifies the delegate when the internal `.components` property changes.
 
@@ -328,24 +328,24 @@ public protocol SpotsRefreshDelegate: class {
 
 ```swift
 public protocol SpotsScrollDelegate: class {
-  func spotDidReachBeginning(completion: Completion)
-  func spotDidReachEnd(completion: (() -> Void)?)
+  func componentDidReachBeginning(completion: Completion)
+  func componentDidReachEnd(completion: (() -> Void)?)
 }
 ```
 
-`spotDidReachBeginning` notifies the delegate when the scrollview has reached the top. This has a default implementation and is rendered optional for anything that conform to `SpotsScrollDelegate`.
+`componentDidReachBeginning` notifies the delegate when the scrollview has reached the top. This has a default implementation and is rendered optional for anything that conform to `SpotsScrollDelegate`.
 
-`spotDidReachEnd` is triggered when the user scrolls to the end of the `SpotsScrollView`, this can be used to implement infinite scrolling.
+`componentDidReachEnd` is triggered when the user scrolls to the end of the `SpotsScrollView`, this can be used to implement infinite scrolling.
 
 ### SpotsCarouselScrollDelegate
 
 ```swift
 public protocol SpotsCarouselScrollDelegate: class {
-  func spotDidEndScrolling(spot: CoreComponent, item: Item)
+  func componentDidEndScrolling(component: CoreComponent, item: Item)
 }
 ```
 
-`spotDidEndScrolling` is triggered when a user ends scrolling in a carousel, it returns item that is being displayed and the spot to give you the context that you need.
+`componentDidEndScrolling` is triggered when a user ends scrolling in a carousel, it returns item that is being displayed and the component to give you the context that you need.
 
 ## The many faces of Spots
 
@@ -434,11 +434,11 @@ Because the framework can be used in a wide variety of ways, we have decided to 
 ```
 
 - **.index**
-Calculated value to determine the index it has inside of the spot.
+Calculated value to determine the index it has inside of the component.
 - **.title**
 This is used as a title in table view view.
 - **.kind**
-Determines which spot should be used. `carousel`, `list`, `grid` are there by default but you can register your own.
+Determines which component should be used. `carousel`, `list`, `grid` are there by default but you can register your own.
 - **.span**
 Determines the amount of views that should fit on one row, by default it is set to zero and uses the default flow layout to render collection based views.
 - **.size**

--- a/Sources/Shared/Classes/SpotFactory.swift
+++ b/Sources/Shared/Classes/SpotFactory.swift
@@ -16,14 +16,14 @@ public struct Factory {
   /// Register a spot for a specfic spot type
   ///
   /// - parameter kind: The reusable identifier that will be used to indentify your view
-  /// - parameter spot: A generic spotable type
+  /// - parameter component: A generic spotable type
   public static func register<T: CoreComponent>(kind: String, spot: T.Type) {
     components[kind] = spot
   }
 
   /// Craft spotable object from component struct
   ///
-  /// - parameter component: A compontent struct used for crafting the spotable object.
+  /// - parameter component: A compontent struct used for crafting The component.
   ///
   /// - returns: A spotable object.
   public static func resolve(model: ComponentModel) -> CoreComponent {

--- a/Sources/Shared/Classes/SpotFactory.swift
+++ b/Sources/Shared/Classes/SpotFactory.swift
@@ -1,6 +1,6 @@
 public struct Factory {
 
-  /// The default spot for the Factory
+  /// The default component for the Factory
   public static var DefaultSpot: CoreComponent.Type = GridComponent.self
 
   /// Defaults components, it includes carousel, list, grid and view
@@ -10,30 +10,30 @@ public struct Factory {
     ComponentModel.Kind.grid.string: GridComponent.self,
     ComponentModel.Kind.row.string: RowComponent.self,
     ComponentModel.Kind.view.string: ViewComponent.self,
-    ComponentModel.Kind.spot.string: Component.self
+    ComponentModel.Kind.component.string: Component.self
   ]
 
-  /// Register a spot for a specfic spot type
+  /// Register a component for a specfic component type
   ///
   /// - parameter kind: The reusable identifier that will be used to indentify your view
-  /// - parameter component: A generic spotable type
-  public static func register<T: CoreComponent>(kind: String, spot: T.Type) {
-    components[kind] = spot
+  /// - parameter component: A generic component type.
+  public static func register<T: CoreComponent>(kind: String, component: T.Type) {
+    components[kind] = component
   }
 
-  /// Craft spotable object from component struct
+  /// Craft component from component model
   ///
   /// - parameter component: A compontent struct used for crafting The component.
   ///
-  /// - returns: A spotable object.
+  /// - returns: A component.
   public static func resolve(model: ComponentModel) -> CoreComponent {
     var resolvedKind = model.kind
     if model.isHybrid {
-      resolvedKind = ComponentModel.Kind.spot.string
+      resolvedKind = ComponentModel.Kind.component.string
     }
 
-    let spot: CoreComponent.Type = components[resolvedKind] ?? DefaultSpot
+    let component: CoreComponent.Type = components[resolvedKind] ?? DefaultSpot
 
-    return spot.init(model: model)
+    return component.init(model: model)
   }
 }

--- a/Sources/Shared/Classes/ViewSpot.swift
+++ b/Sources/Shared/Classes/ViewSpot.swift
@@ -12,7 +12,7 @@ open class ViewComponent: NSObject, CoreComponent, Viewable {
 
   public static var layout: Layout = .init()
 
-  /// Reload spot with ItemChanges.
+  /// Reload component with ItemChanges.
   ///
   /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
   /// - parameter animation:        A Animation that is used when performing the mutation.

--- a/Sources/Shared/Extensions/CarouselScrollDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/CarouselScrollDelegate+Extensions.swift
@@ -2,11 +2,11 @@ public extension CarouselScrollDelegate {
 
   /// Invoked when ever a user scrolls a CarouselComponent.
   ///
-  /// - parameter spot: The spotable object that was scrolled.
-  func spotableCarouselDidScroll(_ spot: CoreComponent) {}
+  /// - parameter component: The component that was scrolled.
+  func componentCarouselDidScroll(_ component: CoreComponent) {}
 
-  /// - parameter spot: Object that comforms to the CoreComponent protocol
+  /// - parameter component: Object that comforms to the CoreComponent protocol
   /// - parameter item: The last view model in the component
   /// - parameter animated: Indicates if the scrolling animated or not.
-  func spotableCarouselDidEndScrolling(_ spot: CoreComponent, item: Item, animated: Bool) {}
+  func component(_ component: CoreComponent, item: Item, animated: Bool) {}
 }

--- a/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
@@ -3,11 +3,11 @@ public extension ComponentDelegate {
 
   /// Triggered when ever a user taps on an item
   ///
-  /// - parameter component: The spotable object that the item belongs to.
+  /// - parameter component: The component that the item belongs to.
   /// - parameter item: The item struct that the user tapped on.
   func component(_ component: CoreComponent, itemSelected item: Item) {}
 
-  /// Invoked when ever the collection of spotable objects changes on the Controller.
+  /// Invoked when ever the collection of components changes on the Controller.
   ///
   /// - parameter components: The collection of new CoreComponent objects.
   func componentsDidChange(_ components: [CoreComponent]) {}

--- a/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
@@ -14,14 +14,14 @@ public extension ComponentDelegate {
 
   /// A delegate method that is triggered when ever a view is going to be displayed.
   ///
-  /// - parameter component: An object that conforms to the spotable protocol.
+  /// - parameter component: An object that conforms to CoreComponent.
   /// - parameter view: The UI element that will be displayed.
   /// - parameter item: The data for the view that is going to be displayed.
   func component(_ component: CoreComponent, willDisplay view: ComponentView, item: Item) {}
 
   /// A delegate method that is triggered when ever a view will no longer be displayed.
   ///
-  /// - parameter component: An object that conforms to the spotable protocol.
+  /// - parameter component: An object that conforms to CoreComponent.
   /// - parameter view: The UI element that did end display.
   /// - parameter item: The data for the view that is going to be displayed.
   func component(_ component: CoreComponent, didEndDisplaying view: ComponentView, item: Item) {}

--- a/Sources/Shared/Extensions/CoreComponent+Extensions.swift
+++ b/Sources/Shared/Extensions/CoreComponent+Extensions.swift
@@ -107,15 +107,15 @@ public extension CoreComponent {
     var spanWidth: CGFloat?
 
     if let layout = model.layout, layout.span > 0.0 {
-      var spotWidth: CGFloat = view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
+      var componentWidth: CGFloat = view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
 
       #if !os(OSX)
         if view.frame.size.width == 0.0 {
-          spotWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
+          componentWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
         }
       #endif
 
-      spanWidth = (spotWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
+      spanWidth = (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in
@@ -171,9 +171,9 @@ public extension CoreComponent {
         return
       }
 
-      let spotHeight = weakSelf.computedHeight
+      let componentHeight = weakSelf.computedHeight
       Dispatch.main { [weak self] in
-        self?.view.frame.size.height = spotHeight
+        self?.view.frame.size.height = componentHeight
         completion?()
       }
     }
@@ -191,7 +191,7 @@ public extension CoreComponent {
     completion?()
   }
 
-  /// Caches the current state of the spot
+  /// Caches the current state of the component
   public func cache() {
     stateCache?.save(dictionary)
   }
@@ -247,13 +247,13 @@ public extension CoreComponent {
 
       prepare(kind: kind, view: view as Any, item: &item)
     #else
-      let spotableKind = self
+      let componentKind = self
 
       if fullWidth == 0.0 {
         fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
       }
 
-      switch spotableKind {
+      switch componentKind {
       case let grid as Gridable:
         var kind = item.kind.isEmpty || type(of: grid).grids.storage[item.kind] == nil
           ? identifier(at: index)
@@ -339,8 +339,8 @@ public extension CoreComponent {
     let size = view.frame.size
     let width = size.width
 
-    components.forEach { spot in
-      let compositeSpot = CompositeComponent(component: spot,
+    components.forEach { component in
+      let compositeSpot = CompositeComponent(component: component,
                                              parentComponent: self,
                                              itemIndex: item.index)
 

--- a/Sources/Shared/Extensions/CoreComponent+Mutation.swift
+++ b/Sources/Shared/Extensions/CoreComponent+Mutation.swift
@@ -323,7 +323,7 @@ public extension CoreComponent {
     }
   }
 
-  /// Reloads a spot only if it changes
+  /// Reloads a component only if it changes
   ///
   /// - parameter items:      A collection of Items
   /// - parameter animation:  The animation that should be used (only works for Listable objects)
@@ -370,7 +370,7 @@ public extension CoreComponent {
     }
   }
 
-  /// Reload spot with ItemChanges.
+  /// Reload component with ItemChanges.
   ///
   /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
   /// - parameter animation:        A Animation that is used when performing the mutation.
@@ -439,7 +439,7 @@ public extension CoreComponent {
     return model.dictionary
   }
 
-  /// Reloads a spot only if it changes
+  /// Reloads a component only if it changes
   ///
   /// - parameter items:      A collection of Items
   /// - parameter animation:  The animation that should be used (only works for Listable objects)

--- a/Sources/Shared/Extensions/Gridable+Extensions.swift
+++ b/Sources/Shared/Extensions/Gridable+Extensions.swift
@@ -64,6 +64,6 @@ public extension CoreComponent where Self : Gridable {
   }
 
   public func configure(with layout: Layout) {
-    layout.configure(spot: self)
+    layout.configure(component: self)
   }
 }

--- a/Sources/Shared/Extensions/Listable+Extension.swift
+++ b/Sources/Shared/Extensions/Listable+Extension.swift
@@ -1,6 +1,6 @@
 extension Listable {
 
   public func configure(with layout: Layout) {
-    layout.configure(spot: self)
+    layout.configure(component: self)
   }
 }

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -54,10 +54,10 @@ public extension SpotsProtocol {
   public func dictionary(_ amountOfItems: Int? = nil) -> [String : Any] {
     var result = [[String: Any]]()
 
-    for spot in components {
-      var spotJSON = spot.model.dictionary(amountOfItems)
-      for item in spot.items where item.kind == "composite" {
-        let results = spot.compositeComponents
+    for component in components {
+      var componentJSON = component.model.dictionary(amountOfItems)
+      for item in component.items where item.kind == "composite" {
+        let results = component.compositeComponents
           .filter({ $0.itemIndex == item.index })
 
         var newItem = item
@@ -69,12 +69,12 @@ public extension SpotsProtocol {
 
         newItem.children = children
 
-        var newItems = spotJSON[ComponentModel.Key.items] as? [[String : Any]]
+        var newItems = componentJSON[ComponentModel.Key.items] as? [[String : Any]]
         newItems?[item.index] = newItem.dictionary
-        spotJSON[ComponentModel.Key.items] = newItems
+        componentJSON[ComponentModel.Key.items] = newItems
       }
 
-      result.append(spotJSON)
+      result.append(componentJSON)
     }
 
     return ["components": result as AnyObject ]
@@ -86,12 +86,12 @@ public extension SpotsProtocol {
   ///
   /// - returns: An optional object with inferred type.
   public func ui<T>(_ includeElement: (Item) -> Bool) -> T? {
-    for spot in components {
-      if let first = spot.items.filter(includeElement).first {
-        return spot.ui(at: first.index)
+    for component in components {
+      if let first = component.items.filter(includeElement).first {
+        return component.ui(at: first.index)
       }
 
-      let cSpots = spot.compositeComponents.map { $0.component }
+      let cSpots = component.compositeComponents.map { $0.component }
       for compositeSpot in cSpots {
         if let first = compositeSpot.items.filter(includeElement).first {
           return compositeSpot.ui(at: first.index)
@@ -104,7 +104,7 @@ public extension SpotsProtocol {
 
   /// Filter CoreComponent objects inside of controller
   ///
-  /// - parameter includeElement: A filter predicate to find a spot
+  /// - parameter includeElement: A filter predicate to find a component
   ///
   /// - returns: A collection of CoreComponent objects that match the includeElements predicate
   public func filter(components includeElement: (CoreComponent) -> Bool) -> [CoreComponent] {
@@ -123,19 +123,19 @@ public extension SpotsProtocol {
   /// - parameter includeElement: The predicate that the item has to match.
   ///
   /// - returns: A collection of tuples containing components with the matching items that were found.
-  public func filter(items includeElement: (Item) -> Bool) -> [(spot: CoreComponent, items: [Item])] {
-    var result = [(spot: CoreComponent, items: [Item])]()
-    for spot in components {
-      let items = spot.items.filter(includeElement)
+  public func filter(items includeElement: (Item) -> Bool) -> [(component: CoreComponent, items: [Item])] {
+    var result = [(component: CoreComponent, items: [Item])]()
+    for component in components {
+      let items = component.items.filter(includeElement)
       if !items.isEmpty {
-        result.append((spot: spot, items: items))
+        result.append((component: component, items: items))
       }
 
-      let childSpots = spot.compositeComponents.map { $0.component }
-      for spot in childSpots {
-        let items = spot.items.filter(includeElement)
+      let childSpots = component.compositeComponents.map { $0.component }
+      for component in childSpots {
+        let items = component.items.filter(includeElement)
         if !items.isEmpty {
-          result.append((spot: spot, items: items))
+          result.append((component: component, items: items))
         }
       }
     }
@@ -146,9 +146,9 @@ public extension SpotsProtocol {
 #if os(iOS)
   /// Scroll to the index of a CoreComponent object, only available on iOS.
   ///
-  /// - parameter index:          The index of the spot that you want to scroll
+  /// - parameter index:          The index of the component that you want to scroll
   /// - parameter includeElement: A filter predicate to find a view model
-  public func scrollTo(spotIndex index: Int = 0, includeElement: (Item) -> Bool) {
+  public func scrollTo(componentIndex index: Int = 0, includeElement: (Item) -> Bool) {
     guard let itemY = component(at: index, ofType: CoreComponent.self)?.scrollTo(includeElement) else { return }
 
     var initialHeight: CGFloat = 0.0
@@ -203,7 +203,7 @@ public extension SpotsProtocol {
   }
 
   /**
-   - parameter indexPath: The index path of the spot you want to lookup
+   - parameter indexPath: The index path of the component you want to lookup
    - returns: A CoreComponent object at index path
    **/
   fileprivate func component(at indexPath: IndexPath) -> CoreComponent {

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -122,7 +122,7 @@ public extension SpotsProtocol {
   ///
   /// - parameter includeElement: The predicate that the item has to match.
   ///
-  /// - returns: A collection of tuples containing spotable objects with the matching items that were found.
+  /// - returns: A collection of tuples containing components with the matching items that were found.
   public func filter(items includeElement: (Item) -> Bool) -> [(spot: CoreComponent, items: [Item])] {
     var result = [(spot: CoreComponent, items: [Item])]()
     for spot in components {
@@ -149,13 +149,13 @@ public extension SpotsProtocol {
   /// - parameter index:          The index of the spot that you want to scroll
   /// - parameter includeElement: A filter predicate to find a view model
   public func scrollTo(spotIndex index: Int = 0, includeElement: (Item) -> Bool) {
-    guard let itemY = spot(at: index, ofType: CoreComponent.self)?.scrollTo(includeElement) else { return }
+    guard let itemY = component(at: index, ofType: CoreComponent.self)?.scrollTo(includeElement) else { return }
 
     var initialHeight: CGFloat = 0.0
     if index > 0 {
       initialHeight += components[0..<index].reduce(0, { $0 + $1.computedHeight })
     }
-    if spot(at: index, ofType: CoreComponent.self)?.computedHeight > scrollView.frame.height - scrollView.contentInset.bottom - initialHeight {
+    if component(at: index, ofType: CoreComponent.self)?.computedHeight > scrollView.frame.height - scrollView.contentInset.bottom - initialHeight {
       let y = itemY - scrollView.frame.size.height + scrollView.contentInset.bottom + initialHeight
       scrollView.setContentOffset(CGPoint(x: CGFloat(0.0), y: y), animated: true)
     }
@@ -199,14 +199,14 @@ public extension SpotsProtocol {
   ///
   /// - returns: A ComponentModel object at index path.
   fileprivate func component(at indexPath: IndexPath) -> ComponentModel {
-    return spot(at: indexPath).model
+    return component(at: indexPath).model
   }
 
   /**
    - parameter indexPath: The index path of the spot you want to lookup
    - returns: A CoreComponent object at index path
    **/
-  fileprivate func spot(at indexPath: IndexPath) -> CoreComponent {
+  fileprivate func component(at indexPath: IndexPath) -> CoreComponent {
     return components[indexPath.item]
   }
 }

--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -41,11 +41,11 @@ import Cache
               weakSelf.scrollView.contentOffset = offset
 
               var yOffset: CGFloat = 0.0
-              for spot in weakSelf.components {
+              for component in weakSelf.components {
                 #if !os(OSX)
-                (spot as? CarouselComponent)?.layout.yOffset = yOffset
+                (component as? CarouselComponent)?.layout.yOffset = yOffset
                 #endif
-                yOffset += spot.view.frame.size.height
+                yOffset += component.view.frame.size.height
               }
 
               #if !os(OSX)

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -143,10 +143,10 @@ extension SpotsProtocol {
     oldSpot.view.removeFromSuperview()
     components[index] = component
     scrollView.componentsContentView.insertSubview(component.view, at: index)
-    setupComponent(at: index, spot: component)
+    setupComponent(at: index, component: component)
 
     #if !os(OSX)
-      (spot as? CarouselComponent)?.layout.yOffset = yOffset
+      (component as? CarouselComponent)?.layout.yOffset = yOffset
     #endif
     yOffset += component.view.frame.size.height
   }
@@ -154,9 +154,9 @@ extension SpotsProtocol {
   fileprivate func newComponent(_ index: Int, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
     let component = Factory.resolve(model: newComponentModels[index])
     components.append(component)
-    setupComponent(at: index, spot: component)
+    setupComponent(at: index, component: component)
     #if !os(OSX)
-      (spot as? CarouselComponent)?.layout.yOffset = yOffset
+      (component as? CarouselComponent)?.layout.yOffset = yOffset
     #endif
     yOffset += component.view.frame.size.height
   }
@@ -180,7 +180,7 @@ extension SpotsProtocol {
   ///
   /// - returns: A boolean value that determines if the closure should run in `process(changes:)`
   fileprivate func setupItemsForComponent(at index: Int, newComponentModels: [ComponentModel], withAnimation animation: Animation = .automatic, completion: Completion = nil) -> Bool {
-    guard let component = self.spot(at: index, ofType: CoreComponent.self) else {
+    guard let component = self.component(at: index, ofType: CoreComponent.self) else {
       return false
     }
 
@@ -240,7 +240,7 @@ extension SpotsProtocol {
   /// Reload CoreComponent object with changes and new items.
   ///
   /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter spot:      The spotable object that should be updated.
+  /// - parameter component:      The component that should be updated.
   /// - parameter newItems:  The new items that should be used to updated the data source.
   /// - parameter animation: The animation that should be used when updating.
   /// - parameter closure:   A completion closure.
@@ -290,7 +290,7 @@ extension SpotsProtocol {
   /// Reload CoreComponent object with less items
   ///
   /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter spot:      The spotable object that should be updated.
+  /// - parameter component:      The component that should be updated.
   /// - parameter newItems:  The new items that should be used to updated the data source.
   /// - parameter animation: The animation that should be used when updating.
   /// - parameter closure:   A completion closure.
@@ -345,7 +345,7 @@ extension SpotsProtocol {
   /// Reload CoreComponent object with more items
   ///
   /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter spot:      The spotable object that should be updated.
+  /// - parameter component:      The component that should be updated.
   /// - parameter newItems:  The new items that should be used to updated the data source.
   /// - parameter animation: The animation that should be used when updating.
   /// - parameter closure:   A completion closure.
@@ -476,7 +476,7 @@ extension SpotsProtocol {
       }
 
       weakSelf.reloadSpotsScrollView()
-      weakSelf.setupSpots(animated: animated)
+      weakSelf.setupComponents(animated: animated)
       weakSelf.cache()
 
       let newComposites = weakSelf.components.flatMap { $0.compositeComponents }
@@ -523,7 +523,7 @@ extension SpotsProtocol {
       }
 
       weakSelf.reloadSpotsScrollView()
-      weakSelf.setupSpots(animated: animated)
+      weakSelf.setupComponents(animated: animated)
 
       completion?()
       if let controller = weakSelf as? Controller {
@@ -539,8 +539,8 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that is performed when the update is completed
    - parameter closure: A transform closure to perform the proper modification to the target spot before updating the internals
    */
-  public func update(spotAtIndex index: Int = 0, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ spot: CoreComponent) -> Void) {
-    guard let component = spot(at: index, ofType: CoreComponent.self) else {
+  public func update(spotAtIndex index: Int = 0, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ component: CoreComponent) -> Void) {
+    guard let component = component(at: index, ofType: CoreComponent.self) else {
       completion?()
       return
     }
@@ -572,7 +572,7 @@ extension SpotsProtocol {
   }
 
   /**
-   Updates spot only if the passed view models are not the same with the current ones.
+   Updates component only if the passed view models are not the same with the current ones.
 
    - parameter spotAtIndex: The index of the spot that you want to perform updates on
    - parameter items: An array of view models
@@ -580,7 +580,7 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that is run when the update is completed
    */
   public func updateIfNeeded(spotAtIndex index: Int = 0, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    guard let component = spot(at: index, ofType: CoreComponent.self), !(component.items == items) else {
+    guard let component = component(at: index, ofType: CoreComponent.self), !(component.items == items) else {
       scrollView.layoutSubviews()
       completion?()
       return
@@ -600,11 +600,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func append(_ item: Item, spotIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.append(item, withAnimation: animation) { [weak self] in
+    component(at: spotIndex, ofType: CoreComponent.self)?.append(item, withAnimation: animation) { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /**
@@ -614,11 +614,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func append(_ items: [Item], spotIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.append(items, withAnimation: animation) { [weak self] in
+    component(at: spotIndex, ofType: CoreComponent.self)?.append(items, withAnimation: animation) { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /**
@@ -628,11 +628,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func prepend(_ items: [Item], spotIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.prepend(items, withAnimation: animation) { [weak self] in
+    component(at: spotIndex, ofType: CoreComponent.self)?.prepend(items, withAnimation: animation) { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /**
@@ -643,11 +643,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func insert(_ item: Item, index: Int = 0, spotIndex: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.insert(item, index: index, withAnimation: animation) { [weak self] in
+    component(at: spotIndex, ofType: CoreComponent.self)?.insert(item, index: index, withAnimation: animation) { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /// Update item at index inside a specific CoreComponent object
@@ -658,7 +658,7 @@ extension SpotsProtocol {
   /// - parameter animation:  A Animation struct that determines which animation that should be used to perform the update.
   /// - parameter completion: A completion closure that will run after the spot has performed updates internally.
   public func update(_ item: Item, index: Int = 0, spotIndex: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    guard let oldItem = spot(at: spotIndex, ofType: CoreComponent.self)?.item(at: index), item != oldItem
+    guard let oldItem = component(at: spotIndex, ofType: CoreComponent.self)?.item(at: index), item != oldItem
       else {
         completion?()
         return
@@ -670,7 +670,7 @@ extension SpotsProtocol {
       }
     #endif
 
-    spot(at: spotIndex, ofType: CoreComponent.self)?.update(item, index: index, withAnimation: animation) { [weak self] in
+    component(at: spotIndex, ofType: CoreComponent.self)?.update(item, index: index, withAnimation: animation) { [weak self] in
       completion?()
       self?.scrollView.layoutSubviews()
       #if os(iOS)
@@ -688,10 +688,10 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func update(_ indexes: [Int], spotIndex: Int = 0, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.reload(indexes, withAnimation: animation) {
+    component(at: spotIndex, ofType: CoreComponent.self)?.reload(indexes, withAnimation: animation) {
       completion?()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /**
@@ -701,10 +701,10 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func delete(_ index: Int, spotIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.delete(index, withAnimation: animation) {
+    component(at: spotIndex, ofType: CoreComponent.self)?.delete(index, withAnimation: animation) {
       completion?()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   /**
@@ -714,10 +714,10 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the spot has performed updates internally
    */
   public func delete(_ indexes: [Int], spotIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    spot(at: spotIndex, ofType: CoreComponent.self)?.delete(indexes, withAnimation: animation) {
+    component(at: spotIndex, ofType: CoreComponent.self)?.delete(indexes, withAnimation: animation) {
       completion?()
     }
-    spot(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
+    component(at: spotIndex, ofType: CoreComponent.self)?.refreshIndexes()
   }
 
   #if os(iOS)
@@ -726,7 +726,7 @@ extension SpotsProtocol {
       guard let weakSelf = self else { return }
       weakSelf.refreshPositions.removeAll()
 
-      weakSelf.refreshDelegate?.spotablesDidReload(weakSelf.components, refreshControl: refreshControl) {
+      weakSelf.refreshDelegate?.componentsDidReload(weakSelf.components, refreshControl: refreshControl) {
         refreshControl.endRefreshing()
       }
     }

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -224,7 +224,7 @@ public extension CoreComponent where Self : Viewable {
     }
   }
 
-  /// Reloads a spot only if it changes
+  /// Reloads a component only if it changes
   ///
   /// - parameter items:      A collection of Items
   /// - parameter animation:  The animation that should be used (only works for Listable objects)

--- a/Sources/Shared/Extensions/Viewable+Extensions.swift
+++ b/Sources/Shared/Extensions/Viewable+Extensions.swift
@@ -31,7 +31,7 @@ public extension CoreComponent where Self : Viewable {
     prepareComponent(self)
   }
 
-  fileprivate func prepareComponent<T: Viewable>(_ spot: T) {
+  fileprivate func prepareComponent<T: Viewable>(_ component: T) {
     if model.kind.isEmpty { model.kind = "view" }
 
     model.items.forEach { (item: Item) in

--- a/Sources/Shared/Protocols/CarouselScrollDelegate.swift
+++ b/Sources/Shared/Protocols/CarouselScrollDelegate.swift
@@ -2,10 +2,10 @@ public protocol CarouselScrollDelegate: class {
 
   /// Invoked when ever a user scrolls a CarouselComponent.
   ///
-  /// - parameter spot: The spotable object that was scrolled.
-  func spotableCarouselDidScroll(_ spot: CoreComponent)
+  /// - parameter component: The component that was scrolled.
+  func componentCarouselDidScroll(_ component: CoreComponent)
 
-  /// - parameter spot: Object that comforms to the CoreComponent protocol
+  /// - parameter component: Object that comforms to the CoreComponent protocol
   /// - parameter item: The last view model in the component
-  func spotableCarouselDidEndScrolling(_ spot: CoreComponent, item: Item, animated: Bool)
+  func componentCarouselDidEndScrolling(_ component: CoreComponent, item: Item, animated: Bool)
 }

--- a/Sources/Shared/Protocols/ComponentDelegate.swift
+++ b/Sources/Shared/Protocols/ComponentDelegate.swift
@@ -3,7 +3,7 @@ public protocol ComponentDelegate: class {
 
   /// A delegate method that is triggered when ever a cell is tapped by the user.
   ///
-  /// - parameter component: An object that conforms to the spotable protocol.
+  /// - parameter component: An object that conforms to CoreComponent.
   /// - parameter itemSelected: The data for the view that is going to be displayed.
   func component(_ component: CoreComponent, itemSelected item: Item)
 
@@ -14,14 +14,14 @@ public protocol ComponentDelegate: class {
 
   /// A delegate method that is triggered when ever a view is going to be displayed.
   ///
-  /// - parameter component: An object that conforms to the spotable protocol.
+  /// - parameter component: An object that conforms to CoreComponent.
   /// - parameter view: The UI element that will be displayed.
   /// - parameter item: The data for the view that is going to be displayed.
   func component(_ component: CoreComponent, willDisplay view: ComponentView, item: Item)
 
   /// A delegate method that is triggered when ever a view will no longer be displayed.
   ///
-  /// - parameter component: An object that conforms to the spotable protocol.
+  /// - parameter component: An object that conforms to CoreComponent.
   /// - parameter view: The UI element that did end display.
   /// - parameter item: The data for the view that is going to be displayed.
   func component(_ component: CoreComponent, didEndDisplaying view: ComponentView, item: Item)

--- a/Sources/Shared/Protocols/CoreComponent.swift
+++ b/Sources/Shared/Protocols/CoreComponent.swift
@@ -36,7 +36,7 @@ public protocol CoreComponent: class {
   var stateCache: StateCache? { get }
   /// Indicator to calculate the height based on content
   var usesDynamicHeight: Bool { get }
-  /// The user interface that will be used to represent the spotable object.
+  /// The user interface that will be used to represent The component.
   var userInterface: UserInterface? { get }
   /// Return a CoreComponent object as a UIScrollView
   var view: ScrollView { get }
@@ -165,7 +165,7 @@ public protocol CoreComponent: class {
   func sizeForItem(at indexPath: IndexPath) -> CGSize
 
   #if os(OSX)
-  /// Unselect any selected views inside of the spotable object.
+  /// Unselect any selected views inside of The component.
   func deselect()
   #endif
 

--- a/Sources/Shared/Protocols/CoreComponent.swift
+++ b/Sources/Shared/Protocols/CoreComponent.swift
@@ -125,14 +125,14 @@ public protocol CoreComponent: class {
   /// - parameter completion: A completion closure that is executed in the main queue when the view model has been removed.
   func update(_ item: Item, index: Int, withAnimation animation: Animation, completion: Completion)
 
-  /// Reloads a spot only if it changes
+  /// Reloads a component only if it changes
   ///
   /// - parameter items:      A collection of Items
   /// - parameter animation:  The animation that should be used (only works for Listable objects)
   /// - parameter completion: A completion closure that is performed when all mutations are performed
   func reloadIfNeeded(_ items: [Item], withAnimation animation: Animation, completion: Completion)
 
-  /// Reload spot with ItemChanges.
+  /// Reload component with ItemChanges.
   ///
   /// - parameter changes:          A collection of changes: inserations, updates, reloads, deletions and updated children.
   /// - parameter animation:        A Animation that is used when performing the mutation.

--- a/Sources/Shared/Protocols/Gridable.swift
+++ b/Sources/Shared/Protocols/Gridable.swift
@@ -7,7 +7,7 @@
 /// Gridable is protocol for Spots that are based on collection views.
 public protocol Gridable: CoreComponent {
 
-  /// The layout object used to initialize the collection spot controller.
+  /// The layout object used to initialize the collection component controller.
   var layout: CollectionLayout { get }
   /// The collection view object managed by this gridable object.
   var collectionView: CollectionView { get }

--- a/Sources/Shared/Protocols/RefreshDelegate.swift
+++ b/Sources/Shared/Protocols/RefreshDelegate.swift
@@ -13,6 +13,6 @@ public protocol RefreshDelegate: class {
   /// - parameter refreshControl: A UIRefreshControl
   /// - parameter completion: A completion closure that should be triggered when the update is completed
   #if os(iOS)
-  func spotablesDidReload(_ components: [CoreComponent], refreshControl: UIRefreshControl, completion: Completion)
+  func componentsDidReload(_ components: [CoreComponent], refreshControl: UIRefreshControl, completion: Completion)
   #endif
 }

--- a/Sources/Shared/Protocols/RefreshDelegate.swift
+++ b/Sources/Shared/Protocols/RefreshDelegate.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A refresh delegate for handling reloading of a Spot
 public protocol RefreshDelegate: class {
 
-  /// A delegate method for when your spot controller was refreshed using pull to refresh
+  /// A delegate method for when your component controller was refreshed using pull to refresh
   ///
   /// - parameter components: A collection of CoreComponent objects
   /// - parameter refreshControl: A UIRefreshControl

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -27,8 +27,8 @@ public protocol SpotsProtocol: class {
   var view: View! { get }
   #endif
 
-  /// The first spotable object in the controller.
-  var spot: CoreComponent? { get }
+  /// The first component in the controller.
+  var component: CoreComponent? { get }
 
   /// A dictionary representation of the controller
   var dictionary: [String : Any] { get }
@@ -46,29 +46,29 @@ public protocol SpotsProtocol: class {
 
   /// Set up CoreComponent objects.
   ///
-  /// - parameter animated: An optional animation closure that is invoked when setting up the spot.
-  func setupSpots(animated: ((_ view: View) -> Void)?)
+  /// - parameter animated: An optional animation closure that is invoked when setting up the component.
+  func setupComponents(animated: ((_ view: View) -> Void)?)
 
   /// Set up Spot at index
   ///
   /// - parameter index: The index of the CoreComponent object
-  /// - parameter spot:  The spotable object that is going to be setup
-  func setupComponent(at index: Int, spot: CoreComponent)
+  /// - parameter component:  The component that is going to be setup
+  func setupComponent(at index: Int, component: CoreComponent)
 
   ///  A generic look up method for resolving components based on index
   ///
-  /// - parameter index: The index of the spot that you are trying to resolve.
-  /// - parameter type: The generic type for the spot you are trying to resolve.
+  /// - parameter index: The index of the component that you are trying to resolve.
+  /// - parameter type: The generic type for the component you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object of inferred type.
-  func spot<T>(at index: Int, ofType type: T.Type) -> T?
+  func component<T>(at index: Int, ofType type: T.Type) -> T?
 
   /// A generic look up method for resolving components using a closure
   ///
-  /// - parameter closure: A closure to perform actions on a spotable object
+  /// - parameter closure: A closure to perform actions on a component
   ///
   /// - returns: An optional CoreComponent object
-  func resolve(spot closure: (_ index: Int, _ spot: CoreComponent) -> Bool) -> CoreComponent?
+  func resolve(component closure: (_ index: Int, _ component: CoreComponent) -> Bool) -> CoreComponent?
 
   #if os(OSX)
   init(components: [CoreComponent], backgroundType: ControllerBackground)

--- a/Sources/Shared/Protocols/Viewable.swift
+++ b/Sources/Shared/Protocols/Viewable.swift
@@ -6,7 +6,7 @@
 
 /// Viewable is a protocol for Spots that are based on UIScrollView
 public protocol Viewable: CoreComponent {
-  /// A view registry that is used internally when resolving kind to the corresponding spot.
+  /// A view registry that is used internally when resolving kind to the corresponding component.
   static var views: Registry { get }
   /// A ScrollView
   var scrollView: ScrollView { get }

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -62,8 +62,8 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     case row
     /// The identifier for ViewComponent
     case view
-    /// The identifier for Spot
-    case spot
+    /// The identifier for Component
+    case component
 
     /// The lowercase raw value of the case
     public var string: String {
@@ -90,7 +90,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   public var index: Int = 0
   /// The title for the component
   public var title: String = ""
-  /// Determines which spotable component that should be used
+  /// Determines which component that should be used.
   /// Default kinds are: list, grid and carousel
   public var kind: String = ""
   /// The header identifier

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -135,9 +135,9 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
 
   /// Configure scroll view with layout
   ///
-  /// - Parameter spot: The CoreComponent object that should be configured.
-  public func configure(spot: Listable) {
-    inset.configure(scrollView: spot.view)
+  /// - parameter component: The CoreComponent object that should be configured.
+  public func configure(component: Listable) {
+    inset.configure(scrollView: component.view)
   }
 
   /// Compare Layout structs.

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -6,7 +6,7 @@ public struct Parser {
   /// - parameter json: A JSON dictionary of components and items.
   /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
   ///
-  /// - returns: A collection of spotable objects
+  /// - returns: A collection of components
   public static func parse(_ json: [String : Any], key: String = "components") -> [CoreComponent] {
     var components: [ComponentModel] = parse(json, key: key)
 
@@ -55,7 +55,7 @@ public struct Parser {
   ///
   /// - parameter json: A JSON dictionary of components and items.
   ///
-  /// - returns: A collection of spotable objects
+  /// - returns: A collection of components
   public static func parse(_ json: [[String : Any]]?) -> [CoreComponent] {
     guard let json = json else { return [] }
 

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -6,7 +6,7 @@ import Foundation
   import CoreGraphics
 #endif
 
-/// A registry that is used internally when resolving kind to the corresponding spot.
+/// A registry that is used internally when resolving kind to the corresponding component.
 public struct Registry {
 
   var useCache: Bool = false

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -32,7 +32,7 @@ public struct StateCache {
     return FileManager.default.fileExists(atPath: path)
   }
 
-  /// Remove state cache for all controllers and spotable objects.
+  /// Remove state cache for all controllers and components.
   public static func removeAll() {
     let path = Cache<JSON>(name: "\(StateCache.cacheName)/\(bundleIdentifer)").path
     do {

--- a/Sources/iOS/Classes/CarouselComponent.swift
+++ b/Sources/iOS/Classes/CarouselComponent.swift
@@ -71,7 +71,7 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
   /// - parameter collectionView: The collection view that the carousel should use for rendering
   /// - parameter layout: The object that the carousel should use for item layout
   ///
-  /// - returns: An initialized carousel spot.
+  /// - returns: An initialized carousel component.
   ///
   /// In case you want to use a default collection view & layout, use `init(component:)`.
   public init(model: ComponentModel, collectionView: UICollectionView, layout: CollectionLayout) {
@@ -130,7 +130,7 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
   /// - parameter itemSpacing: The item spacing used in the flow layout.
   /// - parameter lineSpacing: The line spacing used in the flow layout.
   ///
-  /// - returns: An initialized carousel spot with configured layout.
+  /// - returns: An initialized carousel component with configured layout.
   public convenience init(_ model: ComponentModel, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0, itemSpacing: CGFloat = 0, lineSpacing: CGFloat = 0) {
     self.init(model: model)
 
@@ -143,7 +143,7 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
   ///
   /// - parameter cacheKey: A unique cache key for the CoreComponent object.
   ///
-  /// - returns: An initialized carousel spot.
+  /// - returns: An initialized carousel component.
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
     self.init(model: ComponentModel(stateCache.load()))

--- a/Sources/iOS/Classes/CarouselComponent.swift
+++ b/Sources/iOS/Classes/CarouselComponent.swift
@@ -62,8 +62,8 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
   open lazy var backgroundView = UIView()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /// Initialize an instantiate of CarouselComponent
   ///
@@ -96,8 +96,8 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
     self.dynamicSpan = self.model.layout?.dynamicSpan ?? false
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.carousel.string
@@ -151,16 +151,16 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
   /// Configure collection view with data source, delegate and background view
   public func configureCollectionView() {
     register()
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
     collectionView.backgroundView = backgroundView
     #if os(iOS)
       collectionView.isPagingEnabled = model.interaction.paginate == .page

--- a/Sources/iOS/Classes/CarouselComponent.swift
+++ b/Sources/iOS/Classes/CarouselComponent.swift
@@ -94,7 +94,7 @@ open class CarouselComponent: NSObject, Gridable, ComponentHorizontallyScrollabl
 
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.dynamicSpan = self.model.layout?.dynamicSpan ?? false
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -25,8 +25,8 @@ public class Component: NSObject, CoreComponent, ComponentHorizontallyScrollable
     }
   }
 
-  public var spotDelegate: Delegate?
-  public var spotDataSource: DataSource?
+  public var componentDelegate: Delegate?
+  public var componentDataSource: DataSource?
   public var stateCache: StateCache?
 
   public var userInterface: UserInterface? {
@@ -78,8 +78,8 @@ public class Component: NSObject, CoreComponent, ComponentHorizontallyScrollable
       componentLayout.configure(collectionViewLayout: collectionViewLayout)
     }
 
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
   }
 
   public required convenience init(model: ComponentModel) {
@@ -104,8 +104,8 @@ public class Component: NSObject, CoreComponent, ComponentHorizontallyScrollable
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
   }
 
   public func setup(_ size: CGSize) {
@@ -132,8 +132,8 @@ public class Component: NSObject, CoreComponent, ComponentHorizontallyScrollable
 
   fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     collectionView.frame.size = size
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
 
     if componentKind == .carousel {
       collectionView.showsHorizontalScrollIndicator = false

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -50,7 +50,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   public var refreshPositions = [CGFloat]()
   /// A bool value to indicate if the Controller is refeshing.
   public var refreshing = false
-  /// A convenience method for resolving the first spot.
+  /// A convenience method for resolving the first component.
   public var component: CoreComponent? {
     return component(at: 0, ofType: CoreComponent.self)
   }
@@ -109,7 +109,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
                                            object: nil)
   }
 
-  /// Initialize a new controller with a single spot
+  /// Initialize a new controller with a single component
   ///
   /// - parameter component: A CoreComponent object
   ///
@@ -159,17 +159,17 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 
   ///  A generic look up method for resolving components based on index
   ///
-  /// - parameter index: The index of the spot that you are trying to resolve.
-  /// - parameter type: The generic type for the spot you are trying to resolve.
+  /// - parameter index: The index of the component that you are trying to resolve.
+  /// - parameter type: The generic type for the component you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object of inferred type.
   open func component<T>(at index: Int = 0, ofType type: T.Type) -> T? {
     return components.filter({ $0.index == index }).first as? T
   }
 
-  /// A look up method for resolving a spot at index as a CoreComponent object.
+  /// A look up method for resolving a component at index as a CoreComponent object.
   ///
-  /// - parameter index: The index of the spot that you are trying to resolve.
+  /// - parameter index: The index of the component that you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object.
   open func component(at index: Int = 0) -> CoreComponent? {
@@ -178,7 +178,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 
   /// A generic look up method for resolving components using a closure
   ///
-  /// - parameter closure: A closure to perform actions on a spotable object
+  /// - parameter closure: A closure to perform actions on a component.
   ///
   /// - returns: An optional CoreComponent object
   open func resolve(component closure: (_ index: Int, _ component: CoreComponent) -> Bool) -> CoreComponent? {
@@ -203,7 +203,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 
   // MARK: - View Life Cycle
 
-  /// Called after the spot controller's view is loaded into memory.
+  /// Called after the component controller's view is loaded into memory.
   open override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -218,7 +218,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
     Controller.configure?(scrollView)
   }
 
-  /// Notifies the spot controller that its view is about to be added to a view hierarchy.
+  /// Notifies the component controller that its view is about to be added to a view hierarchy.
   ///
   /// - parameter animated: If true, the view is being added to the window using an animation.
   open override func viewWillAppear(_ animated: Bool) {
@@ -377,7 +377,7 @@ extension Controller {
     return component(at: indexPath).model
   }
 
-  /// Resolve spot at index path.
+  /// Resolve component at index path.
   ///
   /// - parameter indexPath: The index path of The component.
   ///

--- a/Sources/iOS/Classes/Controller.swift
+++ b/Sources/iOS/Classes/Controller.swift
@@ -51,8 +51,8 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   /// A bool value to indicate if the Controller is refeshing.
   public var refreshing = false
   /// A convenience method for resolving the first spot.
-  public var spot: CoreComponent? {
-    return spot(at: 0, ofType: CoreComponent.self)
+  public var component: CoreComponent? {
+    return component(at: 0, ofType: CoreComponent.self)
   }
 
   #if DEVMODE
@@ -102,16 +102,20 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
     self.components = components
     super.init(nibName: nil, bundle: nil)
 
-    NotificationCenter.default.addObserver(self, selector:#selector(self.deviceDidRotate(_:)), name: NSNotification.Name(rawValue: NotificationKeys.deviceDidRotateNotification.rawValue), object: nil)
+    let notificationName = NSNotification.Name(rawValue: NotificationKeys.deviceDidRotateNotification.rawValue)
+    NotificationCenter.default.addObserver(self,
+                                           selector:#selector(self.deviceDidRotate(_:)),
+                                           name: notificationName,
+                                           object: nil)
   }
 
   /// Initialize a new controller with a single spot
   ///
-  /// - parameter spot: A CoreComponent object
+  /// - parameter component: A CoreComponent object
   ///
   /// - returns: An initialized controller containing one object.
-  public convenience init(spot: CoreComponent) {
-    self.init(components: [spot])
+  public convenience init(component: CoreComponent) {
+    self.init(components: [component])
   }
 
   /// Initialize a new controller using JSON.
@@ -159,7 +163,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   /// - parameter type: The generic type for the spot you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object of inferred type.
-  open func spot<T>(at index: Int = 0, ofType type: T.Type) -> T? {
+  open func component<T>(at index: Int = 0, ofType type: T.Type) -> T? {
     return components.filter({ $0.index == index }).first as? T
   }
 
@@ -168,7 +172,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   /// - parameter index: The index of the spot that you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object.
-  open func spot(at index: Int = 0) -> CoreComponent? {
+  open func component(at index: Int = 0) -> CoreComponent? {
     return components.filter({ $0.index == index }).first
   }
 
@@ -177,10 +181,10 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   /// - parameter closure: A closure to perform actions on a spotable object
   ///
   /// - returns: An optional CoreComponent object
-  open func resolve(spot closure: (_ index: Int, _ spot: CoreComponent) -> Bool) -> CoreComponent? {
-    for (index, spot) in components.enumerated()
-      where closure(index, spot) {
-        return spot
+  open func resolve(component closure: (_ index: Int, _ component: CoreComponent) -> Bool) -> CoreComponent? {
+    for (index, component) in components.enumerated()
+      where closure(index, component) {
+        return component
     }
     return nil
   }
@@ -209,7 +213,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
     scrollView.clipsToBounds = true
     scrollView.delegate = self
 
-    setupSpots()
+    setupComponents()
 
     Controller.configure?(scrollView)
   }
@@ -226,7 +230,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
     }
 
     #if os(iOS)
-      refreshControl.addTarget(self, action: #selector(refreshSpots(_:)), for: .valueChanged)
+      refreshControl.addTarget(self, action: #selector(refreshComponent(_:)), for: .valueChanged)
 
       guard let _ = refreshDelegate, refreshControl.superview == nil
         else { return }
@@ -273,46 +277,46 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 
   /// Set up CoreComponent objects.
   ///
-  /// - parameter animated: An optional animation closure that is invoked when setting up the spot.
-  open func setupSpots(animated: ((_ view: UIView) -> Void)? = nil) {
+  /// - parameter animated: An optional animation closure that is invoked when setting up the component.
+  open func setupComponents(animated: ((_ view: UIView) -> Void)? = nil) {
     var yOffset: CGFloat = 0.0
 
-    components.enumerated().forEach { index, spot in
-      setupComponent(at: index, spot: spot)
-      animated?(spot.view)
-      (spot as? CarouselComponent)?.layout.yOffset = yOffset
-      yOffset += spot.view.frame.size.height
+    components.enumerated().forEach { index, component in
+      setupComponent(at: index, component: component)
+      animated?(component.view)
+      (component as? CarouselComponent)?.layout.yOffset = yOffset
+      yOffset += component.view.frame.size.height
     }
   }
 
   /// Set up Spot at index
   ///
   /// - parameter index: The index of the CoreComponent object
-  /// - parameter spot:  The spotable object that is going to be setup
-  open func setupComponent(at index: Int, spot: CoreComponent) {
-    if spot.view.superview == nil {
-      scrollView.componentsContentView.addSubview(spot.view)
+  /// - parameter component:  The component that is going to be setup
+  open func setupComponent(at index: Int, component: CoreComponent) {
+    if component.view.superview == nil {
+      scrollView.componentsContentView.addSubview(component.view)
     }
 
-    guard let superview = spot.view.superview else {
+    guard let superview = component.view.superview else {
       return
     }
 
-    spot.view.frame.origin.x = 0.0
-    spot.model.index = index
-    spot.setup(superview.frame.size)
-    spot.model.size = CGSize(
+    component.view.frame.origin.x = 0.0
+    component.model.index = index
+    component.setup(superview.frame.size)
+    component.model.size = CGSize(
       width: superview.frame.width,
-      height: ceil(spot.view.frame.height))
-    spot.focusDelegate = self
+      height: ceil(component.view.frame.height))
+    component.focusDelegate = self
 
     /// Spot handles registering and preparing the items internally so there is no need to run this for that class.
     /// This should be removed in the future when we decide to remove the core types.
-    if !(spot is Component) {
-      spot.registerAndPrepare()
+    if !(component is Component) {
+      component.registerAndPrepare()
 
-      if !spot.items.isEmpty {
-        spot.view.layoutIfNeeded()
+      if !component.items.isEmpty {
+        component.view.layoutIfNeeded()
       }
     }
   }
@@ -321,11 +325,13 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   /// Refresh action for UIRefreshControl
   ///
   /// - parameter refreshControl: The refresh control used to refresh the controller.
-  open func refreshSpots(_ refreshControl: UIRefreshControl) {
+  open func refreshComponent(_ refreshControl: UIRefreshControl) {
     Dispatch.main { [weak self] in
-      guard let weakSelf = self else { return }
+      guard let weakSelf = self else {
+        return
+      }
       weakSelf.refreshPositions.removeAll()
-      weakSelf.refreshDelegate?.spotablesDidReload(weakSelf.components, refreshControl: refreshControl) {
+      weakSelf.refreshDelegate?.componentsDidReload(weakSelf.components, refreshControl: refreshControl) {
         refreshControl.endRefreshing()
       }
     }
@@ -349,7 +355,7 @@ extension Controller {
     delegate?.componentsDidChange(components)
   }
 
-  /// It updates the delegates for all underlaying spotable objects inside the controller.
+  /// It updates the delegates for all underlaying components inside the controller.
   fileprivate  func updateDelegates() {
     components.forEach {
       $0.delegate = delegate
@@ -368,15 +374,15 @@ extension Controller {
   ///
   /// - returns: A ComponentModel object at index path.
   fileprivate func component(at indexPath: IndexPath) -> ComponentModel {
-    return spot(at: indexPath).model
+    return component(at: indexPath).model
   }
 
   /// Resolve spot at index path.
   ///
-  /// - parameter indexPath: The index path of the spotable object.
+  /// - parameter indexPath: The index path of The component.
   ///
   /// - returns: A CoreComponent object.
-  fileprivate func spot(at indexPath: IndexPath) -> CoreComponent {
+  fileprivate func component(at indexPath: IndexPath) -> CoreComponent {
     return components[indexPath.item]
   }
 }

--- a/Sources/iOS/Classes/GridComponent.swift
+++ b/Sources/iOS/Classes/GridComponent.swift
@@ -68,7 +68,7 @@ open class GridComponent: NSObject, Gridable {
 
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 
@@ -86,7 +86,7 @@ open class GridComponent: NSObject, Gridable {
     }
   }
 
-  /// A convenience init for initializing a Gridspot with a title and a kind.
+  /// A convenience init for initializing a gridComponent with a title and a kind.
   ///
   ///  - parameter title: A string that is used as a title for the GridComponent.
   ///  - parameter kind:  An identifier to determine which kind should be set on the ComponentModel.

--- a/Sources/iOS/Classes/GridComponent.swift
+++ b/Sources/iOS/Classes/GridComponent.swift
@@ -51,8 +51,8 @@ open class GridComponent: NSObject, Gridable {
     }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /// A required initializer to instantiate a GridComponent with a model.
   ///
@@ -69,8 +69,8 @@ open class GridComponent: NSObject, Gridable {
     super.init()
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.grid.string
@@ -111,13 +111,13 @@ open class GridComponent: NSObject, Gridable {
   /// Configure collection view with data source, delegate and background view
   public func configureCollectionView() {
     register()
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 }

--- a/Sources/iOS/Classes/GridComponent.swift
+++ b/Sources/iOS/Classes/GridComponent.swift
@@ -58,7 +58,7 @@ open class GridComponent: NSObject, Gridable {
   ///
   /// - parameter component: A model.
   ///
-  /// - returns: An initialized grid spot with model.
+  /// - returns: An initialized grid component with model.
   public required init(model: ComponentModel) {
     self.model = model
 
@@ -91,7 +91,7 @@ open class GridComponent: NSObject, Gridable {
   ///  - parameter title: A string that is used as a title for the GridComponent.
   ///  - parameter kind:  An identifier to determine which kind should be set on the ComponentModel.
   ///
-  /// - returns: An initialized grid spot with computed component using title and kind.
+  /// - returns: An initialized grid component with computed component using title and kind.
   public convenience init(title: String = "", kind: String? = nil) {
     self.init(model: ComponentModel(title: title, kind: kind ?? "", span: 0.0))
   }
@@ -100,7 +100,7 @@ open class GridComponent: NSObject, Gridable {
   ///
   /// - parameter cacheKey: A unique cache key for the CoreComponent object
   ///
-  /// - returns: An initialized grid spot.
+  /// - returns: An initialized grid component.
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 

--- a/Sources/iOS/Classes/ListComponent.swift
+++ b/Sources/iOS/Classes/ListComponent.swift
@@ -50,8 +50,8 @@ open class ListComponent: NSObject, Listable {
   open fileprivate(set) var stateCache: StateCache?
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   // MARK: - Initializers
 
@@ -70,8 +70,8 @@ open class ListComponent: NSObject, Listable {
     super.init()
     self.userInterface = self.tableView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.list.string
@@ -145,16 +145,16 @@ open class ListComponent: NSObject, Listable {
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
   /// Configure and setup the data source, delegate and additional configuration options for the table view.
   public func setupTableView() {
     register()
-    tableView.dataSource = spotDataSource
-    tableView.delegate = spotDelegate
+    tableView.dataSource = componentDataSource
+    tableView.delegate = componentDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
 
     #if os(iOS)

--- a/Sources/iOS/Classes/ListComponent.swift
+++ b/Sources/iOS/Classes/ListComponent.swift
@@ -59,7 +59,7 @@ open class ListComponent: NSObject, Listable {
   ///
   /// - parameter component: A model.
   ///
-  /// - returns: An initialized list spot with model.
+  /// - returns: An initialized list component with model.
   public required init(model: ComponentModel) {
     self.model = model
 
@@ -89,7 +89,7 @@ open class ListComponent: NSObject, Listable {
   /// - parameter kind:      An identifier to determine which kind should be set on the ComponentModel.
   /// - parameter kind:      An identifier to determine which kind should be set on the ComponentModel.
   ///
-  /// - returns: An initialized list spot with model.
+  /// - returns: An initialized list component with model.
   public convenience init(tableView: UITableView? = nil, title: String = "",
                           kind: String = "list", header: String = "") {
     self.init(model: ComponentModel(title: title, header: header, kind: kind, span: 1.0))
@@ -106,7 +106,7 @@ open class ListComponent: NSObject, Listable {
   ///
   /// - parameter cacheKey: A unique cache key for the CoreComponent object.
   ///
-  /// - returns: An initialized list spot.
+  /// - returns: An initialized list component.
   public convenience init(cacheKey: String, tableView: UITableView? = nil) {
     let stateCache = StateCache(key: cacheKey)
 

--- a/Sources/iOS/Classes/ListComponent.swift
+++ b/Sources/iOS/Classes/ListComponent.swift
@@ -69,7 +69,7 @@ open class ListComponent: NSObject, Listable {
 
     super.init()
     self.userInterface = self.tableView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 

--- a/Sources/iOS/Classes/RowComponent.swift
+++ b/Sources/iOS/Classes/RowComponent.swift
@@ -50,8 +50,8 @@ open class RowComponent: NSObject, Gridable {
     }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /// A required initializer to instantiate a RowComponent with a model.
   ///
@@ -68,8 +68,8 @@ open class RowComponent: NSObject, Gridable {
     super.init()
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.row.string
@@ -98,15 +98,15 @@ open class RowComponent: NSObject, Gridable {
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
   /// Configure collection view with data source, delegate and background view
   public func configureCollectionView() {
     register()
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
   }
 }

--- a/Sources/iOS/Classes/RowComponent.swift
+++ b/Sources/iOS/Classes/RowComponent.swift
@@ -67,7 +67,7 @@ open class RowComponent: NSObject, Gridable {
 
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 
@@ -75,7 +75,7 @@ open class RowComponent: NSObject, Gridable {
       self.model.kind = ComponentModel.Kind.row.string
     }
 
-    registerDefault(view: RowSpotCell.self)
+    registerDefault(view: RowComponentCell.self)
     registerComposite(view: GridComposite.self)
     prepareItems()
     configureCollectionView()

--- a/Sources/iOS/Classes/RowComponent.swift
+++ b/Sources/iOS/Classes/RowComponent.swift
@@ -57,7 +57,7 @@ open class RowComponent: NSObject, Gridable {
   ///
   /// - parameter component: A model.
   ///
-  /// - returns: An initialized row spot with model.
+  /// - returns: An initialized row component with model.
   public required init(model: ComponentModel) {
     self.model = model
 
@@ -89,7 +89,7 @@ open class RowComponent: NSObject, Gridable {
   ///
   /// - parameter cacheKey: A unique cache key for the CoreComponent object
   ///
-  /// - returns: An initialized row spot.
+  /// - returns: An initialized row component.
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 

--- a/Sources/iOS/Classes/RowComponentCell.swift
+++ b/Sources/iOS/Classes/RowComponentCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// A default cell for the RowComponent
-public class RowSpotCell: UICollectionViewCell, ItemConfigurable {
+public class RowComponentCell: UICollectionViewCell, ItemConfigurable {
 
   /// The preferred view size for the view
   public var preferredViewSize = CGSize(width: 88, height: 44)

--- a/Sources/iOS/Extensions/Component+iOS+List.swift
+++ b/Sources/iOS/Extensions/Component+iOS+List.swift
@@ -3,8 +3,8 @@ import UIKit
 extension Component {
 
   func setupTableView(_ tableView: TableView, with size: CGSize) {
-    tableView.dataSource = spotDataSource
-    tableView.delegate = spotDelegate
+    tableView.dataSource = componentDataSource
+    tableView.delegate = componentDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
     tableView.frame.size = size
     tableView.frame.size.width = round(size.width - (tableView.contentInset.left))

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -4,23 +4,23 @@ import UIKit
 extension Delegate: UIScrollViewDelegate {
 
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    performPaginatedScrolling { spot, collectionView, _ in
+    performPaginatedScrolling { component, collectionView, _ in
       /// This will restrict the scroll view to only scroll horizontally.
       let constrainedYOffset = collectionView.contentSize.height - collectionView.frame.size.height
       if constrainedYOffset >= 0.0 {
         collectionView.contentOffset.y = constrainedYOffset
       }
 
-      switch spot {
-      case let spot as Component:
-        spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
-        if spot.model.layout?.pageIndicatorPlacement == .overlay {
-          spot.pageControl.frame.origin.x = scrollView.contentOffset.x
+      switch component {
+      case let component as Component:
+        component.carouselScrollDelegate?.componentCarouselDidScroll(component)
+        if component.model.layout?.pageIndicatorPlacement == .overlay {
+          component.pageControl.frame.origin.x = scrollView.contentOffset.x
         }
-      case let spot as CarouselComponent:
-        spot.carouselScrollDelegate?.spotableCarouselDidScroll(spot)
-        if spot.model.layout?.pageIndicatorPlacement == .overlay {
-          spot.pageControl.frame.origin.x = scrollView.contentOffset.x
+      case let component as CarouselComponent:
+        component.carouselScrollDelegate?.componentCarouselDidScroll(component)
+        if component.model.layout?.pageIndicatorPlacement == .overlay {
+          component.pageControl.frame.origin.x = scrollView.contentOffset.x
         }
       default:
         assertionFailure("CoreComponent object is not eligible for horizontal scrolling.")
@@ -29,23 +29,23 @@ extension Delegate: UIScrollViewDelegate {
   }
 
   public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    component?.didScrollHorizontally { spot in
+    component?.didScrollHorizontally { component in
       let itemIndex = Int(scrollView.contentOffset.x / scrollView.frame.width)
 
       guard itemIndex >= 0 else {
         return
       }
 
-      guard itemIndex < spot.items.count else {
+      guard itemIndex < component.items.count else {
         return
       }
 
-      spot.pageControl.currentPage = itemIndex
+      component.pageControl.currentPage = itemIndex
     }
   }
 
   public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-    performPaginatedScrolling { spot, collectionView, collectionViewLayout in
+    performPaginatedScrolling { component, collectionView, collectionViewLayout in
       let centerIndexPath = getCenterIndexPath(in: collectionView,
                                                scrollView: scrollView,
                                                point: scrollView.contentOffset,
@@ -56,11 +56,11 @@ extension Delegate: UIScrollViewDelegate {
         return
       }
 
-      guard let item = spot.item(at: foundCenterIndex.item) else {
+      guard let item = component.item(at: foundCenterIndex.item) else {
         return
       }
 
-      spot.carouselScrollDelegate?.spotableCarouselDidEndScrolling(spot, item: item, animated: true)
+      component.carouselScrollDelegate?.componentCarouselDidEndScrolling(component, item: item, animated: true)
     }
   }
 
@@ -70,7 +70,7 @@ extension Delegate: UIScrollViewDelegate {
   /// - parameter velocity:            The velocity of the scroll view (in points) at the moment the touch was released.
   /// - parameter targetContentOffset: The expected offset when the scrolling action decelerates to a stop.
   public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    performPaginatedScrolling { spot, collectionView, collectionViewLayout in
+    performPaginatedScrolling { component, collectionView, collectionViewLayout in
       var centerIndexPath: IndexPath?
 
       centerIndexPath = getCenterIndexPath(in: collectionView,
@@ -79,12 +79,12 @@ extension Delegate: UIScrollViewDelegate {
                                            contentSize: collectionViewLayout.contentSize,
                                            offset: collectionViewLayout.minimumInteritemSpacing)
 
-      if spot.model.interaction.paginate == .page {
+      if component.model.interaction.paginate == .page {
         let widthBounds = scrollView.contentSize.width - scrollView.frame.size.width
         let isBeyondBounds = targetContentOffset.pointee.x >= widthBounds && centerIndexPath == nil
 
         if isBeyondBounds {
-          centerIndexPath = IndexPath(item: spot.items.count - 1, section: 0)
+          centerIndexPath = IndexPath(item: component.items.count - 1, section: 0)
         }
       }
 
@@ -96,8 +96,8 @@ extension Delegate: UIScrollViewDelegate {
         return
       }
 
-      if let item = spot.item(at: foundIndexPath.item) {
-        spot.carouselScrollDelegate?.spotableCarouselDidEndScrolling(spot, item: item, animated: false)
+      if let item = component.item(at: foundIndexPath.item) {
+        component.carouselScrollDelegate?.componentCarouselDidEndScrolling(component, item: item, animated: false)
       }
 
       targetContentOffset.pointee.x = centerLayoutAttributes.frame.midX - scrollView.frame.width / 2
@@ -105,13 +105,13 @@ extension Delegate: UIScrollViewDelegate {
   }
 
   fileprivate func performPaginatedScrolling(_ handler: (ComponentHorizontallyScrollable, UICollectionView, CollectionLayout) -> Void) {
-    component?.didScrollHorizontally { spot in
-      guard let collectionView = spot.userInterface as? CollectionView,
+    component?.didScrollHorizontally { component in
+      guard let collectionView = component.userInterface as? CollectionView,
         let collectionViewLayout = collectionView.collectionViewLayout as? CollectionLayout else {
           return
       }
 
-      handler(spot, collectionView, collectionViewLayout)
+      handler(component, collectionView, collectionViewLayout)
     }
   }
 

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -70,10 +70,10 @@ extension Gridable {
 
   /// Perform animation before mutation
   ///
-  /// - parameter spotAnimation: The animation that you want to apply
+  /// - parameter componentAnimation: The animation that you want to apply
   /// - parameter withIndex: The index of the cell
   /// - parameter completion: A completion block that runs after applying the animation
-  public func perform(_ spotAnimation: Animation, withIndex index: Int, completion: () -> Void) {
+  public func perform(_ componentAnimation: Animation, withIndex index: Int, completion: () -> Void) {
     guard let cell = collectionView.cellForItem(at: IndexPath(item: index, section: 0))
       else {
         completion()
@@ -82,7 +82,7 @@ extension Gridable {
 
     let animation = CABasicAnimation()
 
-    switch spotAnimation {
+    switch componentAnimation {
     case .top:
       animation.keyPath = "position.y"
       animation.toValue = -cell.frame.height

--- a/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
+++ b/Sources/iOS/Extensions/Gridable+Extensions+iOS.swift
@@ -60,7 +60,7 @@ extension Gridable {
       prepareItems()
     }
 
-    model.layout?.configure(spot: self)
+    model.layout?.configure(component: self)
     layout.prepare()
     layout.invalidateLayout()
 

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -2,16 +2,16 @@ import UIKit
 
 extension Layout {
 
-  public func configure(spot: Gridable) {
-    spot.layout.sectionInset = UIEdgeInsets(
+  public func configure(component: Gridable) {
+    component.layout.sectionInset = UIEdgeInsets(
       top: CGFloat(inset.top),
       left: CGFloat(inset.left),
       bottom: CGFloat(inset.bottom),
       right: CGFloat(inset.right)
     )
 
-    spot.layout.minimumInteritemSpacing = CGFloat(itemSpacing)
-    spot.layout.minimumLineSpacing = CGFloat(lineSpacing)
+    component.layout.minimumInteritemSpacing = CGFloat(itemSpacing)
+    component.layout.minimumLineSpacing = CGFloat(lineSpacing)
   }
 
   public func configure(collectionViewLayout: CollectionLayout) {

--- a/Sources/macOS/Classes/CarouselComponent.swift
+++ b/Sources/macOS/Classes/CarouselComponent.swift
@@ -109,7 +109,7 @@ open class CarouselComponent: NSObject, Gridable {
   ///
   /// - parameter component: A component
   ///
-  /// - returns: An initialized carousel spot.
+  /// - returns: An initialized carousel component.
   public required init(model: ComponentModel) {
     self.model = model
 
@@ -150,7 +150,7 @@ open class CarouselComponent: NSObject, Gridable {
   ///
   /// - parameter cacheKey: A unique cache key for the CoreComponent object.
   ///
-  /// - returns: An initialized carousel spot.
+  /// - returns: An initialized carousel component.
   public convenience init(cacheKey: String) {
     let stateCache = StateCache(key: cacheKey)
 

--- a/Sources/macOS/Classes/CarouselComponent.swift
+++ b/Sources/macOS/Classes/CarouselComponent.swift
@@ -102,8 +102,8 @@ open class CarouselComponent: NSObject, Gridable {
   }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /// A required initializer to instantiate a CarouselComponent with a model.
   ///
@@ -121,8 +121,8 @@ open class CarouselComponent: NSObject, Gridable {
     super.init()
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.carousel.string
@@ -161,8 +161,8 @@ open class CarouselComponent: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
@@ -173,8 +173,8 @@ open class CarouselComponent: NSObject, Gridable {
 
     let view = NSView()
     collectionView.backgroundView = view
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
     collectionView.collectionViewLayout = layout
   }
 

--- a/Sources/macOS/Classes/CarouselComponent.swift
+++ b/Sources/macOS/Classes/CarouselComponent.swift
@@ -120,7 +120,7 @@ open class CarouselComponent: NSObject, Gridable {
     self.collectionView = CollectionView()
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -22,8 +22,8 @@ import Tailor
   public var componentKind: ComponentModel.Kind = .list
   public var compositeComponents: [CompositeComponent] = []
   public var configure: ((ItemConfigurable) -> Void)?
-  public var spotDelegate: Delegate?
-  public var spotDataSource: DataSource?
+  public var componentDelegate: Delegate?
+  public var componentDataSource: DataSource?
   public var stateCache: StateCache?
   public var userInterface: UserInterface?
   open var gradientLayer: CAGradientLayer?
@@ -128,8 +128,8 @@ import Tailor
 
     userInterface.register()
 
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
   }
 
   public required convenience init(model: ComponentModel) {
@@ -165,8 +165,8 @@ import Tailor
   }
 
   deinit {
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
@@ -176,11 +176,11 @@ import Tailor
 
   fileprivate func configureDataSourceAndDelegate() {
     if let tableView = self.tableView {
-      tableView.dataSource = spotDataSource
-      tableView.delegate = spotDelegate
+      tableView.dataSource = componentDataSource
+      tableView.delegate = componentDelegate
     } else if let collectionView = self.collectionView {
-      collectionView.dataSource = spotDataSource
-      collectionView.delegate = spotDelegate
+      collectionView.dataSource = componentDataSource
+      collectionView.delegate = componentDelegate
     }
   }
 
@@ -231,8 +231,8 @@ import Tailor
     collectionView.allowsEmptySelection = true
     collectionView.layer = CALayer()
     collectionView.wantsLayer = true
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
 
     let backgroundView = NSView()
     backgroundView.wantsLayer = true

--- a/Sources/macOS/Classes/Controller.swift
+++ b/Sources/macOS/Classes/Controller.swift
@@ -23,9 +23,9 @@ open class Controller: NSViewController, SpotsProtocol {
     return view
   }
 
-  /// A convenience method for resolving the first spot
-  open var spot: CoreComponent? {
-    return spot(at: 0)
+  /// A convenience method for resolving the first component
+  open var component: CoreComponent? {
+    return component(at: 0)
   }
 
   /// An array of refresh positions to avoid refreshing multiple times when using infinite scrolling
@@ -88,10 +88,10 @@ open class Controller: NSViewController, SpotsProtocol {
   }
 
   /**
-   - parameter spot: A CoreComponent object
+   - parameter component: A CoreComponent object
    */
-  public convenience init(spot: CoreComponent) {
-    self.init(components: [spot])
+  public convenience init(component: CoreComponent) {
+    self.init(components: [component])
   }
 
   /**
@@ -122,34 +122,34 @@ open class Controller: NSViewController, SpotsProtocol {
 
   ///  A generic look up method for resolving components based on index
   ///
-  /// - parameter index: The index of the spot that you are trying to resolve.
-  /// - parameter type: The generic type for the spot you are trying to resolve.
+  /// - parameter index: The index of the component that you are trying to resolve.
+  /// - parameter type: The generic type for the component you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object of inferred type.
-  open func spot<T>(at index: Int = 0, ofType type: T.Type) -> T? {
+  open func component<T>(at index: Int = 0, ofType type: T.Type) -> T? {
     return components.filter({ $0.index == index }).first as? T
   }
 
-  /// A look up method for resolving a spot at index as a CoreComponent object.
+  /// A look up method for resolving a component at index as a CoreComponent object.
   ///
-  /// - parameter index: The index of the spot that you are trying to resolve.
+  /// - parameter index: The index of the component that you are trying to resolve.
   ///
   /// - returns: An optional CoreComponent object.
-  open func spot(at index: Int = 0) -> CoreComponent? {
+  open func component(at index: Int = 0) -> CoreComponent? {
     return components.filter({ $0.index == index }).first
   }
 
   /**
    A generic look up method for resolving components using a closure
 
-   - parameter closure: A closure to perform actions on a spotable object
+   - parameter closure: A closure to perform actions on a component
 
    - returns: An optional CoreComponent object
    */
-  public func resolve(spot closure: (_ index: Int, _ spot: CoreComponent) -> Bool) -> CoreComponent? {
-    for (index, spot) in components.enumerated()
-      where closure(index, spot) {
-        return spot
+  public func resolve(component closure: (_ index: Int, _ component: CoreComponent) -> Bool) -> CoreComponent? {
+    for (index, component) in components.enumerated()
+      where closure(index, component) {
+        return component
     }
     return nil
   }
@@ -184,103 +184,103 @@ open class Controller: NSViewController, SpotsProtocol {
     scrollView.hasVerticalScroller = true
     scrollView.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
 
-    setupSpots()
+    setupComponents()
     Controller.configure?(scrollView)
   }
 
   open override func viewDidAppear() {
     super.viewDidAppear()
 
-    for spot in components {
-      spot.layout(scrollView.frame.size)
+    for component in components {
+      component.layout(scrollView.frame.size)
     }
   }
 
   public func reloadSpots(components: [CoreComponent], closure: (() -> Void)?) {
-    for spot in self.components {
-      spot.delegate = nil
-      spot.view.removeFromSuperview()
+    for component in self.components {
+      component.delegate = nil
+      component.view.removeFromSuperview()
     }
     self.components = components
     delegate = nil
 
-    setupSpots()
+    setupComponents()
     closure?()
     scrollView.layoutSubviews()
   }
 
   /**
-   - parameter animated: An optional animation closure that runs when a spot is being rendered
+   - parameter animated: An optional animation closure that runs when a component is being rendered
    */
-  public func setupSpots(animated: ((_ view: View) -> Void)? = nil) {
-    components.enumerated().forEach { index, spot in
-      setupComponent(at: index, spot: spot)
-      animated?(spot.view)
+  public func setupComponents(animated: ((_ view: View) -> Void)? = nil) {
+    components.enumerated().forEach { index, component in
+      setupComponent(at: index, component: component)
+      animated?(component.view)
     }
   }
 
-  public func setupComponent(at index: Int, spot: CoreComponent) {
-    if spot.view.superview == nil {
-      scrollView.componentsContentView.addSubview(spot.view)
+  public func setupComponent(at index: Int, component: CoreComponent) {
+    if component.view.superview == nil {
+      scrollView.componentsContentView.addSubview(component.view)
     }
 
     components[index].model.index = index
-    spot.registerAndPrepare()
+    component.registerAndPrepare()
 
-    var height = spot.computedHeight
-    if let componentSize = spot.model.size, componentSize.height > height {
+    var height = component.computedHeight
+    if let componentSize = component.model.size, componentSize.height > height {
       height = componentSize.height
     }
 
-    spot.setup(CGSize(width: view.frame.width, height: height))
-    spot.model.size = CGSize(
+    component.setup(CGSize(width: view.frame.width, height: height))
+    component.model.size = CGSize(
       width: view.frame.width,
-      height: ceil(spot.view.frame.height))
+      height: ceil(component.view.frame.height))
 
-    (spot as? Gridable)?.layout(CGSize(width: view.frame.width, height: height))
+    (component as? Gridable)?.layout(CGSize(width: view.frame.width, height: height))
   }
 
   open override func viewDidLayout() {
     super.viewDidLayout()
 
-    for spot in components {
-      spot.layout(CGSize(width: view.frame.width,
-        height: spot.computedHeight))
+    for component in components {
+      component.layout(CGSize(width: view.frame.width,
+        height: component.computedHeight))
 
-      for compositeSpot in spot.compositeComponents {
-        compositeSpot.component.setup(CGSize(width: view.frame.width,
-                                        height: compositeSpot.component.computedHeight))
+      for compositeComponent in component.compositeComponents {
+        compositeComponent.component.setup(CGSize(width: view.frame.width,
+                                        height: compositeComponent.component.computedHeight))
       }
     }
   }
 
-  public func deselectAllExcept(selectedSpot: CoreComponent) {
-    for spot in components {
-      if selectedSpot.view != spot.view {
-        spot.deselect()
+  public func deselectAllExcept(selectedComponent: CoreComponent) {
+    for component in components {
+      if selectedComponent.view != component.view {
+        component.deselect()
       }
     }
   }
 
   public func windowDidResize(_ notification: Notification) {
-    for case let spot as Gridable in components {
-      guard let layout = spot.model.layout, layout.span > 1 else {
+    for case let component as Gridable in components {
+      guard let layout = component.model.layout, layout.span > 1 else {
         continue
       }
 
-      spot.layout.prepareForTransition(from: spot.layout)
-      spot.layout.invalidateLayout()
+      component.layout.prepareForTransition(from: component.layout)
+      component.layout.invalidateLayout()
     }
   }
 
   public func windowDidEndLiveResize(_ notification: Notification) {
-    for case let spot as Gridable in components {
-      guard let layout = spot.model.layout, layout.span > 1 else {
+    for case let component as Gridable in components {
+      guard let layout = component.model.layout, layout.span > 1 else {
         continue
       }
 
-      spot.layout.prepareForTransition(to: spot.layout)
-      spot.layout.invalidateLayout()
+      component.layout.prepareForTransition(to: component.layout)
+      component.layout.invalidateLayout()
     }
   }
 
@@ -288,7 +288,9 @@ open class Controller: NSViewController, SpotsProtocol {
     guard let scrollView = notification.object as? SpotsScrollView,
       let delegate = scrollDelegate,
       let _ = NSApplication.shared().mainWindow, !refreshing && scrollView.contentOffset.y > 0
-      else { return }
+      else {
+        return
+    }
 
     let offset = scrollView.contentOffset
     let totalHeight = scrollView.documentView?.frame.size.height ?? 0

--- a/Sources/macOS/Classes/GridComponent.swift
+++ b/Sources/macOS/Classes/GridComponent.swift
@@ -155,7 +155,7 @@ open class GridComponent: NSObject, Gridable {
     self.layout = GridComponent.setupLayout(model)
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 
@@ -177,7 +177,7 @@ open class GridComponent: NSObject, Gridable {
   }
 
   /**
-   A convenience init for initializing a Gridspot
+   A convenience init for initializing a gridComponent
 
    - parameter cacheKey: A cache key
    */

--- a/Sources/macOS/Classes/GridComponent.swift
+++ b/Sources/macOS/Classes/GridComponent.swift
@@ -136,8 +136,8 @@ open class GridComponent: NSObject, Gridable {
   }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /**
    A required initializer for creating a GridComponent
@@ -156,8 +156,8 @@ open class GridComponent: NSObject, Gridable {
     super.init()
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.grid.string
@@ -191,8 +191,8 @@ open class GridComponent: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
@@ -237,8 +237,8 @@ open class GridComponent: NSObject, Gridable {
     collectionView.allowsEmptySelection = true
     collectionView.layer = CALayer()
     collectionView.wantsLayer = true
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
     collectionView.collectionViewLayout = layout
 
     let backgroundView = NSView()

--- a/Sources/macOS/Classes/ListComponent.swift
+++ b/Sources/macOS/Classes/ListComponent.swift
@@ -117,8 +117,8 @@ open class ListComponent: NSObject, Listable {
   }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   public required init(model: ComponentModel) {
     self.model = model
@@ -130,8 +130,8 @@ open class ListComponent: NSObject, Listable {
     super.init()
     self.userInterface = tableView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.list.string
@@ -153,8 +153,8 @@ open class ListComponent: NSObject, Listable {
   deinit {
     tableView.delegate = nil
     tableView.dataSource = nil
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
@@ -190,8 +190,8 @@ open class ListComponent: NSObject, Listable {
 
     tableView.frame.size = size
     prepareItems()
-    tableView.dataSource = spotDataSource
-    tableView.delegate = spotDelegate
+    tableView.dataSource = componentDataSource
+    tableView.delegate = componentDelegate
     tableView.target = self
     tableView.addTableColumn(tableColumn)
     tableView.action = #selector(self.action(_:))

--- a/Sources/macOS/Classes/ListComponent.swift
+++ b/Sources/macOS/Classes/ListComponent.swift
@@ -129,7 +129,7 @@ open class ListComponent: NSObject, Listable {
 
     super.init()
     self.userInterface = tableView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 

--- a/Sources/macOS/Classes/RowComponent.swift
+++ b/Sources/macOS/Classes/RowComponent.swift
@@ -138,8 +138,8 @@ open class RowComponent: NSObject, Gridable {
   }()
 
   public var userInterface: UserInterface?
-  var spotDataSource: DataSource?
-  var spotDelegate: Delegate?
+  var componentDataSource: DataSource?
+  var componentDelegate: Delegate?
 
   /**
    A required initializer for creating a RowComponent
@@ -158,8 +158,8 @@ open class RowComponent: NSObject, Gridable {
     super.init()
     self.userInterface = collectionView
     self.model.layout?.configure(component: self)
-    self.spotDataSource = DataSource(component: self)
-    self.spotDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self)
+    self.componentDelegate = Delegate(component: self)
 
     if model.kind.isEmpty {
       self.model.kind = ComponentModel.Kind.grid.string
@@ -203,8 +203,8 @@ open class RowComponent: NSObject, Gridable {
   deinit {
     collectionView.delegate = nil
     collectionView.dataSource = nil
-    spotDataSource = nil
-    spotDelegate = nil
+    componentDataSource = nil
+    componentDelegate = nil
     userInterface = nil
   }
 
@@ -249,8 +249,8 @@ open class RowComponent: NSObject, Gridable {
     collectionView.allowsEmptySelection = true
     collectionView.layer = CALayer()
     collectionView.wantsLayer = true
-    collectionView.dataSource = spotDataSource
-    collectionView.delegate = spotDelegate
+    collectionView.dataSource = componentDataSource
+    collectionView.delegate = componentDelegate
     collectionView.collectionViewLayout = layout
   }
 

--- a/Sources/macOS/Classes/RowComponent.swift
+++ b/Sources/macOS/Classes/RowComponent.swift
@@ -157,7 +157,7 @@ open class RowComponent: NSObject, Gridable {
     self.layout = RowComponent.setupLayout(model)
     super.init()
     self.userInterface = collectionView
-    self.model.layout?.configure(spot: self)
+    self.model.layout?.configure(component: self)
     self.spotDataSource = DataSource(component: self)
     self.spotDelegate = Delegate(component: self)
 

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -13,8 +13,8 @@ extension Component {
 
     prepareItems()
 
-    tableView.dataSource = spotDataSource
-    tableView.delegate = spotDelegate
+    tableView.dataSource = componentDataSource
+    tableView.delegate = componentDelegate
     tableView.backgroundColor = NSColor.clear
     tableView.allowsColumnReordering = false
     tableView.allowsColumnResizing = false

--- a/Sources/macOS/Extensions/Layout+macOS.swift
+++ b/Sources/macOS/Extensions/Layout+macOS.swift
@@ -2,10 +2,10 @@ import Cocoa
 
 extension Layout {
 
-  public func configure(spot: Gridable) {
-    inset.configure(scrollView: spot.view)
+  public func configure(component: Gridable) {
+    inset.configure(scrollView: component.view)
 
-    if let layout = spot.layout as? FlowLayout {
+    if let layout = component.layout as? FlowLayout {
       layout.minimumInteritemSpacing = CGFloat(itemSpacing)
       layout.minimumLineSpacing = CGFloat(lineSpacing)
     }

--- a/Sources/macOS/Structs/GridRegistry.swift
+++ b/Sources/macOS/Structs/GridRegistry.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-/// A view registry that is used internally when resolving kind to the corresponding spot.
+/// A view registry that is used internally when resolving kind to the corresponding component.
 public struct GridRegistry {
 
   public enum Item {

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -20,8 +20,8 @@ class ControllerTests: XCTestCase {
     controller.preloadView()
     let items = [Item(title: "item1")]
 
-    controller.update { spot in
-      spot.model.items = items
+    controller.update { component in
+      component.model.items = items
     }
 
     XCTAssert(controller.component!.model.items == items)
@@ -37,7 +37,8 @@ class ControllerTests: XCTestCase {
 
     let item = Item(title: "title1", kind: "list")
     let expectation = self.expectation(description: "Test append item")
-    controller.append(item, spotIndex: 0) {
+
+    controller.append(item, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 1)
       XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
@@ -56,7 +57,7 @@ class ControllerTests: XCTestCase {
 
     let item = Item(title: "title2", kind: "list")
     let expectation = self.expectation(description: "Test append item")
-    controller.append(item, spotIndex: 0) {
+    controller.append(item, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 2)
       XCTAssert(controller.component!.model.items.last! == item)
       expectation.fulfill()
@@ -76,7 +77,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
     ]
     let expectation = self.expectation(description: "Test append items")
-    controller.append(items, spotIndex: 0) {
+    controller.append(items, componentIndex: 0) {
       XCTAssert(controller.component!.model.items.count > 0)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -96,7 +97,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
     ]
     let expectation = self.expectation(description: "Test prepend items")
-    controller.prepend(items, spotIndex: 0) {
+    controller.prepend(items, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 2)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -121,7 +122,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title4", kind: "list")
     ]
     let expectation = self.expectation(description: "Test prepend items")
-    controller.prepend(items, spotIndex: 0) {
+    controller.prepend(items, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 4)
       XCTAssertEqual(controller.component!.model.items[0].title, "title3")
       XCTAssertEqual(controller.component!.model.items[1].title, "title4")
@@ -241,7 +242,7 @@ class ControllerTests: XCTestCase {
     let item = Item(title: "title1", kind: "grid")
     let expectation = self.expectation(description: "Test append item")
 
-    controller.append(item, spotIndex: 0) {
+    controller.append(item, componentIndex: 0) {
       XCTAssert(controller.component!.model.items.count == 1)
       XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
@@ -262,7 +263,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "grid")
     ]
     let expectation = self.expectation(description: "Test append items")
-    controller.append(items, spotIndex: 0) {
+    controller.append(items, componentIndex: 0) {
       XCTAssert(controller.component!.model.items.count > 0)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -283,7 +284,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "grid")
     ]
     let expectation = self.expectation(description: "Test prepend items")
-    controller.prepend(items, spotIndex: 0) {
+    controller.prepend(items, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 2)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -333,7 +334,7 @@ class ControllerTests: XCTestCase {
     let item = Item(title: "title1", kind: "carousel")
     let expectation = self.expectation(description: "Test append item")
 
-    controller.append(item, spotIndex: 0) {
+    controller.append(item, componentIndex: 0) {
       XCTAssert(controller.component!.model.items.count == 1)
       XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
@@ -355,7 +356,7 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test append items")
 
-    controller.append(items, spotIndex: 0) {
+    controller.append(items, componentIndex: 0) {
       XCTAssert(controller.component!.model.items.count > 0)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -376,7 +377,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "carousel")
     ]
     let expectation = self.expectation(description: "Test prepend items")
-    controller.prepend(items, spotIndex: 0) {
+    controller.prepend(items, componentIndex: 0) {
       XCTAssertEqual(controller.component!.model.items.count, 2)
       XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
@@ -682,7 +683,7 @@ class ControllerTests: XCTestCase {
     let controller = Controller(components: components)
     XCTAssertEqual(controller.components.count, 1)
 
-    /// Test first item in the first component of the first spot inside of the controller
+    /// Test first item in the first component of the first component inside of the controller
     XCTAssertEqual(controller.components.first!.model.kind, components.first!.model.kind)
     XCTAssertEqual(controller.components.first!.model.items[0].title, components.first!.model.items[0].title)
     XCTAssertEqual(controller.components.first!.model.items[0].subtitle, components.first!.model.items[0].subtitle)

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -6,17 +6,17 @@ class ControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
     let model = ComponentModel(title: "ComponentModel", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
 
-    XCTAssertEqual(controller.spot as? ListComponent, listSpot)
+    XCTAssertEqual(controller.component as? ListComponent, listComponent)
   }
 
   func testUpdateSpotAtIndex() {
     let model = ComponentModel(title: "ComponentModel", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
     let items = [Item(title: "item1")]
 
@@ -24,22 +24,22 @@ class ControllerTests: XCTestCase {
       spot.model.items = items
     }
 
-    XCTAssert(controller.spot!.model.items == items)
+    XCTAssert(controller.component!.model.items == items)
   }
 
   func testAppendItemInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
 
-    XCTAssertEqual(controller.spot!.model.items.count, 0)
+    XCTAssertEqual(controller.component!.model.items.count, 0)
 
     let item = Item(title: "title1", kind: "list")
     let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 1)
-      XCTAssert(controller.spot!.model.items.first! == item)
+      XCTAssertEqual(controller.component!.model.items.count, 1)
+      XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -48,17 +48,17 @@ class ControllerTests: XCTestCase {
 
   func testAppendOneMoreItemInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0, items: [Item(title: "title1")])
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
 
-    XCTAssertEqual(controller.spot!.model.items.count, 1)
+    XCTAssertEqual(controller.component!.model.items.count, 1)
 
     let item = Item(title: "title2", kind: "list")
     let expectation = self.expectation(description: "Test append item")
     controller.append(item, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 2)
-      XCTAssert(controller.spot!.model.items.last! == item)
+      XCTAssertEqual(controller.component!.model.items.count, 2)
+      XCTAssert(controller.component!.model.items.last! == item)
       expectation.fulfill()
     }
 
@@ -67,8 +67,8 @@ class ControllerTests: XCTestCase {
 
   func testAppendItemsInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
 
     let items = [
@@ -77,8 +77,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.model.items.count > 0)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssert(controller.component!.model.items.count > 0)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -87,8 +87,8 @@ class ControllerTests: XCTestCase {
 
   func testPrependItemsInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
     controller.preloadView()
 
     let items = [
@@ -97,8 +97,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 2)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssertEqual(controller.component!.model.items.count, 2)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -111,8 +111,8 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
       ]
     )
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
@@ -122,11 +122,11 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 4)
-      XCTAssertEqual(controller.spot!.model.items[0].title, "title3")
-      XCTAssertEqual(controller.spot!.model.items[1].title, "title4")
-      XCTAssertEqual(controller.spot!.model.items[2].title, "title1")
-      XCTAssertEqual(controller.spot!.model.items[3].title, "title2")
+      XCTAssertEqual(controller.component!.model.items.count, 4)
+      XCTAssertEqual(controller.component!.model.items[0].title, "title3")
+      XCTAssertEqual(controller.component!.model.items[1].title, "title4")
+      XCTAssertEqual(controller.component!.model.items[2].title, "title1")
+      XCTAssertEqual(controller.component!.model.items[3].title, "title2")
       expectation.fulfill()
     }
 
@@ -139,24 +139,24 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.model.items.first
+    let firstItem = controller.component!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
-    let listSpot = (controller.spot as! ListComponent)
-    listSpot.delete(model.items.first!) {
-      let lastItem = controller.spot!.model.items.first
+    let listComponent = (controller.component as! ListComponent)
+    listComponent.delete(model.items.first!) {
+      let lastItem = controller.component!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.model.items.count, 1)
+      XCTAssertEqual(controller.component!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -168,7 +168,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
     ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
@@ -176,7 +176,7 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test delete items")
 
     controller.components[0].delete(items, withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.model.items.count, 0)
+      XCTAssertEqual(controller.component!.model.items.count, 0)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -190,17 +190,17 @@ class ControllerTests: XCTestCase {
       Item(title: "title4", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
     let expectation = self.expectation(description: "Test delete items")
 
     controller.components[0].delete(1, withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.model.items.count, 3)
-      XCTAssertEqual(controller.spot!.model.items[0].title, "title1")
-      XCTAssertEqual(controller.spot!.model.items[1].title, "title3")
-      XCTAssertEqual(controller.spot!.model.items[2].title, "title4")
+      XCTAssertEqual(controller.component!.model.items.count, 3)
+      XCTAssertEqual(controller.component!.model.items[0].title, "title1")
+      XCTAssertEqual(controller.component!.model.items[1].title, "title3")
+      XCTAssertEqual(controller.component!.model.items[2].title, "title4")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -214,16 +214,16 @@ class ControllerTests: XCTestCase {
       Item(title: "title4", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
     let expectation = self.expectation(description: "Test delete items")
 
     controller.components[0].delete([1, 2], withAnimation: .none) {
-      XCTAssertEqual(controller.spot!.model.items.count, 2)
-      XCTAssertEqual(controller.spot!.model.items[0].title, "title1")
-      XCTAssertEqual(controller.spot!.model.items[1].title, "title4")
+      XCTAssertEqual(controller.component!.model.items.count, 2)
+      XCTAssertEqual(controller.component!.model.items[0].title, "title1")
+      XCTAssertEqual(controller.component!.model.items[1].title, "title4")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -231,19 +231,19 @@ class ControllerTests: XCTestCase {
 
   func testAppendItemInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
-    XCTAssert(controller.spot!.model.items.count == 0)
+    XCTAssert(controller.component!.model.items.count == 0)
 
     let item = Item(title: "title1", kind: "grid")
     let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
-      XCTAssert(controller.spot!.model.items.count == 1)
-      XCTAssert(controller.spot!.model.items.first! == item)
+      XCTAssert(controller.component!.model.items.count == 1)
+      XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -252,8 +252,8 @@ class ControllerTests: XCTestCase {
 
   func testAppendItemsInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
@@ -263,8 +263,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test append items")
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.model.items.count > 0)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssert(controller.component!.model.items.count > 0)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -273,8 +273,8 @@ class ControllerTests: XCTestCase {
 
   func testPrependItemsInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
@@ -284,8 +284,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 2)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssertEqual(controller.component!.model.items.count, 2)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -298,24 +298,24 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "grid")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.model.items.first
+    let firstItem = controller.component!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
-    let listSpot = (controller.spot as! ListComponent)
-    listSpot.delete(model.items.first!) {
-      let lastItem = controller.spot!.model.items.first
+    let listComponent = (controller.component as! ListComponent)
+    listComponent.delete(model.items.first!) {
+      let lastItem = controller.component!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.model.items.count, 1)
+      XCTAssertEqual(controller.component!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -323,19 +323,19 @@ class ControllerTests: XCTestCase {
 
   func testAppendItemInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = GridComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = GridComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
-    XCTAssert(controller.spot!.model.items.count == 0)
+    XCTAssert(controller.component!.model.items.count == 0)
 
     let item = Item(title: "title1", kind: "carousel")
     let expectation = self.expectation(description: "Test append item")
 
     controller.append(item, spotIndex: 0) {
-      XCTAssert(controller.spot!.model.items.count == 1)
-      XCTAssert(controller.spot!.model.items.first! == item)
+      XCTAssert(controller.component!.model.items.count == 1)
+      XCTAssert(controller.component!.model.items.first! == item)
       expectation.fulfill()
     }
 
@@ -344,8 +344,8 @@ class ControllerTests: XCTestCase {
 
   func testAppendItemsInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = GridComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = GridComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
@@ -356,8 +356,8 @@ class ControllerTests: XCTestCase {
     let expectation = self.expectation(description: "Test append items")
 
     controller.append(items, spotIndex: 0) {
-      XCTAssert(controller.spot!.model.items.count > 0)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssert(controller.component!.model.items.count > 0)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -366,8 +366,8 @@ class ControllerTests: XCTestCase {
 
   func testPrependItemsInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
-    let listSpot = ListComponent(model: model)
-    let controller = Controller(spot: listSpot)
+    let listComponent = ListComponent(model: model)
+    let controller = Controller(component: listComponent)
 
     controller.preloadView()
 
@@ -377,8 +377,8 @@ class ControllerTests: XCTestCase {
     ]
     let expectation = self.expectation(description: "Test prepend items")
     controller.prepend(items, spotIndex: 0) {
-      XCTAssertEqual(controller.spot!.model.items.count, 2)
-      XCTAssert(controller.spot!.model.items == items)
+      XCTAssertEqual(controller.component!.model.items.count, 2)
+      XCTAssert(controller.component!.model.items == items)
       expectation.fulfill()
     }
 
@@ -391,24 +391,24 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "carousel")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(spot: initialListComponent)
+    let controller = Controller(component: initialListComponent)
 
     controller.preloadView()
 
-    let firstItem = controller.spot!.model.items.first
+    let firstItem = controller.component!.model.items.first
 
     XCTAssertEqual(firstItem?.title, "title1")
     XCTAssertEqual(firstItem?.index, 0)
 
     let expectation = self.expectation(description: "Test delete item")
-    let listSpot = (controller.spot as! ListComponent)
-    listSpot.delete(model.items.first!) {
-      let lastItem = controller.spot!.model.items.first
+    let listComponent = (controller.component as! ListComponent)
+    listComponent.delete(model.items.first!) {
+      let lastItem = controller.component!.model.items.first
 
       XCTAssertNotEqual(lastItem?.title, "title1")
       XCTAssertEqual(lastItem?.index, 0)
       XCTAssertEqual(lastItem?.title, "title2")
-      XCTAssertEqual(controller.spot!.model.items.count, 1)
+      XCTAssertEqual(controller.component!.model.items.count, 1)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -430,19 +430,19 @@ class ControllerTests: XCTestCase {
   }
 
   func testFindAndFilterSpotWithClosure() {
-    let listSpot = ListComponent(model: ComponentModel(title: "ListComponent", span: 1.0))
-    let listSpot2 = ListComponent(model: ComponentModel(title: "ListComponent2", span: 1.0))
-    let gridSpot = GridComponent(model: ComponentModel(title: "GridComponent", span: 1.0, items: [Item(title: "Item")]))
-    let controller = Controller(components: [listSpot, listSpot2, gridSpot])
+    let listComponent = ListComponent(model: ComponentModel(title: "ListComponent", span: 1.0))
+    let listComponent2 = ListComponent(model: ComponentModel(title: "ListComponent2", span: 1.0))
+    let gridComponent = GridComponent(model: ComponentModel(title: "GridComponent", span: 1.0, items: [Item(title: "Item")]))
+    let controller = Controller(components: [listComponent, listComponent2, gridComponent])
 
-    XCTAssertNotNil(controller.resolve(spot: { $1.model.title == "ListComponent" }))
-    XCTAssertNotNil(controller.resolve(spot: { $1.model.title == "GridComponent" }))
-    XCTAssertNotNil(controller.resolve(spot: { $1 is Listable }))
-    XCTAssertNotNil(controller.resolve(spot: { $1 is Gridable }))
-    XCTAssertNotNil(controller.resolve(spot: { $1.items.filter { $0.title == "Item" }.first != nil }))
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 0 })?.model.title, "ListComponent")
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 1 })?.model.title, "ListComponent2")
-    XCTAssertEqual(controller.resolve(spot: { $0.0 == 2 })?.model.title, "GridComponent")
+    XCTAssertNotNil(controller.resolve(component: { $1.model.title == "ListComponent" }))
+    XCTAssertNotNil(controller.resolve(component: { $1.model.title == "GridComponent" }))
+    XCTAssertNotNil(controller.resolve(component: { $1 is Listable }))
+    XCTAssertNotNil(controller.resolve(component: { $1 is Gridable }))
+    XCTAssertNotNil(controller.resolve(component: { $1.items.filter { $0.title == "Item" }.first != nil }))
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 0 })?.model.title, "ListComponent")
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 1 })?.model.title, "ListComponent2")
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 2 })?.model.title, "GridComponent")
 
     XCTAssert(controller.filter(components: { $0 is Listable }).count == 2)
   }
@@ -450,7 +450,7 @@ class ControllerTests: XCTestCase {
   func testJSONInitialiser() {
     let component = ListComponent(model: ComponentModel(span: 1.0))
     component.items = [Item(title: "First item")]
-    let sourceController = Controller(spot: component)
+    let sourceController = Controller(component: component)
     let jsonController = Controller([
       "components": [
         ["kind": "list",
@@ -462,7 +462,7 @@ class ControllerTests: XCTestCase {
       ]
       ])
 
-    XCTAssert(sourceController.spot!.model == jsonController.spot!.model)
+    XCTAssert(sourceController.component!.model == jsonController.component!.model)
   }
 
   func testJSONReload() {
@@ -477,9 +477,9 @@ class ControllerTests: XCTestCase {
     ]
     let jsonController = Controller(initialJSON)
 
-    XCTAssert(jsonController.spot!.model.kind == "list")
-    XCTAssert(jsonController.spot!.model.items.count == 1)
-    XCTAssert(jsonController.spot!.model.items.first?.title == "First list item")
+    XCTAssert(jsonController.component!.model.kind == "list")
+    XCTAssert(jsonController.component!.model.items.count == 1)
+    XCTAssert(jsonController.component!.model.items.first?.title == "First list item")
 
     let updateJSON = [
       "components": [
@@ -494,9 +494,9 @@ class ControllerTests: XCTestCase {
 
     let expectation = self.expectation(description: "Reload with JSON")
     jsonController.reload(updateJSON) {
-      XCTAssert(jsonController.spot!.model.kind == "grid")
-      XCTAssert(jsonController.spot!.model.items.count == 2)
-      XCTAssert(jsonController.spot!.model.items.first?.title == "First grid item")
+      XCTAssert(jsonController.component!.model.kind == "grid")
+      XCTAssert(jsonController.component!.model.items.count == 2)
+      XCTAssert(jsonController.component!.model.items.first?.title == "First grid item")
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -703,7 +703,7 @@ class ControllerTests: XCTestCase {
 
     /// Reset layout margins for tvOS
     #if os(tvOS)
-      controller.spot(at: 0, ofType: ListComponent.self)?.tableView.layoutMargins = UIEdgeInsets.zero
+      controller.component(at: 0, ofType: ListComponent.self)?.tableView.layoutMargins = UIEdgeInsets.zero
     #endif
 
     #if !os(OSX)

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -39,7 +39,7 @@ class CoreComponentTests: XCTestCase {
 
     measure {
       for _ in 0..<5 {
-        controller.append(items, spotIndex: 0, withAnimation: .automatic, completion: nil)
+        controller.append(items, componentIndex: 0, withAnimation: .automatic, completion: nil)
         controller.components.forEach { $0.view.layoutSubviews() }
       }
     }

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -5,8 +5,8 @@ import XCTest
 class CoreComponentTests: XCTestCase {
 
   func testAppendingMultipleItemsToComponent() {
-    let listSpot = ListComponent(model: ComponentModel(title: "ComponentModel", span: 1.0))
-    listSpot.setup(CGSize(width: 100, height: 100))
+    let listComponent = ListComponent(model: ComponentModel(title: "ComponentModel", span: 1.0))
+    listComponent.setup(CGSize(width: 100, height: 100))
     var items: [Item] = []
 
     for i in 0..<10 {
@@ -15,14 +15,14 @@ class CoreComponentTests: XCTestCase {
 
     measure {
       for _ in 0..<5 {
-        listSpot.append(items)
-        listSpot.view.layoutSubviews()
+        listComponent.append(items)
+        listComponent.view.layoutSubviews()
       }
     }
 
     let expectation = self.expectation(description: "Wait until done")
     Dispatch.after(seconds: 1.0) {
-      XCTAssertEqual(listSpot.items.count, 500)
+      XCTAssertEqual(listComponent.items.count, 500)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -29,7 +29,7 @@ class StateCacheTests: XCTestCase {
     controller.components = [ListComponent(model: ComponentModel(span: 1.0))]
 
     let expectation = self.expectation(description: "Append item to CoreComponent object")
-    controller.append(Item(title: "foo"), spotIndex: 0, withAnimation: .automatic) {
+    controller.append(Item(title: "foo"), componentIndex: 0, withAnimation: .automatic) {
       self.controller.cache()
       /// Check that the cache was saved to disk
       XCTAssertEqual(self.controller.stateCache!.load().count, 1)

--- a/SpotsTests/iOS/TestCarouselComposite.swift
+++ b/SpotsTests/iOS/TestCarouselComposite.swift
@@ -7,14 +7,14 @@ class CarouselCompositeTests: XCTestCase {
   func testCarouselComposite() {
     let view = CarouselComposite()
     var item = Item()
-    let gridSpot = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [gridSpot])
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
@@ -27,7 +27,7 @@ class CarouselCompositeTests: XCTestCase {
     view.configure(&item, compositeComponents: nil)
     XCTAssertTrue(view.contentView.subviews.count == 0)
 
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
     XCTAssertTrue(view.contentView.subviews.count == 2)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
     XCTAssertTrue(view.contentView.subviews[1] is UITableView)

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -9,7 +9,7 @@ class CarouselComponentTests: XCTestCase {
 
   override func setUp() {
     component = CarouselComponent(model: ComponentModel(span: 1.0))
-    cachedSpot = CarouselComponent(cacheKey: "cached-carousel-spot")
+    cachedSpot = CarouselComponent(cacheKey: "cached-carousel-component")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }
@@ -128,7 +128,7 @@ class CarouselComponentTests: XCTestCase {
     let component = CarouselComponent(model: model)
     component.setup(CGSize(width: 100, height: 100))
 
-    // Test that spot height is equal to first item in the list
+    // Test that component height is equal to first item in the list
     XCTAssertEqual(component.items.count, 3)
     XCTAssertEqual(component.items[0].title, "foo")
     XCTAssertEqual(component.items[1].title, "bar")
@@ -176,7 +176,7 @@ class CarouselComponentTests: XCTestCase {
 
     let width = component.view.bounds.width / 4
 
-    // Test that spot height is equal to first item in the list
+    // Test that component height is equal to first item in the list
     XCTAssertEqual(component.items.count, 4)
     XCTAssertEqual(component.items[0].title, "foo")
     XCTAssertEqual(component.items[1].title, "bar")

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -11,8 +11,8 @@ class DataSourceTests: XCTestCase {
       Item(title: "title 2")
       ]))
 
-    var itemCell1 = component.spotDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
-    let itemCell2 = component.spotDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 1, section: 0))
+    var itemCell1 = component.componentDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    let itemCell2 = component.componentDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 1, section: 0))
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
@@ -20,13 +20,13 @@ class DataSourceTests: XCTestCase {
     XCTAssertEqual(itemCell2.textLabel?.text, component.model.items[1].title)
 
     /// Check that data source always returns a cell
-    let itemCell3 = component.spotDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
+    let itemCell3 = component.componentDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 2, section: 0))
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
     component.model.items[0].kind = "custom"
     component.model.items[0].size.height = 0.0
-    itemCell1 = component.spotDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+    itemCell1 = component.componentDataSource!.tableView(component.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
     let itemConfigurable = itemCell1 as! CustomListCell
     XCTAssertEqual(component.model.items[0].size.height, itemConfigurable.preferredViewSize.height)
   }
@@ -38,20 +38,20 @@ class DataSourceTests: XCTestCase {
       Item(title: "title 2")
       ]))
 
-    var itemCell1 = component.spotDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
-    let itemCell2 = component.spotDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
+    var itemCell1 = component.componentDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    let itemCell2 = component.componentDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 1, section: 0))
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
 
     /// Check that data source always returns a cell
-    let itemCell3 = component.spotDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 2, section: 0))
+    let itemCell3 = component.componentDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 2, section: 0))
     XCTAssertNotNil(itemCell3)
 
     /// Check that preferred view size is applied if height is 0.0
     component.model.items[0].kind = "custom"
     component.model.items[0].size.height = 0.0
-    itemCell1 = component.spotDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
+    itemCell1 = component.componentDataSource!.collectionView(component.collectionView, cellForItemAt: IndexPath(item: 0, section: 0))
     let itemConfigurable = itemCell1 as! CustomGridCell
     XCTAssertEqual(component.model.items[0].size.height, itemConfigurable.preferredViewSize.height)
   }
@@ -69,7 +69,7 @@ class DataSourceTests: XCTestCase {
     component.layout.headerReferenceSize = CGSize(width: 100, height: 48)
     component.view.layoutSubviews()
 
-    let header = component.spotDataSource!.collectionView(component.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    let header = component.componentDataSource!.collectionView(component.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)
     XCTAssert(header is CustomGridHeaderView)
   }
@@ -87,7 +87,7 @@ class DataSourceTests: XCTestCase {
     component.layout.headerReferenceSize = CGSize(width: 100, height: 48)
     component.view.layoutSubviews()
 
-    let header = component.spotDataSource!.collectionView(component.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
+    let header = component.componentDataSource!.collectionView(component.collectionView, viewForSupplementaryElementOfKind: UICollectionElementKindSectionHeader, at: IndexPath(item: 0, section: 0))
     XCTAssertNotNil(header)
   }
 }

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -21,19 +21,19 @@ class DelegateTests: XCTestCase {
       Item(title: "title 1")
       ]))
     component.delegate = delegate
-    component.spotDelegate?.collectionView(component.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+    component.componentDelegate?.collectionView(component.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
 
     XCTAssertEqual(component.model.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
-    component.spotDelegate?.collectionView(component.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
+    component.componentDelegate?.collectionView(component.collectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
   func testCollectionViewCanFocus() {
     let component = GridComponent(model: ComponentModel(span: 1, items: [Item(title: "title 1")]))
-    XCTAssertEqual(component.spotDelegate?.collectionView(component.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
-    XCTAssertEqual(component.spotDelegate?.collectionView(component.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
+    XCTAssertEqual(component.componentDelegate?.collectionView(component.collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
+    XCTAssertEqual(component.componentDelegate?.collectionView(component.collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
   }
 
   // MARK: - UITableView
@@ -44,20 +44,20 @@ class DelegateTests: XCTestCase {
       Item(title: "title 1")
       ]))
     component.delegate = delegate
-    component.spotDelegate?.tableView(component.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
+    component.componentDelegate?.tableView(component.tableView, didSelectRowAt: IndexPath(item: 0, section: 0))
 
     XCTAssertEqual(component.model.items[0].meta["selected"] as? Bool, true)
     XCTAssertEqual(delegate.countsInvoked, 1)
 
-    component.spotDelegate?.tableView(component.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
+    component.componentDelegate?.tableView(component.tableView, didSelectRowAt: IndexPath(item: 1, section: 0))
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
   func testTableViewHeightForRowOnListable() {
     let component = ListComponent(model: ComponentModel(span: 1, items: [Item(title: "title 1")]))
     component.setup(CGSize(width: 100, height: 100))
-    XCTAssertEqual(component.spotDelegate?.tableView(component.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
-    XCTAssertEqual(component.spotDelegate?.tableView(component.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
+    XCTAssertEqual(component.componentDelegate?.tableView(component.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+    XCTAssertEqual(component.componentDelegate?.tableView(component.tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
   }
 
   func testDelegateTitleForHeader() {
@@ -73,24 +73,24 @@ class DelegateTests: XCTestCase {
     component.view.frame.size = CGSize(width: 100, height: 100)
     component.view.layoutSubviews()
 
-    var view = component.spotDelegate?.tableView(component.tableView, viewForHeaderInSection: 0)
+    var view = component.componentDelegate?.tableView(component.tableView, viewForHeaderInSection: 0)
     XCTAssert(view is CustomListHeaderView)
 
     /// Expect to return nil if header is in use.
-    var title = component.spotDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
+    var title = component.componentDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, nil)
 
     /// Expect to return title if header is empty.
     component.model.header = ""
-    title = component.spotDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
+    title = component.componentDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, component.model.title)
 
     /// Expect to return nil if title and header is empty.
     component.model.title = ""
-    title = component.spotDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
+    title = component.componentDelegate?.tableView(component.tableView, titleForHeaderInSection: 0)
     XCTAssertEqual(title, nil)
 
-    view = component.spotDelegate?.tableView(component.tableView, viewForHeaderInSection: 0)
+    view = component.componentDelegate?.tableView(component.tableView, viewForHeaderInSection: 0)
     XCTAssertEqual(view, nil)
 
   }

--- a/SpotsTests/iOS/TestFactory.swift
+++ b/SpotsTests/iOS/TestFactory.swift
@@ -13,7 +13,7 @@ class FactoryTests: XCTestCase {
   ]
 
   func testRegisterAndResolve() {
-    Factory.register(kind: "merry-go-round", spot: CarouselComponent.self)
+    Factory.register(kind: "merry-go-round", component: CarouselComponent.self)
 
     let model = ComponentModel(json)
     var component = Factory.resolve(model: model)
@@ -21,7 +21,7 @@ class FactoryTests: XCTestCase {
     XCTAssertTrue(component.model == model)
     XCTAssertTrue(component is CarouselComponent)
 
-    Factory.register(kind: "merry-go-round", spot: GridComponent.self)
+    Factory.register(kind: "merry-go-round", component: GridComponent.self)
     component = Factory.resolve(model: model)
 
     XCTAssertTrue(component.model == model)
@@ -65,7 +65,7 @@ class FactoryTests: XCTestCase {
     XCTAssertEqual(components.count, 1)
     XCTAssert(components.first is ListComponent)
 
-    /// Test first item in the first component of the first spot
+    /// Test first item in the first component of the first component
     XCTAssertEqual(components.first!.model.kind, "list")
     XCTAssertEqual(components.first!.model.items[0].title, "Fullname")
     XCTAssertEqual(components.first!.model.items[0].subtitle, "Job title")

--- a/SpotsTests/iOS/TestGridComposite.swift
+++ b/SpotsTests/iOS/TestGridComposite.swift
@@ -7,14 +7,14 @@ class GridCompositeTests: XCTestCase {
   func testGridComposite() {
     let view = GridComposite()
     var item = Item()
-    let gridSpot = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [gridSpot])
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
@@ -27,7 +27,7 @@ class GridCompositeTests: XCTestCase {
     view.configure(&item, compositeComponents: nil)
     XCTAssertTrue(view.contentView.subviews.count == 0)
 
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
     XCTAssertTrue(view.contentView.subviews.count == 2)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
     XCTAssertTrue(view.contentView.subviews[1] is UITableView)

--- a/SpotsTests/iOS/TestGridSpot.swift
+++ b/SpotsTests/iOS/TestGridSpot.swift
@@ -9,7 +9,7 @@ class GridComponentTests: XCTestCase {
 
   override func setUp() {
     component = GridComponent(model: ComponentModel(span: 1.0))
-    cachedComponent = GridComponent(cacheKey: "cached-grid-spot")
+    cachedComponent = GridComponent(cacheKey: "cached-grid-component")
     XCTAssertNotNil(cachedComponent.stateCache)
     cachedComponent.stateCache?.clear()
   }

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -13,13 +13,13 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: CGSize(width: 50, height: 50))
       ]
     )
-    let carouselSpot = CarouselComponent(model: model)
-    carouselSpot.setup(parentSize)
-    carouselSpot.layout(parentSize)
-    carouselSpot.view.layoutSubviews()
+    let carouselComponent = CarouselComponent(model: model)
+    carouselComponent.setup(parentSize)
+    carouselComponent.layout(parentSize)
+    carouselComponent.view.layoutSubviews()
 
-    XCTAssertEqual(carouselSpot.layout.contentSize, CGSize(width: 100, height: 50))
-    XCTAssertEqual(carouselSpot.view.frame.size, CGSize(width: 100, height: 50))
+    XCTAssertEqual(carouselComponent.layout.contentSize, CGSize(width: 100, height: 50))
+    XCTAssertEqual(carouselComponent.view.frame.size, CGSize(width: 100, height: 50))
   }
 
   func testContentSizeForHorizontalLayoutsWithInsets() {
@@ -32,13 +32,13 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: CGSize(width: 50, height: 100))
       ]
     )
-    let carouselSpot = CarouselComponent(model: model)
-    carouselSpot.setup(parentSize)
-    carouselSpot.layout(parentSize)
-    carouselSpot.view.layoutSubviews()
+    let carouselComponent = CarouselComponent(model: model)
+    carouselComponent.setup(parentSize)
+    carouselComponent.layout(parentSize)
+    carouselComponent.view.layoutSubviews()
 
-    XCTAssertEqual(carouselSpot.layout.contentSize, CGSize(width: 100, height: 150))
-    XCTAssertEqual(carouselSpot.view.frame.size, CGSize(width: 100, height: 150))
+    XCTAssertEqual(carouselComponent.layout.contentSize, CGSize(width: 100, height: 150))
+    XCTAssertEqual(carouselComponent.view.frame.size, CGSize(width: 100, height: 150))
   }
 
   func testLayoutAttributesForElementInHorizontalLayoutWithInsets() {
@@ -52,12 +52,12 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: itemSize)
       ]
     )
-    let carouselSpot = CarouselComponent(model: model)
-    carouselSpot.setup(parentSize)
-    carouselSpot.layout(parentSize)
-    carouselSpot.view.layoutSubviews()
+    let carouselComponent = CarouselComponent(model: model)
+    carouselComponent.setup(parentSize)
+    carouselComponent.layout(parentSize)
+    carouselComponent.view.layoutSubviews()
 
-    let layoutAttributes = carouselSpot.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
+    let layoutAttributes = carouselComponent.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
 
     let expectedFrameA = CGRect(
       origin: CGPoint(
@@ -91,12 +91,12 @@ class TestGridableLayout: XCTestCase {
         Item(title: "bar", size: itemSize)
       ]
     )
-    let carouselSpot = CarouselComponent(model: model)
-    carouselSpot.setup(parentSize)
-    carouselSpot.layout(parentSize)
-    carouselSpot.view.layoutSubviews()
+    let carouselComponent = CarouselComponent(model: model)
+    carouselComponent.setup(parentSize)
+    carouselComponent.layout(parentSize)
+    carouselComponent.view.layoutSubviews()
 
-    let layoutAttributes = carouselSpot.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
+    let layoutAttributes = carouselComponent.layout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
 
     XCTAssertEqual(layoutAttributes?.count, 2)
     XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: model.layout!.inset.top), size: itemSize))

--- a/SpotsTests/iOS/TestLayoutExtensions.swift
+++ b/SpotsTests/iOS/TestLayoutExtensions.swift
@@ -21,29 +21,29 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableComponent() {
-    let gridSpot = GridComponent(model: ComponentModel(span: 1))
+    let gridComponent = GridComponent(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
-    layout.configure(spot: gridSpot)
+    layout.configure(component: gridComponent)
 
-    XCTAssertEqual(gridSpot.layout.minimumInteritemSpacing, CGFloat(layout.itemSpacing))
-    XCTAssertEqual(gridSpot.layout.minimumLineSpacing, CGFloat(layout.lineSpacing))
+    XCTAssertEqual(gridComponent.layout.minimumInteritemSpacing, CGFloat(layout.itemSpacing))
+    XCTAssertEqual(gridComponent.layout.minimumLineSpacing, CGFloat(layout.lineSpacing))
 
-    XCTAssertEqual(gridSpot.view.contentInset.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(gridSpot.view.contentInset.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(gridSpot.view.contentInset.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(gridSpot.view.contentInset.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(gridComponent.view.contentInset.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(gridComponent.view.contentInset.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(gridComponent.view.contentInset.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(gridComponent.view.contentInset.right, CGFloat(layout.inset.right))
   }
 
   func testConfigureListableComponent() {
-    let listSpot = ListComponent(model: ComponentModel(span: 1))
+    let listComponent = ListComponent(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
-    layout.configure(spot: listSpot)
+    layout.configure(component: listComponent)
 
-    XCTAssertEqual(listSpot.view.contentInset.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(listSpot.view.contentInset.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(listSpot.view.contentInset.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(listSpot.view.contentInset.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(listComponent.view.contentInset.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(listComponent.view.contentInset.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(listComponent.view.contentInset.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(listComponent.view.contentInset.right, CGFloat(layout.inset.right))
   }
 }

--- a/SpotsTests/iOS/TestListComposite.swift
+++ b/SpotsTests/iOS/TestListComposite.swift
@@ -7,14 +7,14 @@ class ListCompositeTests: XCTestCase {
   func testListComposite() {
     let view = ListComposite()
     var item = Item()
-    let gridSpot = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [gridSpot])
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselSpot = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    let listSpot = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(span: 1)), itemIndex: 0)
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
@@ -27,7 +27,7 @@ class ListCompositeTests: XCTestCase {
     view.configure(&item, compositeComponents: nil)
     XCTAssertTrue(view.contentView.subviews.count == 0)
 
-    view.configure(&item, compositeComponents: [carouselSpot, listSpot])
+    view.configure(&item, compositeComponents: [carouselComponent, listComponent])
     XCTAssertTrue(view.contentView.subviews.count == 2)
     XCTAssertTrue(view.contentView.subviews[0] is UICollectionView)
     XCTAssertTrue(view.contentView.subviews[1] is UITableView)

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -7,7 +7,7 @@ class ListComponentTests: XCTestCase {
   var cachedSpot: ListComponent!
 
   override func setUp() {
-    cachedSpot = ListComponent(cacheKey: "cached-list-spot")
+    cachedSpot = ListComponent(cacheKey: "cached-list-component")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }

--- a/SpotsTests/iOS/TestListSpot.swift
+++ b/SpotsTests/iOS/TestListSpot.swift
@@ -31,19 +31,19 @@ class ListComponentTests: XCTestCase {
 
   func testSafelyResolveKind() {
     let model = ComponentModel(title: "ListComponent", kind: "custom-list", span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let listSpot = ListComponent(model: model)
+    let listComponent = ListComponent(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
-    XCTAssertEqual(listSpot.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
+    XCTAssertEqual(listComponent.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
 
     ListComponent.views.defaultItem = Registry.Item.classType(ListComponentCell.self)
-    XCTAssertEqual(listSpot.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
+    XCTAssertEqual(listComponent.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
 
     ListComponent.views.defaultItem = Registry.Item.classType(ListComponentCell.self)
-    XCTAssertEqual(listSpot.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
+    XCTAssertEqual(listComponent.identifier(at: indexPath), ListComponent.views.defaultIdentifier)
 
     ListComponent.views["custom-item-kind"] = Registry.Item.classType(ListComponentCell.self)
-    XCTAssertEqual(listSpot.identifier(at: indexPath), "custom-item-kind")
+    XCTAssertEqual(listComponent.identifier(at: indexPath), "custom-item-kind")
 
     ListComponent.views.storage.removeAll()
   }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -9,7 +9,7 @@ class RowSpotTests: XCTestCase {
 
   override func setUp() {
     component = RowComponent(model: ComponentModel(span: 1))
-    cachedSpot = RowComponent(cacheKey: "cached-row-spot")
+    cachedSpot = RowComponent(cacheKey: "cached-row-component")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
   }

--- a/SpotsTests/iOS/TestRowSpot.swift
+++ b/SpotsTests/iOS/TestRowSpot.swift
@@ -43,19 +43,19 @@ class RowSpotTests: XCTestCase {
 
   func testSafelyResolveKind() {
     let model = ComponentModel(title: "RowComponent", kind: "custom-grid", span: 1, items: [Item(title: "foo", kind: "custom-item-kind")])
-    let rowSpot = RowComponent(model: model)
+    let rowComponent = RowComponent(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
-    XCTAssertEqual(rowSpot.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
+    XCTAssertEqual(rowComponent.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
 
     RowComponent.views.defaultItem = Registry.Item.classType(GridComponentCell.self)
-    XCTAssertEqual(rowSpot.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
+    XCTAssertEqual(rowComponent.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
 
     RowComponent.views.defaultItem = Registry.Item.classType(GridComponentCell.self)
-    XCTAssertEqual(rowSpot.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
+    XCTAssertEqual(rowComponent.identifier(at: indexPath), RowComponent.views.defaultIdentifier)
 
     RowComponent.views["custom-item-kind"] = Registry.Item.classType(GridComponentCell.self)
-    XCTAssertEqual(rowSpot.identifier(at: indexPath), "custom-item-kind")
+    XCTAssertEqual(rowComponent.identifier(at: indexPath), "custom-item-kind")
 
     RowComponent.views.storage.removeAll()
   }

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -37,7 +37,7 @@ class TestSpot: XCTestCase {
 
   func testSpotCache() {
     let item = Item(title: "test")
-    let component = Component(cacheKey: "test-spot-cache")
+    let component = Component(cacheKey: "test-component-cache")
 
     XCTAssertEqual(component.model.items.count, 0)
     component.append(item) {

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -15,30 +15,30 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableComponent() {
-    let gridSpot = GridComponent(model: ComponentModel(span: 1))
-    let gridableLayout = gridSpot.layout as? FlowLayout
+    let gridComponent = GridComponent(model: ComponentModel(span: 1))
+    let gridableLayout = gridComponent.layout as? FlowLayout
     let layout = Layout(json)
 
-    layout.configure(spot: gridSpot)
+    layout.configure(component: gridComponent)
 
     XCTAssertEqual(gridableLayout?.minimumInteritemSpacing, CGFloat(layout.itemSpacing))
     XCTAssertEqual(gridableLayout?.minimumLineSpacing, CGFloat(layout.lineSpacing))
 
-    XCTAssertEqual(gridSpot.view.contentInsets.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(gridSpot.view.contentInsets.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(gridSpot.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(gridSpot.view.contentInsets.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(gridComponent.view.contentInsets.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(gridComponent.view.contentInsets.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(gridComponent.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(gridComponent.view.contentInsets.right, CGFloat(layout.inset.right))
   }
 
   func testConfigureListableComponent() {
-    let listSpot = ListComponent(model: ComponentModel(span: 1))
+    let listComponent = ListComponent(model: ComponentModel(span: 1))
     let layout = Layout(json)
 
-    layout.configure(spot: listSpot)
+    layout.configure(component: listComponent)
 
-    XCTAssertEqual(listSpot.view.contentInsets.top, CGFloat(layout.inset.top))
-    XCTAssertEqual(listSpot.view.contentInsets.left, CGFloat(layout.inset.left))
-    XCTAssertEqual(listSpot.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
-    XCTAssertEqual(listSpot.view.contentInsets.right, CGFloat(layout.inset.right))
+    XCTAssertEqual(listComponent.view.contentInsets.top, CGFloat(layout.inset.top))
+    XCTAssertEqual(listComponent.view.contentInsets.left, CGFloat(layout.inset.left))
+    XCTAssertEqual(listComponent.view.contentInsets.bottom, CGFloat(layout.inset.bottom))
+    XCTAssertEqual(listComponent.view.contentInsets.right, CGFloat(layout.inset.right))
   }
 }

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -29,7 +29,7 @@ class TestSpot: XCTestCase {
 
   func testSpotCache() {
     let item = Item(title: "test")
-    let component = Component(cacheKey: "test-spot-cache")
+    let component = Component(cacheKey: "test-component-cache")
 
     XCTAssertEqual(component.model.items.count, 0)
     component.append(item) {


### PR DESCRIPTION
I thought I was done yesterday but it seems like we had `spot` references literarily everywhere. So this is yet another search and replace operation to replace `spot` with `component`.

When this change is done, I think we will end up having a much more related naming across the entire project. I like that we are doing it but these PR's are a bit of a pain.