### PR TITLE
Improve header and footer height calculations in delegate

### DIFF
--- a/Sources/Shared/Extensions/CoreComponent+Extensions.swift
+++ b/Sources/Shared/Extensions/CoreComponent+Extensions.swift
@@ -490,7 +490,7 @@ public extension CoreComponent {
     self.views.defaultItem = Registry.Item.classType(view)
   }
 
-  public func heightForItem(_ item: inout Item, component: CoreComponent) -> CGFloat {
+  public func heightForItem(_ item: inout Item) -> CGFloat {
     guard let kind: String = item.kind, !kind.isEmpty else {
       return 0.0
     }

--- a/Sources/Shared/Extensions/CoreComponent+Extensions.swift
+++ b/Sources/Shared/Extensions/CoreComponent+Extensions.swift
@@ -490,29 +490,6 @@ public extension CoreComponent {
     self.views.defaultItem = Registry.Item.classType(view)
   }
 
-  public func heightForItem(_ item: inout Item) -> CGFloat {
-    guard let kind: String = item.kind, !kind.isEmpty else {
-      return 0.0
-    }
-
-    guard let resolvedView = Configuration.views.make(kind)?.view else {
-      return 0.0
-    }
-
-    guard let itemConfigurable = resolvedView as? ItemConfigurable else {
-      return resolvedView.frame.size.height
-    }
-
-    itemConfigurable.configure(&item)
-
-
-    guard resolvedView.frame.size.height != 0.0 else {
-      return itemConfigurable.preferredViewSize.height
-    }
-
-    return resolvedView.frame.size.height
-  }
-
   public func beforeUpdate() {}
   public func afterUpdate() {}
   func configure(with layout: Layout) {}

--- a/Sources/Shared/Extensions/CoreComponent+Extensions.swift
+++ b/Sources/Shared/Extensions/CoreComponent+Extensions.swift
@@ -490,6 +490,29 @@ public extension CoreComponent {
     self.views.defaultItem = Registry.Item.classType(view)
   }
 
+  public func heightForItem(_ item: inout Item, component: CoreComponent) -> CGFloat {
+    guard let kind: String = item.kind, !kind.isEmpty else {
+      return 0.0
+    }
+
+    guard let resolvedView = Configuration.views.make(kind)?.view else {
+      return 0.0
+    }
+
+    guard let itemConfigurable = resolvedView as? ItemConfigurable else {
+      return resolvedView.frame.size.height
+    }
+
+    itemConfigurable.configure(&item)
+
+
+    guard resolvedView.frame.size.height != 0.0 else {
+      return itemConfigurable.preferredViewSize.height
+    }
+
+    return resolvedView.frame.size.height
+  }
+
   public func beforeUpdate() {}
   public func afterUpdate() {}
   func configure(with layout: Layout) {}

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -161,7 +161,10 @@ extension Delegate: UITableViewDelegate {
       return view?.frame.size.height ?? 0.0
     }
 
-    return (header?.view as? ItemConfigurable)?.preferredViewSize.height ?? 0.0
+    let height = heightForItem(&item, component: component)
+    component.model.footer = item
+
+    return height
   }
 
   /// Asks the data source for the title of the header of the specified section of the table view.
@@ -335,6 +338,29 @@ extension Delegate: UITableViewDelegate {
       height: tableView.frame.size.height)
 
     return component.item(at: indexPath)?.size.height ?? 0
+  }
+
+  private func heightForItem(_ item: inout Item, component: CoreComponent) -> CGFloat {
+    guard let kind: String = item.kind, !kind.isEmpty else {
+      return 0.0
+    }
+
+    guard let resolvedView = Configuration.views.make(kind)?.view else {
+      return 0.0
+    }
+
+    guard let itemConfigurable = resolvedView as? ItemConfigurable else {
+      return resolvedView.frame.size.height
+    }
+
+    itemConfigurable.configure(&item)
+    
+
+    guard resolvedView.frame.size.height != 0.0 else {
+      return itemConfigurable.preferredViewSize.height
+    }
+
+    return resolvedView.frame.size.height
   }
 }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -298,29 +298,6 @@ extension Delegate: UITableViewDelegate {
 
     return component.item(at: indexPath)?.size.height ?? 0
   }
