### PR TITLE
Fix compiler errors with optional assignments.

### DIFF
--- a/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Gridable+macOS+Extensions.swift
@@ -20,7 +20,7 @@ extension Gridable {
   public func refreshHeight(_ completion: (() -> Void)? = nil) {
     Dispatch.after(seconds: 0.2) { [weak self] in
       guard let strongSelf = self,
-        let collectionView = weakSelf.collectionView else {
+        let collectionView = self?.collectionView else {
           completion?()
           return
       }

--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,8 @@ test:
   override:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test | xcpretty
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build | xcpretty
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
   post:


### PR DESCRIPTION
This PR fixes a compiler error that `collectionView` is not optional for `Gridable` objects on `macOS`.