### PR TITLE
Remove support for legacy mapping on `ComponentModel` and related models.

### DIFF
--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -25,8 +25,6 @@ public enum ComponentModelDiff {
 /// The ComponentModel struct is used to configure a Component object
 public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
 
-  public static var legacyMapping: Bool = false
-
   /// An enum with all the string keys used in the view model
   public enum Key: String, StringConvertible {
     case index
@@ -183,19 +181,14 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     self.meta      <- map.property("meta")
     self.isHybrid  <- map.property("hybrid")
 
-    if ComponentModel.legacyMapping {
-      self.layout = Layout(map.property("meta") ?? [:])
-      self.interaction = Interaction(map.property("meta") ?? [:])
-    } else {
-      if let layoutDictionary: [String : Any] = map.property(Layout.rootKey) {
-        self.layout = Layout(layoutDictionary)
-      }
+    if let layoutDictionary: [String : Any] = map.property(Layout.rootKey) {
+      self.layout = Layout(layoutDictionary)
+    }
 
-      if let interactionDictionary: [String : Any] = map.property(Interaction.rootKey) {
-        self.interaction = Interaction(interactionDictionary)
-      } else {
-        self.interaction = Interaction()
-      }
+    if let interactionDictionary: [String : Any] = map.property(Interaction.rootKey) {
+      self.interaction = Interaction(interactionDictionary)
+    } else {
+      self.interaction = Interaction()
     }
 
     if self.layout == nil {
@@ -244,10 +237,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
 
     if let span = span, layout == nil {
       self.layout = Layout(span: span)
-    }
-
-    if ComponentModel.legacyMapping {
-      self.layout?.configure(withJSON: meta)
     }
   }
 

--- a/Sources/Shared/Structs/Inset.swift
+++ b/Sources/Shared/Structs/Inset.swift
@@ -56,18 +56,10 @@ public struct Inset: Mappable, Equatable {
   ///
   /// - Parameter map: A JSON dictionary that will be mapped into the content insets.
   public init(_ map: [String : Any]) {
-    switch ComponentModel.legacyMapping {
-    case true:
-      self.top    <- map.property(GridableMeta.Key.contentInsetTop)
-      self.left   <- map.property(GridableMeta.Key.contentInsetLeft)
-      self.bottom <- map.property(GridableMeta.Key.contentInsetBottom)
-      self.right  <- map.property(GridableMeta.Key.contentInsetRight)
-    case false:
-      self.top    <- map.property(Key.top.rawValue)
-      self.left   <- map.property(Key.left.rawValue)
-      self.bottom <- map.property(Key.bottom.rawValue)
-      self.right  <- map.property(Key.right.rawValue)
-    }
+    self.top    <- map.property(Key.top.rawValue)
+    self.left   <- map.property(Key.left.rawValue)
+    self.bottom <- map.property(Key.bottom.rawValue)
+    self.right  <- map.property(Key.right.rawValue)
   }
 
   /// Configure struct with a JSON dictionary.

--- a/Sources/Shared/Structs/Interaction.swift
+++ b/Sources/Shared/Structs/Interaction.swift
@@ -58,11 +58,7 @@ public struct Interaction: Mappable {
   ///
   /// - Parameter map: A JSON dictionary.
   public mutating func configure(withJSON map: [String : Any]) {
-    if ComponentModel.legacyMapping {
-      if let _: Bool = map.property(Key.paginate.rawValue) {
-        self.paginate = .page
-      }
-    } else if let paginate: String = map.property(Key.paginate.rawValue) {
+    if let paginate: String = map.property(Key.paginate.rawValue) {
       self.paginate <- Paginate(rawValue: paginate)
     }
   }

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -108,13 +108,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   ///
   /// - Parameter map: A JSON dictionary.
   public mutating func configure(withJSON map: [String : Any]) {
-    switch ComponentModel.legacyMapping {
-    case true:
-      self.inset = Inset(map)
-    case false:
-      self.inset = Inset(map.property(Inset.rootKey) ?? [:])
-    }
-
+    self.inset = Inset(map.property(Inset.rootKey) ?? [:])
     self.itemSpacing <- map.property(Key.itemSpacing.rawValue)
     self.lineSpacing <- map.property(Key.lineSpacing.rawValue)
     self.dynamicSpan <- map.property(Key.dynamicSpan.rawValue)

--- a/SpotsTests/Shared/TestLayout.swift
+++ b/SpotsTests/Shared/TestLayout.swift
@@ -50,17 +50,6 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(layout.inset, Inset(top: 1, left: 2, bottom: 3, right: 4))
   }
 
-  func testLegacyJSONMapping() {
-    let layout = Layout(json)
-
-    XCTAssertEqual(layout.span, 4.0)
-    XCTAssertEqual(layout.itemSpacing, 8.0)
-    XCTAssertEqual(layout.lineSpacing, 6.0)
-    XCTAssertEqual(layout.dynamicSpan, true)
-    XCTAssertEqual(layout.dynamicHeight, true)
-    XCTAssertEqual(layout.inset, Inset(top: 1, left: 2, bottom: 3, right: 4))
-  }
-
   func testDictionary() {
     let layout = Layout(json)
     let layoutJSON = layout.dictionary

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -66,56 +66,6 @@ class CarouselComponentTests: XCTestCase {
     CarouselComponent.views.storage.removeAll()
   }
 
-  func testMetaMapping() {
-    var json: [String : Any] = [
-      "kind" : "carousel",
-      "meta": [
-        "item-spacing": 25.0,
-        "line-spacing": 10.0,
-        "dynamic-span": true
-      ]
-    ]
-
-    ComponentModel.legacyMapping = true
-
-    var model = ComponentModel(json)
-    var component = CarouselComponent(model: model)
-    component.setup(CGSize(width: 100, height: 100))
-
-    guard let collectionViewLayout = component.collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {
-      XCTFail("Unable to resolve collection view layout")
-      return
-    }
-
-    XCTAssertEqual(collectionViewLayout.minimumInteritemSpacing, 25.0)
-    XCTAssertEqual(collectionViewLayout.minimumLineSpacing, 10.0)
-    XCTAssertEqual(component.model.layout?.dynamicSpan, true)
-
-    json = [
-      "kind" : "carousel",
-      "meta": [
-        "item-spacing": 12.5,
-        "line-spacing": 7.5,
-        "dynamic-span": false
-      ]
-    ]
-
-    model = ComponentModel(json)
-    component = CarouselComponent(model: model)
-    component.setup(CGSize(width: 100, height: 100))
-
-    guard let secondCollectionViewLayout = component.collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {
-      XCTFail("Unable to resolve collection view layout")
-      return
-    }
-
-    XCTAssertEqual(secondCollectionViewLayout.minimumInteritemSpacing, 12.5)
-    XCTAssertEqual(secondCollectionViewLayout.minimumLineSpacing, 7.5)
-    XCTAssertEqual(component.model.layout?.dynamicSpan, false)
-
-    ComponentModel.legacyMapping = false
-  }
-
   func testCarouselSetupWithSimpleStructure() {
     let json: [String : Any] = [
       "kind" : "carousel",

--- a/SpotsTests/iOS/TestInteraction.swift
+++ b/SpotsTests/iOS/TestInteraction.swift
@@ -53,18 +53,6 @@ class InteractionTests: XCTestCase {
     XCTAssertEqual(interaction.paginate, .disabled)
   }
 
-  func testLegacyMapping() {
-    let json: [String : Any] = [
-      "paginate": true
-    ]
-
-    ComponentModel.legacyMapping = true
-    let interaction = Interaction(json)
-    ComponentModel.legacyMapping = false
-
-    XCTAssertTrue(interaction.paginate == .page)
-  }
-
   func testDictionary() {
     let json: [String : Any] = [
       "paginate": "page"


### PR DESCRIPTION
This PR removes the property `legacyMapping` on `ComponentModel`.
It fixes this issue #541 