### PR TITLE
Improve Component layout on macOS

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -192,6 +192,8 @@ import Tailor
     setupHeader(kind: model.header)
     setupFooter(kind: model.footer)
 
+    configureDataSourceAndDelegate()
+
     if let tableView = self.tableView {
       documentView.addSubview(tableView)
       setupTableView(tableView, with: size)
@@ -231,8 +233,6 @@ import Tailor
     collectionView.allowsEmptySelection = true
     collectionView.layer = CALayer()
     collectionView.wantsLayer = true
-    collectionView.dataSource = componentDataSource
-    collectionView.delegate = componentDelegate
 
     let backgroundView = NSView()
     backgroundView.wantsLayer = true

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -49,8 +49,10 @@ extension Component {
     tableView.frame.size.width = size.width
 
     if let layout = model.layout {
+      tableView.frame.origin.y += CGFloat(layout.inset.bottom)
       tableView.frame.origin.x = CGFloat(layout.inset.left)
       tableView.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
+      tableView.frame.size.height += CGFloat(layout.inset.bottom)
     }
 
     scrollView.frame.size.height = tableView.frame.height + headerHeight + footerHeight

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -13,8 +13,6 @@ extension Component {
 
     prepareItems()
 
-    tableView.dataSource = componentDataSource
-    tableView.delegate = componentDelegate
     tableView.backgroundColor = NSColor.clear
     tableView.allowsColumnReordering = false
     tableView.allowsColumnResizing = false

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -43,6 +43,7 @@ extension Component {
   }
 
   func layoutTableView(_ tableView: TableView, with size: CGSize) {
+    scrollView.frame.size.width = size.width
     tableView.frame.origin.y = headerView?.frame.size.height ?? 0.0
     tableView.sizeToFit()
     tableView.frame.size.width = size.width


### PR DESCRIPTION
This PR improves the layout operations for `Component` on `macOS`.

- [x] `ListComponent` now supports `Inset`.
- [x] `Controller` now handles window resizing more accurately.
- [x] `Component` now uses `configureDataSourceAndDelegate` to reduce code duplication.