### PR TITLE
Fix faulty method implementation

### DIFF
--- a/Sources/Shared/Extensions/CarouselScrollDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/CarouselScrollDelegate+Extensions.swift
@@ -8,5 +8,5 @@ public extension CarouselScrollDelegate {
   /// - parameter component: Object that comforms to the CoreComponent protocol
   /// - parameter item: The last view model in the component
   /// - parameter animated: Indicates if the scrolling animated or not.
-  func component(_ component: CoreComponent, item: Item, animated: Bool) {}
+  func componentCarouselDidEndScrolling(_ component: CoreComponent, item: Item, animated: Bool) {}
 }


### PR DESCRIPTION
Seems like I made a small error when making one of the methods optional. This PR fixes that issue and is a trivial fix.

What happened is that I was missing parts of the function declaration which made the delegate method non-optional.