-
-  private func heightForItem(_ item: inout Item, component: CoreComponent) -> CGFloat {
-    guard let kind: String = item.kind, !kind.isEmpty else {
-      return 0.0
-    }
-
-    guard let resolvedView = Configuration.views.make(kind)?.view else {
-      return 0.0
-    }
-
-    guard let itemConfigurable = resolvedView as? ItemConfigurable else {
-      return resolvedView.frame.size.height
-    }
-
-    itemConfigurable.configure(&item)
-    
-
-    guard resolvedView.frame.size.height != 0.0 else {
-      return itemConfigurable.preferredViewSize.height
-    }
-
-    return resolvedView.frame.size.height
-  }
 }
 
 extension Delegate: UICollectionViewDelegateFlowLayout {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -105,7 +105,7 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let height = heightForItem(&item, component: component)
+    let height = component.heightForItem(&item)
     component.model.header = item
 
     return height
@@ -120,7 +120,7 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let height = heightForItem(&item, component: component)
+    let height = component.heightForItem(&item)
     component.model.footer = item
 
     return height

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -90,6 +90,29 @@ extension Delegate: UICollectionViewDelegate {
 
 extension Delegate: UITableViewDelegate {
 
+  fileprivate func heightForItem(_ item: inout Item) -> CGFloat {
+    guard let kind: String = item.kind, !kind.isEmpty else {
+      return 0.0
+    }
+
+    guard let resolvedView = Configuration.views.make(kind)?.view else {
+      return 0.0
+    }
+
+    guard let itemConfigurable = resolvedView as? ItemConfigurable else {
+      return resolvedView.frame.size.height
+    }
+
+    itemConfigurable.configure(&item)
+
+
+    guard resolvedView.frame.size.height != 0.0 else {
+      return itemConfigurable.preferredViewSize.height
+    }
+
+    return resolvedView.frame.size.height
+  }
+
   /// Asks the delegate for the height to use for the header of a particular section.
   ///
   /// - parameter tableView: The table-view object requesting this information.
@@ -105,7 +128,7 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let height = component.heightForItem(&item)
+    let height = heightForItem(&item)
     component.model.header = item
 
     return height
@@ -120,7 +143,7 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let height = component.heightForItem(&item)
+    let height = heightForItem(&item)
     component.model.footer = item
 
     return height

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -91,11 +91,11 @@ extension Delegate: UICollectionViewDelegate {
 extension Delegate: UITableViewDelegate {
 
   fileprivate func heightForItem(_ item: inout Item) -> CGFloat {
-    guard let kind: String = item.kind, !kind.isEmpty else {
+    guard !item.kind.isEmpty else {
       return 0.0
     }
 
-    guard let resolvedView = Configuration.views.make(kind)?.view else {
+    guard let resolvedView = Configuration.views.make(item.kind)?.view else {
       return 0.0
     }
 
@@ -104,7 +104,6 @@ extension Delegate: UITableViewDelegate {
     }
 
     itemConfigurable.configure(&item)
-
 
     guard resolvedView.frame.size.height != 0.0 else {
       return itemConfigurable.preferredViewSize.height

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -101,33 +101,14 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let kind: String = component.model.header?.kind ?? ""
-    let header = component.type.headers.make(kind)
-
-    if header == nil {
-      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: kind)
-      view?.frame.size.height = component.model.meta(ListComponent.Key.headerHeight, 0.0)
-      view?.frame.size.width = tableView.frame.size.width
-
-      switch view {
-      case let view as ListHeaderFooterWrapper:
-        if let (_, resolvedView) = Configuration.views.make(kind),
-          let componentView = resolvedView as? ItemConfigurable {
-          view.frame.size.height = componentView.preferredViewSize.height
-        }
-      case let view as ItemConfigurable:
-        if var item = component.model.header {
-          view.configure(&item)
-          component.model.header = item
-        }
-      default:
-        break
-      }
-
-      return view?.frame.size.height ?? 0.0
+    guard var item: Item = component.model.header else {
+      return 0.0
     }
 
-    return (header?.view as? ItemConfigurable)?.preferredViewSize.height ?? 0.0
+    let height = heightForItem(&item, component: component)
+    component.model.header = item
+
+    return height
   }
 
   public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -135,30 +116,8 @@ extension Delegate: UITableViewDelegate {
       return 0.0
     }
 
-    let kind: String = component.model.header?.kind ?? ""
-    let header = component.type.headers.make(kind)
-
-    if header == nil {
-      let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: kind)
-      view?.frame.size.height = component.model.meta(ListComponent.Key.headerHeight, 0.0)
-      view?.frame.size.width = tableView.frame.size.width
-
-      switch view {
-      case let view as ListHeaderFooterWrapper:
-        if let (_, resolvedView) = Configuration.views.make(kind),
-          let componentView = resolvedView as? ItemConfigurable {
-            view.frame.size.height = componentView.preferredViewSize.height
-        }
-      case let view as ItemConfigurable:
-        if var item = component.model.footer {
-          view.configure(&item)
-          component.model.footer = item
-        }
-      default:
-        break
-      }
-
-      return view?.frame.size.height ?? 0.0
+    guard var item: Item = component.model.footer else {
+      return 0.0
     }
 
     let height = heightForItem(&item, component: component)

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -52,6 +52,19 @@ extension Controller {
 }
 
 #if !os(OSX)
+
+  class RegularView: UIView {
+    override init(frame: CGRect) {
+      var frame = frame
+      frame.size.height = 44
+      super.init(frame: frame)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+  }
+
   class HeaderView: UIView, ItemConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 200, height: 50)

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -65,6 +65,23 @@ extension Controller {
     }
   }
 
+  class ItemConfigurableView: UIView, ItemConfigurable {
+
+    var preferredViewSize: CGSize = CGSize(width: 200, height: 50)
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(_ item: inout Item) {
+      frame.size.height = 75
+    }
+  }
+
   class HeaderView: UIView, ItemConfigurable {
 
     var preferredViewSize: CGSize = CGSize(width: 200, height: 50)

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -96,6 +96,7 @@ class DelegateTests: XCTestCase {
 
   func testTableViewHeaderHeight() {
     Configuration.register(view: RegularView.self, identifier: "regular-header")
+    Configuration.register(view: ItemConfigurableView.self, identifier: "item-configurable-header")
     Configuration.register(view: CustomListHeaderView.self, identifier: "custom-header")
 
     let component = Component(model: ComponentModel(header: Item(kind: "custom-header")))
@@ -129,6 +130,11 @@ class DelegateTests: XCTestCase {
 
     XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 0)
 
+    component.model.header = Item(kind: "item-configurable-header")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 75)
+
     delegate.component = nil
     tableView.reloadDataSource()
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
@@ -136,6 +142,7 @@ class DelegateTests: XCTestCase {
 
   func testTableViewFooterHeight() {
     Configuration.register(view: RegularView.self, identifier: "regular-footer")
+    Configuration.register(view: ItemConfigurableView.self, identifier: "item-configurable-footer")
     Configuration.register(view: CustomListHeaderView.self, identifier: "custom-footer")
 
     let component = Component(model: ComponentModel(footer: Item(kind: "custom-footer")))
@@ -168,6 +175,11 @@ class DelegateTests: XCTestCase {
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
+
+    component.model.header = Item(kind: "item-configurable-footer")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 75)
 
     delegate.component = nil
     tableView.reloadDataSource()

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -92,6 +92,85 @@ class DelegateTests: XCTestCase {
 
     view = component.componentDelegate?.tableView(component.tableView, viewForHeaderInSection: 0)
     XCTAssertEqual(view, nil)
+  }
 
+  func testTableViewHeaderHeight() {
+    Configuration.register(view: RegularView.self, identifier: "regular-header")
+    Configuration.register(view: CustomListHeaderView.self, identifier: "custom-header")
+
+    let component = Component(model: ComponentModel(header: Item(kind: "custom-header")))
+    component.setup(CGSize(width: 100, height: 100))
+    component.view.layoutSubviews()
+
+    guard let tableView = component.tableView else {
+      XCTFail("Unable to resolve table view.")
+      return
+    }
+
+    guard let delegate = component.componentDelegate else {
+      XCTFail("Unable to resolve delegate.")
+      return
+    }
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 88)
+
+    component.model.header = nil
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 0)
+
+    component.model.header = Item(kind: "regular-header")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 44)
+
+    component.model.header = Item(kind: "")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 0)
+
+    delegate.component = nil
+    tableView.reloadDataSource()
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
+  }
+
+  func testTableViewFooterHeight() {
+    Configuration.register(view: RegularView.self, identifier: "regular-footer")
+    Configuration.register(view: CustomListHeaderView.self, identifier: "custom-footer")
+
+    let component = Component(model: ComponentModel(footer: Item(kind: "custom-footer")))
+    component.setup(CGSize(width: 100, height: 100))
+    component.view.layoutSubviews()
+
+    guard let tableView = component.tableView else {
+      XCTFail("Unable to resolve table view.")
+      return
+    }
+
+    guard let delegate = component.componentDelegate else {
+      XCTFail("Unable to resolve delegate.")
+      return
+    }
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 88)
+
+    component.model.footer = nil
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
+
+    component.model.footer = Item(kind: "regular-footer")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 44)
+
+    component.model.footer = Item(kind: "")
+    tableView.reloadDataSource()
+
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
+
+    delegate.component = nil
+    tableView.reloadDataSource()
+    XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
   }
 }


### PR DESCRIPTION
This PR refactors the delegate methods for header and footer height on `UITableView`.
After this refactoring the code should be easier to navigate and understand.
Both methods now share the same method called `heightForItem`.

I added some tests to check that the correct height are returned.