### PR TITLE
Fix component configure closure on macOS.

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -71,27 +71,6 @@ public extension Component {
     return height
   }
 
-  #if !os(OSX)
-  public func configureClosureDidChange() {
-    guard let configure = configure else {
-      return
-    }
-
-    userInterface?.visibleViews.forEach { view in
-      switch view {
-      case let view as ItemConfigurable:
-        configure(view)
-      case let view as Wrappable:
-        if let wrappedView = view.wrappedView as? ItemConfigurable {
-          configure(wrappedView)
-        }
-      default:
-        break
-      }
-    }
-  }
-  #endif
-
   /// A helper method to return self as a Component type.
   ///
   /// - returns: Self as a Component type

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -71,6 +71,25 @@ public extension Component {
     return height
   }
 
+  func configureClosureDidChange() {
+    guard let configure = configure else {
+      return
+    }
+
+    userInterface?.visibleViews.forEach { view in
+      switch view {
+      case let view as ItemConfigurable:
+        configure(view)
+      case let view as Wrappable:
+        if let wrappedView = view.wrappedView as? ItemConfigurable {
+          configure(wrappedView)
+        }
+      default:
+        break
+      }
+    }
+  }
+
   /// A helper method to return self as a Component type.
   ///
   /// - returns: Self as a Component type

--- a/Sources/Shared/Extensions/UserInterface+Extensions.swift
+++ b/Sources/Shared/Extensions/UserInterface+Extensions.swift
@@ -1,0 +1,10 @@
+extension UserInterface {
+
+  func resolveVisibleView(_ view: View) -> View {
+    guard let wrappedView = (view as? Wrappable)?.wrappedView else {
+      return view
+    }
+
+    return wrappedView
+  }
+}

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -3,9 +3,9 @@ public protocol UserInterface: class {
 
   static var compositeIdentifier: String { get }
 
-  #if !os(OSX)
   var visibleViews: [View] { get }
 
+  #if !os(OSX)
   /// The index of the current selected item
   @available(iOS 9.0, *)
   var selectedIndex: Int { get }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -225,23 +225,4 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func register() {
 
   }
-
-  fileprivate func configureClosureDidChange() {
-    guard let configure = configure else {
-      return
-    }
-
-    userInterface?.visibleViews.forEach { view in
-      switch view {
-      case let view as ItemConfigurable:
-        configure(view)
-      case let view as Wrappable:
-        if let wrappedView = view.wrappedView as? ItemConfigurable {
-          configure(wrappedView)
-        }
-      default:
-        break
-      }
-    }
-  }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -225,4 +225,23 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func register() {
 
   }
+
+  fileprivate func configureClosureDidChange() {
+    guard let configure = configure else {
+      return
+    }
+
+    userInterface?.visibleViews.forEach { view in
+      switch view {
+      case let view as ItemConfigurable:
+        configure(view)
+      case let view as Wrappable:
+        if let wrappedView = view.wrappedView as? ItemConfigurable {
+          configure(wrappedView)
+        }
+      default:
+        break
+      }
+    }
+  }
 }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -34,7 +34,11 @@ extension UICollectionView: UserInterface {
   }
 
   public var visibleViews: [View] {
-    return visibleCells
+    let views = visibleCells.map { view in
+      resolveVisibleView(view)
+    }
+
+    return views
   }
 
   /// The index of the current selected item

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -27,7 +27,11 @@ extension UITableView: UserInterface {
   }
 
   public var visibleViews: [View] {
-    return visibleCells
+    let views = visibleCells.map { view in
+      resolveVisibleView(view)
+    }
+
+    return views
   }
 
   public var selectedIndex: Int {

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -21,7 +21,13 @@ import Tailor
   public var model: ComponentModel
   public var componentKind: ComponentModel.Kind = .list
   public var compositeComponents: [CompositeComponent] = []
-  public var configure: ((ItemConfigurable) -> Void)?
+
+  public var configure: ((ItemConfigurable) -> Void)? {
+    didSet {
+      configureClosureDidChange()
+    }
+  }
+
   public var componentDelegate: Delegate?
   public var componentDataSource: DataSource?
   public var stateCache: StateCache?

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -10,7 +10,6 @@ extension NSCollectionView: UserInterface {
         continue
       }
 
-
       views.append(item.view)
     }
 

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -10,7 +10,15 @@ extension NSCollectionView: UserInterface {
         continue
       }
 
