### PR TITLE
Remove items from component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
-  - bash <(curl -s https://codecov.io/bash) -cF osx
+  - bash <(curl -s https://codecov.io/bash) -cF osx -J 'Spots'
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 script:
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
+  - bash <(curl -s https://codecov.io/bash) -cF osx
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ script:
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
   - bash <(curl -s https://codecov.io/bash) -cF osx -J 'Spots'
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
   - bundle exec danger
 
 #after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ before_install:
   - travis_wait 35; bin/bootstrap-if-needed
 
 script:
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build | xcpretty
-  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' clean build
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0' -enableCodeCoverage YES test
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
+  - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
   - bundle exec danger
 
 #after_success:

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -192,13 +192,13 @@ public extension Component {
 
   /// Refresh indexes for all items to ensure that the indexes are unique and in ascending order.
   public func refreshIndexes(completion: Completion = nil) {
-    var updatedItems = items
+    var updatedItems = model.items
 
     updatedItems.enumerated().forEach {
       updatedItems[$0.offset].index = $0.offset
     }
 
-    items = updatedItems
+    model.items = updatedItems
     completion?()
   }
 

--- a/Sources/Shared/Extensions/Component+Mutation.swift
+++ b/Sources/Shared/Extensions/Component+Mutation.swift
@@ -424,16 +424,6 @@ public extension Component {
     }
   }
 
-  /// A collection of view models
-  var items: [Item] {
-    set(items) {
-      model.items = items
-    }
-    get {
-      return model.items
-    }
-  }
-
   /// Return a dictionary representation of Component object
   public var dictionary: [String : Any] {
     return model.dictionary

--- a/Sources/Shared/Extensions/Component+Mutation.swift
+++ b/Sources/Shared/Extensions/Component+Mutation.swift
@@ -274,12 +274,12 @@ public extension Component {
           return
       }
 
-      strongSelf.items[index] = item
+      strongSelf.model.items[index] = item
 
-      if strongSelf.items[index].kind == CompositeComponent.identifier {
+      if strongSelf.model.items[index].kind == CompositeComponent.identifier {
         if let compositeView: Composable? = strongSelf.userInterface?.view(at: index) {
           let compositeComponents = strongSelf.compositeComponents.filter { $0.itemIndex == item.index }
-          compositeView?.configure(&strongSelf.items[index],
+          compositeView?.configure(&strongSelf.model.items[index],
                                    compositeComponents: compositeComponents)
         } else {
           for compositeSpot in strongSelf.compositeComponents {
@@ -294,12 +294,12 @@ public extension Component {
         return
       } else {
         strongSelf.configureItem(at: index, usesViewSize: true)
-        let newItem = strongSelf.items[index]
+        let newItem = strongSelf.model.items[index]
 
         if newItem.kind != oldItem.kind || newItem.size.height != oldItem.size.height {
           if let cell: ItemConfigurable = strongSelf.userInterface?.view(at: index), animation != .none {
             strongSelf.userInterface?.beginUpdates()
-            cell.configure(&strongSelf.items[index])
+            cell.configure(&strongSelf.model.items[index])
             strongSelf.userInterface?.endUpdates()
           } else {
             strongSelf.userInterface?.reload([index], withAnimation: animation, completion: nil)
@@ -311,7 +311,7 @@ public extension Component {
           }
           return
         } else if let cell: ItemConfigurable = strongSelf.userInterface?.view(at: index) {
-          cell.configure(&strongSelf.items[index])
+          cell.configure(&strongSelf.model.items[index])
           strongSelf.view.superview?.layoutSubviews()
           completion?()
         } else {
@@ -441,7 +441,7 @@ public extension Component {
         return
       }
 
-      if strongSelf.items == items {
+      if strongSelf.model.items == items {
         Dispatch.main {
           strongSelf.cache()
           completion?()
@@ -457,13 +457,13 @@ public extension Component {
         }
 
         var indexes: [Int]? = nil
-        let oldItems = strongSelf.items
-        strongSelf.items = items
+        let oldItems = strongSelf.model.items
+        strongSelf.model.items = items
 
         if items.count == oldItems.count {
           for (index, item) in items.enumerated() {
             guard !(item == oldItems[index]) else {
-              strongSelf.items[index].size = oldItems[index].size
+              strongSelf.model.items[index].size = oldItems[index].size
               continue
             }
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -56,7 +56,7 @@ public extension SpotsProtocol {
 
     for component in components {
       var componentJSON = component.model.dictionary(amountOfItems)
-      for item in component.items where item.kind == CompositeComponent.identifier {
+      for item in component.model.items where item.kind == CompositeComponent.identifier {
         let results = component.compositeComponents
           .filter({ $0.itemIndex == item.index })
 
@@ -87,13 +87,13 @@ public extension SpotsProtocol {
   /// - returns: An optional object with inferred type.
   public func ui<T>(_ includeElement: (Item) -> Bool) -> T? {
     for component in components {
-      if let first = component.items.filter(includeElement).first {
+      if let first = component.model.items.filter(includeElement).first {
         return component.ui(at: first.index)
       }
 
       let cSpots = component.compositeComponents.map { $0.component }
       for compositeSpot in cSpots {
-        if let first = compositeSpot.items.filter(includeElement).first {
+        if let first = compositeSpot.model.items.filter(includeElement).first {
           return compositeSpot.ui(at: first.index)
         }
       }
@@ -126,14 +126,14 @@ public extension SpotsProtocol {
   public func filter(items includeElement: (Item) -> Bool) -> [(component: Component, items: [Item])] {
     var result = [(component: Component, items: [Item])]()
     for component in components {
-      let items = component.items.filter(includeElement)
+      let items = component.model.items.filter(includeElement)
       if !items.isEmpty {
         result.append((component: component, items: items))
       }
 
       let childSpots = component.compositeComponents.map { $0.component }
       for component in childSpots {
-        let items = component.items.filter(includeElement)
+        let items = component.model.items.filter(includeElement)
         if !items.isEmpty {
           result.append((component: component, items: items))
         }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -191,11 +191,11 @@ extension SpotsProtocol {
       width: view.frame.width,
       height: ceil(tempSpot.view.frame.height))
 
-    guard let diff = Item.evaluate(tempSpot.items, oldModels: component.items) else {
+    guard let diff = Item.evaluate(tempSpot.model.items, oldModels: component.model.items) else {
       return true
     }
 
-    let newItems = tempSpot.items
+    let newItems = tempSpot.model.items
     let changes: (ItemChanges) = Item.processChanges(diff)
 
     for index in changes.updatedChildren {
@@ -206,21 +206,21 @@ extension SpotsProtocol {
       }
     }
 
-    if newItems.count == component.items.count {
+    if newItems.count == component.model.items.count {
       reload(with: changes, in: component, newItems: newItems, animation: animation) { [weak self] in
         if let strongSelf = self, let completion = completion {
           strongSelf.completeUpdates()
           completion()
         }
       }
-    } else if newItems.count < component.items.count {
+    } else if newItems.count < component.model.items.count {
       reload(with: changes, in: component, lessItems: newItems, animation: animation) { [weak self] in
         if let strongSelf = self, let completion = completion {
           strongSelf.completeUpdates()
           completion()
         }
       }
-    } else if newItems.count > component.items.count {
+    } else if newItems.count > component.model.items.count {
       reload(with: changes, in: component, moreItems: newItems, animation: animation) { [weak self] in
         if let strongSelf = self, let completion = completion {
           strongSelf.completeUpdates()
@@ -256,7 +256,7 @@ extension SpotsProtocol {
         }
       }
 
-      component.items = newItems
+      component.model.items = newItems
     }) { [weak self] in
       guard let strongSelf = self else {
         return
@@ -296,7 +296,7 @@ extension SpotsProtocol {
                       completion: (() -> Void)? = nil) {
     component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
       component.beforeUpdate()
-      component.items = newItems
+      component.model.items = newItems
     }) { [weak self] in
       guard let strongSelf = self, !newItems.isEmpty else {
         self?.finishReloading(component: component, withCompletion: completion)
@@ -321,7 +321,7 @@ extension SpotsProtocol {
           }
         }
 
-        if !component.items.filter({ !$0.children.isEmpty }).isEmpty {
+        if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
           component.beforeUpdate()
           component.reload(nil, withAnimation: animation) {
             strongSelf.finishReloading(component: component, withCompletion: completion)
@@ -351,9 +351,9 @@ extension SpotsProtocol {
                       completion: (() -> Void)? = nil) {
     component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
       component.beforeUpdate()
-      component.items = newItems
+      component.model.items = newItems
     }) {
-      if !component.items.filter({ !$0.children.isEmpty }).isEmpty {
+      if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
         component.reload(nil, withAnimation: animation) { [weak self] in
           self?.finishReloading(component: component, withCompletion: completion)
         }
@@ -575,7 +575,7 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that is run when the update is completed
    */
   public func updateIfNeeded(componentAtIndex index: Int = 0, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    guard let component = component(at: index), !(component.items == items) else {
+    guard let component = component(at: index), !(component.model.items == items) else {
       scrollView.layoutSubviews()
       completion?()
       return
@@ -583,8 +583,8 @@ extension SpotsProtocol {
 
     update(componentAtIndex: index, withAnimation: animation, withCompletion: {
       completion?()
-    }, {
-      $0.items = items
+    }, { component in
+      component.model.items = items
     })
   }
 

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -79,10 +79,10 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      guard let firstItem = component.items.first else { return }
+      guard let firstItem = component.model.items.first else { return }
 
-      contentSize.width = component.items.reduce(0, { $0 + floor($1.size.width) })
-      contentSize.width += minimumInteritemSpacing * CGFloat(component.items.count - 1)
+      contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
+      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)
 
       contentSize.height = firstItem.size.height + headerReferenceSize.height + footerHeight
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -43,7 +43,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter cell: The cell object that was removed.
   /// - parameter indexPath: The index path of the data item that the cell represented.
   public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-    guard let component = component, indexPath.item < component.items.count,
+    guard let component = component, indexPath.item < component.model.items.count,
       let item = component.item(at: indexPath) else {
       return
     }
@@ -78,8 +78,8 @@ extension Delegate: UICollectionViewDelegate {
     }
 
     if let component = component,
-      component.items[indexPath.item].kind != CompositeComponent.identifier,
-      indexPath.item < component.items.count {
+      component.model.items[indexPath.item].kind != CompositeComponent.identifier,
+      indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedSpot = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
     }
@@ -306,8 +306,8 @@ extension Delegate: UITableViewDelegate {
     }
 
     if let component = component,
-      component.items[indexPath.item].kind != CompositeComponent.identifier,
-      indexPath.item < component.items.count {
+      component.model.items[indexPath.item].kind != CompositeComponent.identifier,
+      indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedSpot = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
     }

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -74,7 +74,7 @@ extension Delegate: UIScrollViewDelegate {
         let isBeyondBounds = targetContentOffset.pointee.x >= widthBounds && centerIndexPath == nil
 
         if isBeyondBounds {
-          centerIndexPath = IndexPath(item: component.items.count - 1, section: 0)
+          centerIndexPath = IndexPath(item: component.model.items.count - 1, section: 0)
         }
       }
 

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -23,10 +23,10 @@ public class GridableLayout: FlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      guard let firstItem = component.items.first else { return }
+      guard let firstItem = component.model.items.first else { return }
 
-      contentSize.width = component.items.reduce(0, { $0 + floor($1.size.width) })
-      contentSize.width += minimumInteritemSpacing * CGFloat(component.items.count - 1)
+      contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
+      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)
 
       contentSize.height = firstItem.size.height
     case .vertical:

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -9,9 +9,11 @@ extension Delegate: NSCollectionViewDelegate {
      This can probably be fixed in a more convenient way in the future without delays.
      */
     Dispatch.after(seconds: 0.1) { [weak self] in
-      guard let strongSelf = self, let first = indexPaths.first,
+      guard let strongSelf = self,
+        let first = indexPaths.first,
         let component = strongSelf.component,
-        let item = component.item(at: first.item), first.item < component.items.count else {
+        let item = component.item(at: first.item), first.item < component.model.items.count
+        else {
           return
       }
       component.delegate?.component(component, itemSelected: item)

--- a/Spots.xcodeproj/xcshareddata/xcschemes/RxSpots-iOS.xcscheme
+++ b/Spots.xcodeproj/xcshareddata/xcschemes/RxSpots-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -58,7 +58,7 @@ class CompositionTests: XCTestCase {
     let component = GridComponent(model: model)
     component.setup(CGSize(width: 100, height: 100))
 
-    XCTAssertEqual(component.items.count, 2)
+    XCTAssertEqual(component.model.items.count, 2)
 
     guard component.compositeComponents.count == 2 else {
       XCTFail("Could not find composite components")
@@ -67,14 +67,14 @@ class CompositionTests: XCTestCase {
 
     XCTAssertEqual(component.compositeComponents.count, 2)
     XCTAssertEqual(component.compositeComponents[0].component.model.kind, ComponentModel.Kind.list.rawValue)
-    XCTAssertEqual(component.compositeComponents[0].component.items.count, 2)
-    XCTAssertEqual(component.compositeComponents[0].component.items[0].title, "foo")
-    XCTAssertEqual(component.compositeComponents[0].component.items[1].title, "bar")
+    XCTAssertEqual(component.compositeComponents[0].component.model.items.count, 2)
+    XCTAssertEqual(component.compositeComponents[0].component.model.items[0].title, "foo")
+    XCTAssertEqual(component.compositeComponents[0].component.model.items[1].title, "bar")
 
     XCTAssertEqual(component.compositeComponents[1].component.model.kind, ComponentModel.Kind.list.rawValue)
-    XCTAssertEqual(component.compositeComponents[1].component.items.count, 2)
-    XCTAssertEqual(component.compositeComponents[1].component.items[0].title, "baz")
-    XCTAssertEqual(component.compositeComponents[1].component.items[1].title, "bal")
+    XCTAssertEqual(component.compositeComponents[1].component.model.items.count, 2)
+    XCTAssertEqual(component.compositeComponents[1].component.model.items[0].title, "baz")
+    XCTAssertEqual(component.compositeComponents[1].component.model.items[1].title, "bal")
   }
 
   func testUICreation() {
@@ -126,7 +126,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(component.compositeComponents[0].parentComponent!.model == component.model)
     XCTAssertTrue(component.compositeComponents[0].component.userInterface is TableView)
     XCTAssertEqual(component.compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(component.compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(component.compositeComponents[0].component.model.items.count))
 
     composite = component.ui(at: 1)
     itemConfigurable = component.compositeComponents[0].component.ui(at: 1)
@@ -136,7 +136,7 @@ class CompositionTests: XCTestCase {
     XCTAssertTrue(component.compositeComponents[1].parentComponent!.model == component.model)
     XCTAssertTrue(component.compositeComponents[1].component.userInterface is TableView)
     XCTAssertEqual(component.compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(component.compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(component.compositeComponents[1].component.model.items.count))
 
     composite = component.ui(at: 2)
     XCTAssertNil(composite)
@@ -255,9 +255,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -265,18 +265,18 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[0].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -284,9 +284,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: ComponentModel.Kind.grid.rawValue,
@@ -388,9 +388,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -398,18 +398,18 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
       XCTAssertNotNil(composite)
       XCTAssertNotNil(itemConfigurable)
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[0].parentComponent!.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 10)
+      XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 10)
       XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -417,9 +417,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 
@@ -549,9 +549,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -559,9 +559,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
       guard components[1].compositeComponents.count == 2 else {
         XCTFail("Could not find composite components.")
@@ -573,9 +573,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[0].parentComponent!.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 10)
+      XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 10)
       XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -583,9 +583,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 
@@ -711,9 +711,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -721,18 +721,18 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[0].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -740,9 +740,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: ComponentModel.Kind.grid.rawValue,
@@ -887,9 +887,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[0].parentComponent?.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 11)
+      XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 11)
       XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -897,9 +897,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
       itemConfigurable = components[1].compositeComponents[0].component.ui(at: 0)
 
@@ -908,9 +908,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[0].parentComponent?.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 11)
+      XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 11)
       XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[1].compositeComponents[1].component.ui(at: 0)
 
@@ -918,9 +918,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
       XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 11)
+      XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 11)
       XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 
@@ -1052,9 +1052,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -1062,18 +1062,18 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
     XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
     XCTAssertNotNil(composite)
     XCTAssertNotNil(itemConfigurable)
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[0].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[0].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[0].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[0].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[0].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[0].component.model.items.count))
 
     itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -1081,9 +1081,9 @@ class CompositionTests: XCTestCase {
     XCTAssertEqual(composite?.contentView.subviews.count, 1)
     XCTAssertTrue(components[1].compositeComponents[1].parentComponent!.model == components[1].model)
     XCTAssertTrue(components[1].compositeComponents[1].component.userInterface is TableView)
-    XCTAssertEqual(components[1].compositeComponents[1].component.items.count, 10)
+    XCTAssertEqual(components[1].compositeComponents[1].component.model.items.count, 10)
     XCTAssertEqual(components[1].compositeComponents[1].component.view.frame.size.height,
-                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.items.count))
+                   (itemConfigurable!.preferredViewSize.height + heightOffset) * CGFloat(components[1].compositeComponents[1].component.model.items.count))
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: ComponentModel.Kind.grid.rawValue,
@@ -1145,9 +1145,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[0].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[0].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[0].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[0].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[0].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[0].component.model.items.count))
 
       itemConfigurable = components[0].compositeComponents[1].component.ui(at: 0)
 
@@ -1155,9 +1155,9 @@ class CompositionTests: XCTestCase {
       XCTAssertEqual(composite?.contentView.subviews.count, 1)
       XCTAssertTrue(components[0].compositeComponents[1].parentComponent!.model == components[0].model)
       XCTAssertTrue(components[0].compositeComponents[1].component.userInterface is TableView)
-      XCTAssertEqual(components[0].compositeComponents[1].component.items.count, 10)
+      XCTAssertEqual(components[0].compositeComponents[1].component.model.items.count, 10)
       XCTAssertEqual(components[0].compositeComponents[1].component.view.frame.size.height,
-                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.items.count))
+                     ((itemConfigurable?.preferredViewSize.height ?? 0.0) + self.heightOffset) * CGFloat(components[0].compositeComponents[1].component.model.items.count))
 
       XCTAssertEqual(reloadTimes, 1)
 

--- a/SpotsTests/Shared/TestController.swift
+++ b/SpotsTests/Shared/TestController.swift
@@ -184,7 +184,7 @@ class ControllerTests: XCTestCase {
 
     controller.prepareController()
 
-    let items = controller.components.first!.items
+    let items = controller.components.first!.model.items
     let expectation = self.expectation(description: "Test delete items")
 
     controller.components[0].delete(items, withAnimation: .none) {
@@ -433,12 +433,12 @@ class ControllerTests: XCTestCase {
       ])
     let component = ListComponent(model: model)
 
-    XCTAssert(component.items == model.items)
+    XCTAssert(component.model.items == model.items)
 
     let newItems = [Item(title: "title3", kind: "list")]
-    component.items = newItems
-    XCTAssertFalse(component.items == model.items)
-    XCTAssert(component.items == newItems)
+    component.model.items = newItems
+    XCTAssertFalse(component.model.items == model.items)
+    XCTAssert(component.model.items == newItems)
   }
 
   func testFindAndFilterSpotWithClosure() {
@@ -451,7 +451,7 @@ class ControllerTests: XCTestCase {
     XCTAssertNotNil(controller.resolve(component: { $1.model.title == "GridComponent" }))
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is TableView }))
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is CollectionView }))
-    XCTAssertNotNil(controller.resolve(component: { $1.items.filter { $0.title == "Item" }.first != nil }))
+    XCTAssertNotNil(controller.resolve(component: { $1.model.items.filter { $0.title == "Item" }.first != nil }))
     XCTAssertEqual(controller.resolve(component: { $0.0 == 0 })?.model.title, "ListComponent")
     XCTAssertEqual(controller.resolve(component: { $0.0 == 1 })?.model.title, "ListComponent2")
     XCTAssertEqual(controller.resolve(component: { $0.0 == 2 })?.model.title, "GridComponent")
@@ -462,7 +462,7 @@ class ControllerTests: XCTestCase {
 
   func testJSONInitialiser() {
     let component = ListComponent(model: ComponentModel(kind: "list"))
-    component.items = [Item(title: "First item")]
+    component.model.items = [Item(title: "First item")]
     let sourceController = Controller(component: component)
     let jsonController = Controller([
       "components": [
@@ -573,8 +573,8 @@ class ControllerTests: XCTestCase {
 
     let controller = Controller(initialJSON)
     XCTAssertTrue(controller.components[0].userInterface is TableView)
-    XCTAssertEqual(controller.components[0].items.first?.title, "First list item")
-    XCTAssertEqual(controller.components[1].items.first?.title, "First list item")
+    XCTAssertEqual(controller.components[0].model.items.first?.title, "First list item")
+    XCTAssertEqual(controller.components[1].model.items.first?.title, "First list item")
     XCTAssertTrue(controller.components[1].userInterface is TableView)
     XCTAssertTrue(controller.components.count == 2)
     XCTAssertTrue(controller.components[0].compositeComponents.count == 0)
@@ -585,16 +585,16 @@ class ControllerTests: XCTestCase {
       XCTAssertEqual(controller.components.count, 2)
       XCTAssertTrue(controller.components[0].userInterface is TableView)
       XCTAssertTrue(controller.components[1].userInterface is CollectionView)
-      XCTAssertEqual(controller.components[0].items.first?.title, "First list item 2")
-      XCTAssertEqual(controller.components[1].items.first?.title, "First list item")
+      XCTAssertEqual(controller.components[0].model.items.first?.title, "First list item 2")
+      XCTAssertEqual(controller.components[1].model.items.first?.title, "First list item")
 
-      XCTAssertEqual(controller.components[0].items[1].kind, CompositeComponent.identifier)
+      XCTAssertEqual(controller.components[0].model.items[1].kind, CompositeComponent.identifier)
       XCTAssertEqual(controller.components[0].compositeComponents.count, 1)
 
       controller.reloadIfNeeded(initialJSON) {
         XCTAssertTrue(controller.components[0].userInterface is TableView)
-        XCTAssertEqual(controller.components[0].items.first?.title, "First list item")
-        XCTAssertEqual(controller.components[1].items.first?.title, "First list item")
+        XCTAssertEqual(controller.components[0].model.items.first?.title, "First list item")
+        XCTAssertEqual(controller.components[1].model.items.first?.title, "First list item")
         XCTAssertTrue(controller.components[1].userInterface is TableView)
         XCTAssertTrue(controller.components.count == 2)
         XCTAssertTrue(controller.components[0].compositeComponents.count == 0)
@@ -646,7 +646,7 @@ class ControllerTests: XCTestCase {
 
     /// Test what changed on the items
     let newItems = newComponentModels.first!.items
-    let oldItems = controller.components.first!.items
+    let oldItems = controller.components.first!.model.items
     var diff = Item.evaluate(newItems, oldModels: oldItems)
 
     XCTAssertEqual(diff![0], .text)

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -22,7 +22,7 @@ class CoreComponentTests: XCTestCase {
 
     let expectation = self.expectation(description: "Wait until done")
     Dispatch.after(seconds: 1.0) {
-      XCTAssertEqual(listComponent.items.count, 500)
+      XCTAssertEqual(listComponent.model.items.count, 500)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
@@ -46,7 +46,7 @@ class CoreComponentTests: XCTestCase {
 
     let expectation = self.expectation(description: "Wait until done")
     Dispatch.after(seconds: 1.0) {
-      XCTAssertEqual(controller.components[0].items.count, 500)
+      XCTAssertEqual(controller.components[0].model.items.count, 500)
       expectation.fulfill()
     }
     waitForExpectations(timeout: 10.0, handler: nil)

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -157,12 +157,12 @@ class CarouselComponentTests: XCTestCase {
     }
 
     // Test that component height is equal to first item in the list
-    XCTAssertEqual(component.items.count, 3)
-    XCTAssertEqual(component.items[0].title, "foo")
-    XCTAssertEqual(component.items[1].title, "bar")
-    XCTAssertEqual(component.items[2].title, "baz")
-    XCTAssertEqual(component.items.first?.size.width, 120)
-    XCTAssertEqual(component.items.first?.size.height, 180)
+    XCTAssertEqual(component.model.items.count, 3)
+    XCTAssertEqual(component.model.items[0].title, "foo")
+    XCTAssertEqual(component.model.items[1].title, "bar")
+    XCTAssertEqual(component.model.items[2].title, "baz")
+    XCTAssertEqual(component.model.items.first?.size.width, 120)
+    XCTAssertEqual(component.model.items.first?.size.height, 180)
     XCTAssertEqual(component.view.frame.size.height, 180)
 
     // Check default value of `paginate`
@@ -205,19 +205,19 @@ class CarouselComponentTests: XCTestCase {
     let width = component.view.bounds.width / 4
 
     // Test that component height is equal to first item in the list
-    XCTAssertEqual(component.items.count, 4)
-    XCTAssertEqual(component.items[0].title, "foo")
-    XCTAssertEqual(component.items[1].title, "bar")
-    XCTAssertEqual(component.items[2].title, "baz")
-    XCTAssertEqual(component.items[3].title, "bazar")
-    XCTAssertEqual(component.items[0].size.width, width)
-    XCTAssertEqual(component.items[0].size.height, 88)
-    XCTAssertEqual(component.items[1].size.width, width)
-    XCTAssertEqual(component.items[1].size.height, 88)
-    XCTAssertEqual(component.items[2].size.width, width)
-    XCTAssertEqual(component.items[2].size.height, 88)
-    XCTAssertEqual(component.items[3].size.width, width)
-    XCTAssertEqual(component.items[3].size.height, 88)
+    XCTAssertEqual(component.model.items.count, 4)
+    XCTAssertEqual(component.model.items[0].title, "foo")
+    XCTAssertEqual(component.model.items[1].title, "bar")
+    XCTAssertEqual(component.model.items[2].title, "baz")
+    XCTAssertEqual(component.model.items[3].title, "bazar")
+    XCTAssertEqual(component.model.items[0].size.width, width)
+    XCTAssertEqual(component.model.items[0].size.height, 88)
+    XCTAssertEqual(component.model.items[1].size.width, width)
+    XCTAssertEqual(component.model.items[1].size.height, 88)
+    XCTAssertEqual(component.model.items[2].size.width, width)
+    XCTAssertEqual(component.model.items[2].size.height, 88)
+    XCTAssertEqual(component.model.items[3].size.width, width)
+    XCTAssertEqual(component.model.items[3].size.height, 88)
 
     // Assert that height has been added for the page indicator
     XCTAssertEqual(component.view.frame.size.height, 110)
@@ -266,10 +266,10 @@ class CarouselComponentTests: XCTestCase {
     XCTAssertEqual(model.layout!.pageIndicatorPlacement, .overlay)
 
     // Assert item layout (derived from preferred view size)
-    XCTAssertEqual(component.items[0].size.height, 88)
-    XCTAssertEqual(component.items[1].size.height, 88)
-    XCTAssertEqual(component.items[2].size.height, 88)
-    XCTAssertEqual(component.items[3].size.height, 88)
+    XCTAssertEqual(component.model.items[0].size.height, 88)
+    XCTAssertEqual(component.model.items[1].size.height, 88)
+    XCTAssertEqual(component.model.items[2].size.height, 88)
+    XCTAssertEqual(component.model.items[3].size.height, 88)
 
     // Assert that no height has been added for a page indicator
     XCTAssertEqual(component.view.frame.height, 88)
@@ -342,7 +342,7 @@ class CarouselComponentTests: XCTestCase {
     component.view.layoutSubviews()
 
     // Make sure our mocked item size is correct
-    XCTAssertEqual(collectionView.itemSize, component.items[0].size)
+    XCTAssertEqual(collectionView.itemSize, component.model.items[0].size)
 
     // When scrolling, make sure the closest item is centered
     var originalPoint = CGPoint(x: 350, y: 0)

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -21,8 +21,8 @@ class TestSpot: XCTestCase {
 
     XCTAssertTrue(component.view is TableView)
     XCTAssertTrue(component.view.isEqual(component.tableView))
-    XCTAssertEqual(component.items[0].size, CGSize(width: 100, height: 44))
-    XCTAssertEqual(component.items[1].size, CGSize(width: 100, height: 44))
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 100, height: 44))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 100, height: 44))
     XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 100))
 
     /// tvOS adds 14 pixels to each item in a table view.
@@ -79,8 +79,8 @@ class TestSpot: XCTestCase {
     listComponent.view.layoutSubviews()
 
     XCTAssertEqual(component.model.interaction.scrollDirection, listComponent.model.interaction.scrollDirection)
-    XCTAssertEqual(component.items[0].size, listComponent.items[0].size)
-    XCTAssertEqual(component.items[1].size, listComponent.items[0].size)
+    XCTAssertEqual(component.model.items[0].size, listComponent.model.items[0].size)
+    XCTAssertEqual(component.model.items[1].size, listComponent.model.items[0].size)
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 0, section: 0)), listComponent.sizeForItem(at: IndexPath(item: 0, section: 0)))
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 1, section: 0)), listComponent.sizeForItem(at: IndexPath(item: 1, section: 0)))
     XCTAssertEqual(component.view.frame, listComponent.view.frame)
@@ -102,8 +102,8 @@ class TestSpot: XCTestCase {
     gridComponent.view.layoutSubviews()
 
     XCTAssertEqual(component.model.interaction.scrollDirection, gridComponent.model.interaction.scrollDirection)
-    XCTAssertEqual(component.items[0].size, gridComponent.items[0].size)
-    XCTAssertEqual(component.items[1].size, gridComponent.items[0].size)
+    XCTAssertEqual(component.model.items[0].size, gridComponent.model.items[0].size)
+    XCTAssertEqual(component.model.items[1].size, gridComponent.model.items[0].size)
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 0, section: 0)), gridComponent.sizeForItem(at: IndexPath(item: 0, section: 0)))
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 1, section: 0)), gridComponent.sizeForItem(at: IndexPath(item: 1, section: 0)))
     XCTAssertEqual(component.view.frame, gridComponent.view.frame)
@@ -126,8 +126,8 @@ class TestSpot: XCTestCase {
     carouselComponent.view.layoutSubviews()
 
     XCTAssertEqual(component.model.interaction.scrollDirection, carouselComponent.model.interaction.scrollDirection)
-    XCTAssertEqual(component.items[0].size, carouselComponent.items[0].size)
-    XCTAssertEqual(component.items[1].size, carouselComponent.items[0].size)
+    XCTAssertEqual(component.model.items[0].size, carouselComponent.model.items[0].size)
+    XCTAssertEqual(component.model.items[1].size, carouselComponent.model.items[0].size)
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 0, section: 0)), carouselComponent.sizeForItem(at: IndexPath(item: 0, section: 0)))
     XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 1, section: 0)), carouselComponent.sizeForItem(at: IndexPath(item: 1, section: 0)))
     XCTAssertEqual(component.view.frame, carouselComponent.view.frame)

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -20,8 +20,8 @@ class TestSpot: XCTestCase {
 
     XCTAssertNotNil(component.view)
     XCTAssertNotNil(component.tableView)
-    XCTAssertEqual(component.items[0].size, CGSize(width: 100, height: 88))
-    XCTAssertEqual(component.items[1].size, CGSize(width: 100, height: 88))
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 100, height: 88))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 100, height: 88))
     XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 180))
     let expectedContentSizeHeight: CGFloat = 180
     XCTAssertEqual(component.view.contentSize, CGSize(width: 100, height: expectedContentSizeHeight))

--- a/circle.yml
+++ b/circle.yml
@@ -13,9 +13,9 @@ test:
   override:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash) -cF ios
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash) -cF tvos
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-  post:
-    - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -11,11 +11,11 @@ dependencies:
 
 test:
   override:
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build | xcpretty
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test | xcpretty
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
   post:
     - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -13,9 +13,9 @@ test:
   override:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-    - bash <(curl -s https://codecov.io/bash) -cF ios
+    - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
-    - bash <(curl -s https://codecov.io/bash) -cF tvos
+    - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test


### PR DESCRIPTION
This PR removes the computed `items` property from `Component`. 

- It fixes this issue #536 
- It updates CI configuration to run faster on Travis. That one only runs the `macOS` tests now.
- Small adjustments to `codecov`