### PR TITLE
Improve Component layout on macOS

### DIFF
--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -48,8 +48,10 @@ extension Component {
     tableView.frame.size.width = size.width
 
     if let layout = model.layout {
+      tableView.frame.origin.y += CGFloat(layout.inset.bottom)
       tableView.frame.origin.x = CGFloat(layout.inset.left)
       tableView.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
+      tableView.frame.size.height += CGFloat(layout.inset.bottom)
     }
 
     scrollView.frame.size.height = tableView.frame.height + headerHeight + footerHeight

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -43,6 +43,7 @@ extension Component {
   }
 
   func layoutTableView(_ tableView: TableView, with size: CGSize) {
+    scrollView.frame.size.width = size.width
     tableView.frame.origin.y = headerView?.frame.size.height ?? 0.0
     tableView.sizeToFit()
     tableView.frame.size.width = size.width


### PR DESCRIPTION
This PR improves the layout operations for `Component` on macOS.
You can now insets with `Component`'s using `tableView` as user interface.
The main changes are applied on `Controller` when the windows are resized.