-      views.append(item.view)
+      switch item {
+        case let wrapper as GridWrapper:
+          guard let view = wrapper.wrappedView else {
+            continue
+          }
+          views.append(view)
+        default:
+          views.append(item.view)
+      }
     }
 
     return views

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -11,7 +11,7 @@ extension NSCollectionView: UserInterface {
       }
 
       switch item {
-        case let wrapper as GridWrapper:
+        case let wrapper as Wrappable:
           guard let view = wrapper.wrappedView else {
             continue
           }

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -5,12 +5,13 @@ extension NSCollectionView: UserInterface {
   public var visibleViews: [View] {
     var views = [View]()
 
-    for case let wrapper as GridWrapper in visibleItems() {
-      guard let view = wrapper.wrappedView else {
+    for item in visibleItems() {
+      guard visibleRect.contains(item.view.frame.origin) else {
         continue
       }
 
-      views.append(view)
+
+      views.append(item.view)
     }
 
     return views

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -3,7 +3,17 @@ import Cocoa
 extension NSCollectionView: UserInterface {
 
   public var visibleViews: [View] {
-    return []
+    var views = [View]()
+
+    for case let wrapper as GridWrapper in visibleItems() {
+      guard let view = wrapper.wrappedView else {
+        continue
+      }
+
+      views.append(view)
+    }
+
+    return views
   }
 
   public static var compositeIdentifier: String {

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -2,6 +2,10 @@ import Cocoa
 
 extension NSCollectionView: UserInterface {
 
+  public var visibleViews: [View] {
+    return []
+  }
+
   public static var compositeIdentifier: String {
     return "collection-composite"
   }

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -10,7 +10,15 @@ extension NSCollectionView: UserInterface {
         continue
       }
 
-      views.append(resolveVisibleView(item.view))
+      switch item {
+        case let wrapper as Wrappable:
+          guard let view = wrapper.wrappedView else {
+            continue
+          }
+          views.append(view)
+        default:
+          views.append(item.view)
+      }
     }
 
     return views

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -6,7 +6,7 @@ extension NSCollectionView: UserInterface {
     var views = [View]()
 
     for item in visibleItems() {
-      guard visibleRect.contains(item.view.frame.origin) else {
+      guard visibleRect.intersects(item.view.frame) else {
         continue
       }
 

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -10,15 +10,7 @@ extension NSCollectionView: UserInterface {
         continue
       }
 
-      switch item {
-        case let wrapper as Wrappable:
-          guard let view = wrapper.wrappedView else {
-            continue
-          }
-          views.append(view)
-        default:
-          views.append(item.view)
-      }
+      views.append(resolveVisibleView(item.view))
     }
 
     return views

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -7,11 +7,19 @@ extension NSTableView: UserInterface {
     var views = [View]()
 
     for row in rows.location..<rows.length-rows.location {
-      guard let view = rowView(atRow: row, makeIfNecessary: false) else {
+      guard let resolvedRowView = rowView(atRow: row, makeIfNecessary: false) else {
         continue
       }
 
-      views.append(view)
+      switch resolvedRowView {
+        case let wrapper as Wrappable:
+          guard let view = wrapper.wrappedView else {
+            continue
+          }
+          views.append(view)
+        default:
+          views.append(resolvedRowView)
+      }
     }
 
     return views

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -3,7 +3,18 @@ import Cocoa
 extension NSTableView: UserInterface {
 
   public var visibleViews: [View] {
-    return []
+    let rows = self.rows(in: visibleRect)
+    var views = [View]()
+
+    for row in rows.location..<rows.length-rows.location {
+      guard let view = rowView(atRow: row, makeIfNecessary: false) else {
+        continue
+      }
+
+      views.append(view)
+    }
+
+    return views
   }
 
   public static var compositeIdentifier: String {

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -7,19 +7,11 @@ extension NSTableView: UserInterface {
     var views = [View]()
 
     for row in rows.location..<rows.length-rows.location {
-      guard let resolvedRowView = rowView(atRow: row, makeIfNecessary: false) else {
+      guard let view = rowView(atRow: row, makeIfNecessary: false) else {
         continue
       }
 
-      switch resolvedRowView {
-        case let wrapper as Wrappable:
-          guard let view = wrapper.wrappedView else {
-            continue
-          }
-          views.append(view)
-        default:
-          views.append(resolvedRowView)
-      }
+      views.append(resolveVisibleView(view))
     }
 
     return views

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -2,6 +2,10 @@ import Cocoa
 
 extension NSTableView: UserInterface {
 
+  public var visibleViews: [View] {
+    return []
+  }
+
   public static var compositeIdentifier: String {
     return "list-composite"
   }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD0D1DAEA464009C10FF /* TestParser.swift */; };
 		BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
 		BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */; };
+		BD0AF3521E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */; };
+		BD0AF3531E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */; };
+		BD0AF3541E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */; };
 		BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
 		BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */; };
@@ -383,6 +386,7 @@
 		52CD42791E4477C800187E09 /* PageIndicatorPlacement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageIndicatorPlacement.swift; sourceTree = "<group>"; };
 		BD01BD0D1DAEA464009C10FF /* TestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestParser.swift; sourceTree = "<group>"; };
 		BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListComposite.swift; sourceTree = "<group>"; };
+		BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserInterface+Extensions.swift"; sourceTree = "<group>"; };
 		BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestViewModelExtensions.swift; sourceTree = "<group>"; };
 		BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BD165A361E6EAAA60023AF82 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
@@ -819,6 +823,7 @@
 				BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */,
 				BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */,
 				BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */,
+				BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1486,6 +1491,7 @@
 				BDDCF6E71E4DF92F004B38C4 /* StringConvertible.swift in Sources */,
 				BDAD85C21E3E7032008289AE /* ComponentDelegate.swift in Sources */,
 				BDAD85EF1E3E7032008289AE /* StateCache.swift in Sources */,
+				BD0AF3541E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDDCF6D81E4DF911004B38C4 /* Item.swift in Sources */,
 				BDDCF6E21E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
 				BDB1F8B41E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */,
@@ -1624,6 +1630,7 @@
 				BDAD84BA1E3E701C008289AE /* ListHeaderFooterWrapper.swift in Sources */,
 				BDAD858D1E3E7032008289AE /* Component+Mutation.swift in Sources */,
 				BDAD85991E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */,
+				BD0AF3521E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDAD84DE1E3E701C008289AE /* UICollectionView+UserInterface.swift in Sources */,
 				BDB1F8B31E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */,
 				BDDCF6EA1E4DF936004B38C4 /* Extensions.swift in Sources */,
@@ -1797,6 +1804,7 @@
 				BDDCF6F01E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BDAD85611E3E7032008289AE /* CompositeComponent.swift in Sources */,
 				BDAD851D1E3E7025008289AE /* DataSource+macOS+Extensions.swift in Sources */,
+				BD0AF3531E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDAD858B1E3E7032008289AE /* Component+Core.swift in Sources */,
 				BDAD850A1E3E7025008289AE /* CarouselComponentCell.swift in Sources */,
 				BDAD85C11E3E7032008289AE /* ComponentDelegate.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -275,6 +275,9 @@
 		BDB8D5971E4DFBBA00220BC3 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F71C44076B006EBA49 /* Tailor.framework */; };
 		BDB8D5981E4DFBC300220BC3 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD63FAB1D941A80008E885A /* Tailor.framework */; };
 		BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */; };
+		BDCA3CF31E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
+		BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
+		BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
 		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
 		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
@@ -510,6 +513,7 @@
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDB8D5921E4DFADC00220BC3 /* TestItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestItem.swift; sourceTree = "<group>"; };
 		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
+		BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserInterface.swift; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
 		BDD63FAB1D941A80008E885A /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/tvOS/Tailor.framework; sourceTree = "<group>"; };
 		BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridComposite.swift; sourceTree = "<group>"; };
@@ -1034,6 +1038,7 @@
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
 				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
 				BDB8D5921E4DFADC00220BC3 /* TestItem.swift */,
+				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1585,6 +1590,7 @@
 				BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */,
 				BD10D5271D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
+				BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDD9ABCF1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
@@ -1728,6 +1734,7 @@
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BDA8DAF51DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */,
+				BDCA3CF31E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD45D9951E30A8A000C2D6B2 /* TestInset.swift in Sources */,
 				BDD9ABCB1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 				BDEFF5521DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
@@ -1826,6 +1833,7 @@
 			files = (
 				D58478E71C440645006EBA49 /* TestComponentModel.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
+				BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestCoreComponent.swift in Sources */,

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -95,4 +95,18 @@ class CoreComponentTests: XCTestCase {
     XCTAssertFalse(type(of: genericView) === ListWrapper.self)
     XCTAssertTrue(type(of: genericView) === TestView.self)
   }
+
+  func testComponentConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let component = CarouselComponent(model: ComponentModel(kind: "carousel", span: 0.0, items: items))
+    component.setup(CGSize(width: 100, height: 100))
+
+    var invokeCount = 0
+    component.configure = { view in
+      invokeCount += 1
+    }
+    XCTAssertEqual(invokeCount, 2)
+  }
 }

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -108,7 +108,7 @@ class CoreComponentTests: XCTestCase {
       invokeCount += 1
     }
 
-    /// This should be invoked twice, once for each view.
+    // This should be invoked twice, once for each view.
     XCTAssertEqual(invokeCount, 2)
   }
 
@@ -123,6 +123,8 @@ class CoreComponentTests: XCTestCase {
     component.configure = { _ in
       invokeCount += 1
     }
+
+    // This should be invoked twice, once for each view.
     XCTAssertEqual(invokeCount, 2)
   }
 }

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -96,11 +96,27 @@ class CoreComponentTests: XCTestCase {
     XCTAssertTrue(type(of: genericView) === TestView.self)
   }
 
-  func testComponentConfigurationClosure() {
+  func testCarouselComponentConfigurationClosure() {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
     let component = CarouselComponent(model: ComponentModel(kind: "carousel", span: 0.0, items: items))
+    component.setup(CGSize(width: 100, height: 100))
+
+    var invokeCount = 0
+    component.configure = { view in
+      invokeCount += 1
+    }
+
+    /// This should be invoked twice, once for each view.
+    XCTAssertEqual(invokeCount, 2)
+  }
+
+  func testListComponentConfigurationClosure() {
+    Configuration.register(view: TestView.self, identifier: "test-view")
+
+    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
+    let component = CarouselComponent(model: ComponentModel(kind: "list", items: items))
     component.setup(CGSize(width: 100, height: 100))
 
     var invokeCount = 0

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -104,7 +104,7 @@ class CoreComponentTests: XCTestCase {
     component.setup(CGSize(width: 100, height: 100))
 
     var invokeCount = 0
-    component.configure = { view in
+    component.configure = { _ in
       invokeCount += 1
     }
 
@@ -120,7 +120,7 @@ class CoreComponentTests: XCTestCase {
     component.setup(CGSize(width: 100, height: 100))
 
     var invokeCount = 0
-    component.configure = { view in
+    component.configure = { _ in
       invokeCount += 1
     }
     XCTAssertEqual(invokeCount, 2)

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -22,7 +22,7 @@ class TestUserInterface: XCTestCase {
     let model = ComponentModel(kind: "list", items: items)
     let component = Component(model: model)
     
-    component.setup(CGSize(width: 100, height: 100))
+    component.setup(CGSize(width: 200, height: 200))
 
     XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
   }

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -3,83 +3,56 @@ import XCTest
 
 class TestUserInterface: XCTestCase {
 
-  func testVisibleViewsOnListComponent() {
+  func testEmptyComponent() {
     let model = ComponentModel(kind: "list")
     let component = Component(model: model)
     
     component.setup(CGSize(width: 100, height: 100))
 
-    /// Expect that the user interface returns zero views because the model has no items.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
+  }
 
+  func testVisibleViewsOnListComponent() {
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
       Item(title: "baz")
     ]
+    let model = ComponentModel(kind: "list", items: items)
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
 
-    let expectation = self.expectation(description: "Wait until components has reloaded.")
-
-    component.reloadIfNeeded(items) {
-      /// After the component has reloaded with items, three views should be returned.
-      XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
-      expectation.fulfill()
-    }
-
-    waitForExpectations(timeout: 10.0, handler: nil)
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
   }
 
   func testVisibleViewsOnGridComponent() {
-    let model = ComponentModel(kind: "grid")
-    let component = Component(model: model)
-    
-    component.setup(CGSize(width: 100, height: 100))
-
-    /// Expect that the user interface returns zero views because the model has no items.
-    XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
-
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
       Item(title: "baz")
     ]
+    let model = ComponentModel(kind: "grid", items: items)
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
 
-    let expectation = self.expectation(description: "Wait until components has reloaded.")
-
-    component.reloadIfNeeded(items) {
-      /// After the component has reloaded with items, three views should be returned.
-      XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
-      expectation.fulfill()
-    }
-
-    waitForExpectations(timeout: 10.0, handler: nil)
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
   }
 
   func testVisibleViewsOnCarouselComponent() {
-    let layout = Layout(span: 1)
-    let model = ComponentModel(kind: "carousel", layout: layout)
-    let component = Component(model: model)
-    
-    component.setup(CGSize(width: 100, height: 100))
-
-    /// Expect that the user interface returns zero views because the model has no items.
-    XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
-
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
       Item(title: "baz")
     ]
+    let layout = Layout(span: 1)
+    let model = ComponentModel(kind: "carousel", layout: layout, items: items)
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
 
-    let expectation = self.expectation(description: "Wait until components has reloaded.")
-
-    component.reloadIfNeeded(items) {
-      /// After the component has loaded, only one of the views should be visisble as span
-      /// is set to 1 item per page in the carousel.
-      XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
-      expectation.fulfill()
-    }
-
-    waitForExpectations(timeout: 10.0, handler: nil)
+    /// Expect to only have one visible view as the carousel as a span set to one.
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
   }
 }

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -13,6 +13,7 @@ class TestUserInterface: XCTestCase {
   }
 
   func testVisibleViewsOnListComponent() {
+    Configuration.views.defaultItem = nil
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class TestUserInterface: XCTestCase {
 
-  func testVisibleViews() {
+  func testVisibleViewsOnListComponent() {
     let model = ComponentModel(kind: "list")
     let component = Component(model: model)
     
@@ -23,6 +23,60 @@ class TestUserInterface: XCTestCase {
     component.reloadIfNeeded(items) {
       /// After the component has reloaded with items, three views should be returned.
       XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testVisibleViewsOnGridComponent() {
+    let model = ComponentModel(kind: "grid")
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
+
+    /// Expect that the user interface returns zero views because the model has no items.
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
+
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+
+    let expectation = self.expectation(description: "Wait until components has reloaded.")
+
+    component.reloadIfNeeded(items) {
+      /// After the component has reloaded with items, three views should be returned.
+      XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testVisibleViewsOnCarouselComponent() {
+    let layout = Layout(span: 1)
+    let model = ComponentModel(kind: "carousel", layout: layout)
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
+
+    /// Expect that the user interface returns zero views because the model has no items.
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
+
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+
+    let expectation = self.expectation(description: "Wait until components has reloaded.")
+
+    component.reloadIfNeeded(items) {
+      /// After the component has loaded, only one of the views should be visisble as span
+      /// is set to 1 item per page in the carousel.
+      XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
       expectation.fulfill()
     }
 

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -54,5 +54,10 @@ class TestUserInterface: XCTestCase {
 
     /// Expect to only have one visible view as the carousel as a span set to one.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
+
+    component.view.contentOffset.x = 50
+
+    /// Expect two views to be visible on screen because the x offset is half of a view.
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 2)
   }
 }

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -51,13 +51,12 @@ class TestUserInterface: XCTestCase {
     let component = Component(model: model)
     
     component.setup(CGSize(width: 100, height: 100))
-
-    /// Expect to only have one visible view as the carousel as a span set to one.
+    // Expect to only have one visible view as the carousel as a span set to one.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
 
     component.view.contentOffset.x = 50
 
-    /// Expect two views to be visible on screen because the x offset is half of a view.
+    // Expect two views to be visible on screen because the x offset is half of a view.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 2)
   }
 }

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -56,6 +56,7 @@ class TestUserInterface: XCTestCase {
     XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
 
     component.view.contentOffset.x = 50
+    // If we don't call layoutIfNeeded, then `visibleCells` won't update correctly.
     component.collectionView?.layoutIfNeeded()
 
     // Expect two views to be visible on screen because the x offset is half of a view.

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -1,0 +1,31 @@
+@testable import Spots
+import XCTest
+
+class TestUserInterface: XCTestCase {
+
+  func testVisibleViews() {
+    let model = ComponentModel(kind: "list")
+    let component = Component(model: model)
+    
+    component.setup(CGSize(width: 100, height: 100))
+
+    /// Expect that the user interface returns zero views because the model has no items.
+    XCTAssertEqual(component.userInterface?.visibleViews.count, 0)
+
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+
+    let expectation = self.expectation(description: "Wait until components has reloaded.")
+
+    component.reloadIfNeeded(items) {
+      /// After the component has reloaded with items, three views should be returned.
+      XCTAssertEqual(component.userInterface?.visibleViews.count, 3)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+}

--- a/SpotsTests/Shared/TestUserInterface.swift
+++ b/SpotsTests/Shared/TestUserInterface.swift
@@ -56,6 +56,7 @@ class TestUserInterface: XCTestCase {
     XCTAssertEqual(component.userInterface?.visibleViews.count, 1)
 
     component.view.contentOffset.x = 50
+    component.collectionView?.layoutIfNeeded()
 
     // Expect two views to be visible on screen because the x offset is half of a view.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 2)

--- a/SpotsTests/iOS/TestCarouselSpot.swift
+++ b/SpotsTests/iOS/TestCarouselSpot.swift
@@ -425,18 +425,4 @@ class CarouselComponentTests: XCTestCase {
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
-
-  func testSpotConfigurationClosure() {
-    Configuration.register(view: TestView.self, identifier: "test-view")
-
-    let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let component = CarouselComponent(model: ComponentModel(kind: "carousel", span: 0.0, items: items))
-    component.setup(CGSize(width: 100, height: 100))
-
-    var invokeCount = 0
-    component.configure = { view in
-      invokeCount += 1
-    }
-    XCTAssertEqual(invokeCount, 2)
-  }
 }


### PR DESCRIPTION
This PR adds some extra superpowers to `UserInterface` by adding `visibleViews` to `macOS`.
Now you can call that method on any component to get all the visible views for that component.

It also implements the configure closure on macOS, which in turns solves this issue: https://github.com/hyperoslo/Spots/issues/463

#### Gist
- [x] Add new test file for `UserInterface`.
- [x] Fix issue with configuration closure on macOS
- [x] Improve tests for configuration closure.