### PR TITLE
Rename Controller to SpotsController

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Data source and delegate setup is handled by **Spots**, so there is no need for 
 * [Usage](#usage)
 * [View models in the Cloud](#view-models-in-the-cloud)
 * [Programmatic approach](#programmatic-approach)
-* [Controller](#componentscontroller)
+* [SpotsController](#spotscontroller)
 * [Delegates](#delegates)
   * [ComponentDelegate](#componentdelegate)
   * [RefreshDelegate](#refreshdelegate)
@@ -81,7 +81,7 @@ Data source and delegate setup is handled by **Spots**, so there is no need for 
 - View based caching for controllers, table and collection views.
 - Supports displaying multiple collections, tables and regular views in the same container.
 - Features both infinity scrolling and pull to refresh (on iOS), all you have to do is to
-setup delegates that conform to the public protocols on `Controller`.
+setup delegates that conform to the public protocols on `SpotsController`.
 - No need to implement your own data source, every `Component` has its
 own set of `Item`’s.
 which is maintained internally and is there at your disposable if you decide to
@@ -111,13 +111,13 @@ Apple's definition of a universal applications is iPhone and iPad. Spots takes t
 
 ## Why JSON?
 
-JSON works great as a common transport language, it is platform agnostic and it is something that developers are already using regularly when building application that fetch data from an external resource. **Spots** uses JSON internally to save a snapshot of the view state to disk, the only thing that you have to do is to give the **Controller** a cache key and call save whenever you have performed your update.
+JSON works great as a common transport language, it is platform agnostic and it is something that developers are already using regularly when building application that fetch data from an external resource. **Spots** uses JSON internally to save a snapshot of the view state to disk, the only thing that you have to do is to give the **SpotsController** a cache key and call save whenever you have performed your update.
 
 So what if I don't have a backend that supports **Spots** view models? Not to worry, you can set up **Spots** programmatically and still use all the other advantages of the framework.
 
 ## View state caching
 
-As mentioned above, **Spots** features a view state cache. Instead of saving all your data in a database somewhere and perform queries every time to initiate a view controller, we went with a different and much simpler approach. If a **Controller** has a cache key and you call `save`, internally it will encode all underlaying **CoreComponent** objects and its children into a JSON file and store that to disk. The uniqueness of the file comes from the cache key, think of this like your screen identifier. The next time you construct a **Controller** with that cache key, it will try to load that from disk and display it the exact same way as it was before saving. The main benefit here is that you don’t have to worry about your object changing by updating to future versions of **Spots**.
+As mentioned above, **Spots** features a view state cache. Instead of saving all your data in a database somewhere and perform queries every time to initiate a view controller, we went with a different and much simpler approach. If a **SpotsController** has a cache key and you call `save`, internally it will encode all underlaying **CoreComponent** objects and its children into a JSON file and store that to disk. The uniqueness of the file comes from the cache key, think of this like your screen identifier. The next time you construct a **SpotsController** with that cache key, it will try to load that from disk and display it the exact same way as it was before saving. The main benefit here is that you don’t have to worry about your object changing by updating to future versions of **Spots**.
 
 **Component** also supports view state caching, this gives you fine-grained control over the information that you want cache.
 
@@ -143,14 +143,14 @@ See [Installation](#installation) for how to enable live editing using CocoaPods
 
 ## How does it work?
 
-At the top level of **Spots**, you have the **Controller** which is the replacement for your view controller.
+At the top level of **Spots**, you have the **SpotsController** which is the replacement for your view controller.
 
-Inside of the **Controller**, you have a **SpotsScrollView** that handles the linear layout of the components that you add to your data source. It is also in charge of giving the user a unified scrolling experience. Scrolling is disabled on all underlaying components except for components that have horizontal scrolling.
+Inside of the **SpotsController**, you have a **SpotsScrollView** that handles the linear layout of the components that you add to your data source. It is also in charge of giving the user a unified scrolling experience. Scrolling is disabled on all underlaying components except for components that have horizontal scrolling.
 
 So how does scrolling work? Whenever a user scrolls, the **SpotsScrollView** computes the offset and size of its children. By using this technique you can easily create screens that contain lists, grids and carousels with a scrolling experience as smooth as proverbial butter. By dynamically changing the size and offset of the children, **SpotsScrollView** also ensures that reusable views are allocated and deallocated like you would expect them to.
 **SpotsScrollView** uses KVO on any view that gets added so if one component changes height or position, the entire layout will invalidate itself and redraw it like it was intended.
 
-**Controller** supports multiple **Component**'s, each represent their own UI container and hold their own data source. Components all share the same data model called `ComponentModel`, it includes layout, interaction and view model data. **Component** gets its super-powers from protocol extensions, powers like mutation, layout processing and convenience methods for accessing model information.
+**SpotsController** supports multiple **Component**'s, each represent their own UI container and hold their own data source. Components all share the same data model called `ComponentModel`, it includes layout, interaction and view model data. **Component** gets its super-powers from protocol extensions, powers like mutation, layout processing and convenience methods for accessing model information.
 
 ## Working with views
 
@@ -227,19 +227,19 @@ let component = ComponentModel(
 
 It is very common that you need to modify your data source and tell your UI component to either insert, update or delete depending on the action that you performed. This process can be cumbersome, so to help you out, **Spots** has some great convenience methods to help you with this process.
 
-On **Controller** you have simple methods like `reload(withAnimation, completion)` that tells all the **CoreComponent** objects to reload.
+On **SpotsController** you have simple methods like `reload(withAnimation, completion)` that tells all the **CoreComponent** objects to reload.
 
-You can reload **Controller** using a collection of **ComponentModel**’s. Internally it will perform a diffing process to pinpoint what changed, in this process it cascades down from component level to item level, and checks all the moving parts, to perform the most appropriate update operation depending on the change. At item level, it will check if the items size changed, if not it will scale down to only run the `configure` method on the view that was affected. This is what we call hard and soft updates, it will reduce the amount of *blinking* that you can normally see in iOS.
+You can reload **SpotsController** using a collection of **ComponentModel**’s. Internally it will perform a diffing process to pinpoint what changed, in this process it cascades down from component level to item level, and checks all the moving parts, to perform the most appropriate update operation depending on the change. At item level, it will check if the items size changed, if not it will scale down to only run the `configure` method on the view that was affected. This is what we call hard and soft updates, it will reduce the amount of *blinking* that you can normally see in iOS.
 
-A **Controller** can also be reloaded using JSON. It behaves a bit differently than `reloadIfNeeded(components)` as it will create new components and diff them towards each other to find out if something changed. If something changed, it will simply replace the old objects with the new ones.
+A **SpotsController** can also be reloaded using JSON. It behaves a bit differently than `reloadIfNeeded(components)` as it will create new components and diff them towards each other to find out if something changed. If something changed, it will simply replace the old objects with the new ones.
 
 The difference between `reload` and `reloadIfNeeded` methods is that they will only run if change is needed, just like the naming implies.
 
-If you need more fine-grained control by pinpointing an individual component, we got you covered on this as well. **Controller** has an update method that takes the component index as its first argument, followed by an animation label to specify which animation to use when doing the update.
+If you need more fine-grained control by pinpointing an individual component, we got you covered on this as well. **SpotsController** has an update method that takes the component index as its first argument, followed by an animation label to specify which animation to use when doing the update.
 The remaining arguments are one mutation closure where you get the **CoreComponent** object and can perform your updates, and finally one completion closure that will run when your update is performed both on the data source and the UI component.
 This method has a corresponding method called `updateIfNeeded`, which applies the update if needed.
 
-You can also `append` `prepend`, `insert`, `update` or `delete` with a series to similar methods that are publicly available on **Controller**.
+You can also `append` `prepend`, `insert`, `update` or `delete` with a series to similar methods that are publicly available on **SpotsController**.
 
 All methods take an `Item` as their first argument, the second is the index of the **CoreComponent** object that you want to update. Just like `reload` and `update`, it also has an animation label to give you control over what animation should be used. As an added bonus, these methods also work with multiple items, so instead of passing just one item, you can pass a collection of items that you want to `append`, `prepend` etc.
 
@@ -290,7 +290,7 @@ let json = Layout(
 
 ### View models in the Cloud
 ```swift
-let controller = Controller(json)
+let controller = SpotsController(json)
 navigationController?.pushViewController(controller, animated: true)
 ```
 
@@ -309,13 +309,13 @@ let contactModel = ComponentModel(
   ]
 )
 let component = Component(model: contactModel)
-let controller = Controller(components: [component])
+let controller = SpotsController(components: [component])
 
 navigationController?.pushViewController(controller, animated: true)
 ```
 
-## Controller
-The `Controller` inherits from `UIViewController` and `NSViewController` but it sports some core features that makes your everyday mundane tasks a thing of the past. `Controller` has four different delegates
+## SpotsController
+The `SpotsController` inherits from `UIViewController` and `NSViewController` but it sports some core features that makes your everyday mundane tasks a thing of the past. `SpotsController` has four different delegates
 
 ## Delegates
 
@@ -542,7 +542,7 @@ end
 ## Dependencies
 
 - **[Cache](https://github.com/hyperoslo/Cache)**
-Used for `ComponentModel` and `Item` caching when initializing a `Controller` or `CoreComponent` object with a cache key.
+Used for `ComponentModel` and `Item` caching when initializing a `SpotsController` or `CoreComponent` object with a cache key.
 - **[Tailor](https://github.com/zenangst/Tailor)**
 To seamlessly map JSON to both `ComponentModel` and `Item`.
 

--- a/RxSpots/RxSpotsDelegate.swift
+++ b/RxSpots/RxSpotsDelegate.swift
@@ -24,13 +24,13 @@ public final class RxComponentDelegate: DelegateProxy, DelegateProxyType, Compon
   public let didEndDisplayingView: Observable<(Component, ComponentView, Item)>
 
   public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
-    return (object as? Component)?.delegate ?? (object as? Controller)?.delegate
+    return (object as? Component)?.delegate ?? (object as? SpotsController)?.delegate
   }
 
   public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
     if let component = object as? Component {
       component.delegate = delegate as? ComponentDelegate
-    } else if let controller = object as? Controller {
+    } else if let controller = object as? SpotsController {
       controller.delegate = delegate as? ComponentDelegate
     }
   }

--- a/RxSpotsTests/RxSpotsDelegateTests.swift
+++ b/RxSpotsTests/RxSpotsDelegateTests.swift
@@ -10,7 +10,7 @@ class RxComponentDelegateTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    let controller = Controller()
+    let controller = SpotsController()
 
     delegateProxy = RxComponentDelegate(parentObject: controller)
   }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -77,8 +77,8 @@ extension SpotsProtocol {
         strongSelf.cache()
         Dispatch.main {
           strongSelf.scrollView.layoutViews()
-          if let controller = self as? Controller {
-            Controller.componentsDidReloadComponentModels?(controller)
+          if let controller = self as? SpotsController {
+            SpotsController.componentsDidReloadComponentModels?(controller)
           }
           completion?()
         }
@@ -91,8 +91,8 @@ extension SpotsProtocol {
         Dispatch.main {
           strongSelf.scrollView.layoutSubviews()
           strongSelf.cache()
-          if let controller = self as? Controller {
-            Controller.componentsDidReloadComponentModels?(controller)
+          if let controller = self as? SpotsController {
+            SpotsController.componentsDidReloadComponentModels?(controller)
           }
 
           completion?()
@@ -449,8 +449,8 @@ extension SpotsProtocol {
       let oldComponentModels = strongSelf.components.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
-        if let controller = self as? Controller {
-          Controller.componentsDidReloadComponentModels?(controller)
+        if let controller = self as? SpotsController {
+          SpotsController.componentsDidReloadComponentModels?(controller)
         }
         strongSelf.cache()
         completion?()
@@ -490,8 +490,8 @@ extension SpotsProtocol {
         newSpots[$0.offset].view.contentOffset = $0.element
       }
 
-      if let controller = self as? Controller {
-        Controller.componentsDidReloadComponentModels?(controller)
+      if let controller = self as? SpotsController {
+        SpotsController.componentsDidReloadComponentModels?(controller)
       }
 
       strongSelf.scrollView.layoutSubviews()
@@ -521,8 +521,8 @@ extension SpotsProtocol {
       strongSelf.setupComponents(animated: animated)
 
       completion?()
-      if let controller = strongSelf as? Controller {
-        Controller.componentsDidReloadComponentModels?(controller)
+      if let controller = strongSelf as? SpotsController {
+        SpotsController.componentsDidReloadComponentModels?(controller)
       }
       strongSelf.scrollView.layoutSubviews()
     }

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -9,7 +9,7 @@ import Cache
 public protocol SpotsProtocol: class {
 
   /// A closure that is called when the controller is reloaded with components
-  static var componentsDidReloadComponentModels: ((_ controller: Controller) -> Void)? { get set }
+  static var componentsDidReloadComponentModels: ((_ controller: SpotsController) -> Void)? { get set }
   /// A StateCache object
   var stateCache: StateCache? { get set }
   /// The internal SpotsScrollView

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Cache
 
 /// A controller powered by components.
-open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, UIScrollViewDelegate {
+open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDelegate, UIScrollViewDelegate {
 
   open var contentView: View {
     return view
@@ -12,7 +12,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
   public var focusedItemIndex: Int?
 
   /// A closure that is called when the controller is reloaded with components
-  public static var componentsDidReloadComponentModels: ((Controller) -> Void)?
+  public static var componentsDidReloadComponentModels: ((SpotsController) -> Void)?
 
   /// A notification enum
   ///
@@ -216,7 +216,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 
     setupComponents()
 
-    Controller.configure?(scrollView)
+    SpotsController.configure?(scrollView)
   }
 
   /// Notifies the component controller that its view is about to be added to a view hierarchy.
@@ -329,7 +329,7 @@ open class Controller: UIViewController, SpotsProtocol, ComponentFocusDelegate, 
 // MARK: - Private methods
 
 /// An extension with private methods on Controller
-extension Controller {
+extension SpotsController {
 
   /// This method is triggered in `delegate.didSet`
   fileprivate func componentsDelegateDidChange() {

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -3,7 +3,7 @@ import UIKit
 /**
  A Controller extension to handle scrollViewDidScroll
  */
-extension Controller {
+extension SpotsController {
 
   /// Tells the delegate when the user scrolls the content view within the receiver.
   ///

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -4,10 +4,10 @@ public enum ControllerBackground {
   case regular, dynamic
 }
 
-open class Controller: NSViewController, SpotsProtocol {
+open class SpotsController: NSViewController, SpotsProtocol {
 
   /// A closure that is called when the controller is reloaded with components
-  public static var componentsDidReloadComponentModels: ((Controller) -> Void)?
+  public static var componentsDidReloadComponentModels: ((SpotsController) -> Void)?
 
   open static var configure: ((_ container: SpotsScrollView) -> Void)?
 
@@ -66,7 +66,7 @@ open class Controller: NSViewController, SpotsProtocol {
     self.backgroundType = backgroundType
     super.init(nibName: nil, bundle: nil)!
 
-    NotificationCenter.default.addObserver(self, selector: #selector(Controller.scrollViewDidScroll(_:)), name: NSNotification.Name.NSScrollViewDidLiveScroll, object: scrollView)
+    NotificationCenter.default.addObserver(self, selector: #selector(SpotsController.scrollViewDidScroll(_:)), name: NSNotification.Name.NSScrollViewDidLiveScroll, object: scrollView)
 
     NotificationCenter.default.addObserver(self, selector: #selector(windowDidResize(_:)), name: NSNotification.Name.NSWindowDidResize, object: nil)
 
@@ -169,7 +169,7 @@ open class Controller: NSViewController, SpotsProtocol {
     scrollView.hasVerticalScroller = true
     scrollView.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
 
-    Controller.configure?(scrollView)
+    SpotsController.configure?(scrollView)
   }
 
   open override func viewWillAppear() {

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -83,8 +83,8 @@
 		BDAD84A71E3E701C008289AE /* CarouselComponentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84821E3E701B008289AE /* CarouselComponentCell.swift */; };
 		BDAD84A81E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
 		BDAD84A91E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
-		BDAD84AA1E3E701C008289AE /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* Controller.swift */; };
-		BDAD84AB1E3E701C008289AE /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* Controller.swift */; };
+		BDAD84AA1E3E701C008289AE /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* SpotsController.swift */; };
+		BDAD84AB1E3E701C008289AE /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* SpotsController.swift */; };
 		BDAD84AC1E3E701C008289AE /* GridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84851E3E701B008289AE /* GridableLayout.swift */; };
 		BDAD84AD1E3E701C008289AE /* GridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84851E3E701B008289AE /* GridableLayout.swift */; };
 		BDAD84AE1E3E701C008289AE /* GridComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84861E3E701B008289AE /* GridComposite.swift */; };
@@ -111,8 +111,8 @@
 		BDAD84C91E3E701C008289AE /* SpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84931E3E701C008289AE /* SpotsScrollView.swift */; };
 		BDAD84CC1E3E701C008289AE /* Composable+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84961E3E701C008289AE /* Composable+iOS.swift */; };
 		BDAD84CD1E3E701C008289AE /* Composable+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84961E3E701C008289AE /* Composable+iOS.swift */; };
-		BDAD84CE1E3E701C008289AE /* Controller+UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84971E3E701C008289AE /* Controller+UIScrollViewDelegate.swift */; };
-		BDAD84CF1E3E701C008289AE /* Controller+UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84971E3E701C008289AE /* Controller+UIScrollViewDelegate.swift */; };
+		BDAD84CE1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84971E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift */; };
+		BDAD84CF1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84971E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift */; };
 		BDAD84D01E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */; };
 		BDAD84D11E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */; };
 		BDAD84D21E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */; };
@@ -129,7 +129,7 @@
 		BDAD84E31E3E701C008289AE /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84A11E3E701C008289AE /* UIViewController+Extensions.swift */; };
 		BDAD850A1E3E7025008289AE /* CarouselComponentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84E71E3E7025008289AE /* CarouselComponentCell.swift */; };
 		BDAD850B1E3E7025008289AE /* CollectionViewLeftLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84E81E3E7025008289AE /* CollectionViewLeftLayout.swift */; };
-		BDAD850C1E3E7025008289AE /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84E91E3E7025008289AE /* Controller.swift */; };
+		BDAD850C1E3E7025008289AE /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84E91E3E7025008289AE /* SpotsController.swift */; };
 		BDAD850D1E3E7025008289AE /* GridComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84EA1E3E7025008289AE /* GridComposite.swift */; };
 		BDAD850F1E3E7025008289AE /* GridComponentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84EC1E3E7025008289AE /* GridComponentCell.swift */; };
 		BDAD85101E3E7025008289AE /* GridComponentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84ED1E3E7025008289AE /* GridComponentItem.swift */; };
@@ -281,9 +281,9 @@
 		BDCA3CF31E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
 		BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
 		BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
-		BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
-		BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
-		BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestController.swift */; };
+		BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */; };
+		BDCFCD431DCA7EFF0047E84C /* TestSpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */; };
+		BDCFCD441DCA7F830047E84C /* TestSpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */; };
 		BDD63FAC1D941A80008E885A /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD63FAB1D941A80008E885A /* Tailor.framework */; };
 		BDD9ABCB1DB533CE005D8C04 /* TestGridComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */; };
 		BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */; };
@@ -425,7 +425,7 @@
 		BDAD84801E3E701B008289AE /* CarouselComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselComposite.swift; sourceTree = "<group>"; };
 		BDAD84821E3E701B008289AE /* CarouselComponentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselComponentCell.swift; sourceTree = "<group>"; };
 		BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpotHeader.swift; sourceTree = "<group>"; };
-		BDAD84841E3E701B008289AE /* Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Controller.swift; sourceTree = "<group>"; };
+		BDAD84841E3E701B008289AE /* SpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SpotsController.swift; sourceTree = "<group>"; };
 		BDAD84851E3E701B008289AE /* GridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridableLayout.swift; sourceTree = "<group>"; };
 		BDAD84861E3E701B008289AE /* GridComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridComposite.swift; sourceTree = "<group>"; };
 		BDAD84871E3E701C008289AE /* GridHeaderFooterWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridHeaderFooterWrapper.swift; sourceTree = "<group>"; };
@@ -439,7 +439,7 @@
 		BDAD84921E3E701C008289AE /* SpotsContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsContentView.swift; sourceTree = "<group>"; };
 		BDAD84931E3E701C008289AE /* SpotsScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsScrollView.swift; sourceTree = "<group>"; };
 		BDAD84961E3E701C008289AE /* Composable+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Composable+iOS.swift"; sourceTree = "<group>"; };
-		BDAD84971E3E701C008289AE /* Controller+UIScrollViewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Controller+UIScrollViewDelegate.swift"; sourceTree = "<group>"; };
+		BDAD84971E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+UIScrollViewDelegate.swift"; sourceTree = "<group>"; };
 		BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataSource+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD849B1E3E701C008289AE /* Inset+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Inset+iOS.swift"; sourceTree = "<group>"; };
@@ -449,7 +449,7 @@
 		BDAD84A11E3E701C008289AE /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD84E71E3E7025008289AE /* CarouselComponentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselComponentCell.swift; sourceTree = "<group>"; };
 		BDAD84E81E3E7025008289AE /* CollectionViewLeftLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewLeftLayout.swift; sourceTree = "<group>"; };
-		BDAD84E91E3E7025008289AE /* Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
+		BDAD84E91E3E7025008289AE /* SpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsController.swift; sourceTree = "<group>"; };
 		BDAD84EA1E3E7025008289AE /* GridComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GridComposite.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BDAD84EC1E3E7025008289AE /* GridComponentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GridComponentCell.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BDAD84ED1E3E7025008289AE /* GridComponentItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GridComponentItem.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -518,7 +518,7 @@
 		BDB8D5921E4DFADC00220BC3 /* TestItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestItem.swift; sourceTree = "<group>"; };
 		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
 		BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserInterface.swift; sourceTree = "<group>"; };
-		BDCFCD401DCA7EFF0047E84C /* TestController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
+		BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsController.swift; sourceTree = "<group>"; };
 		BDD63FAB1D941A80008E885A /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/tvOS/Tailor.framework; sourceTree = "<group>"; };
 		BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridComposite.swift; sourceTree = "<group>"; };
 		BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCarouselComposite.swift; sourceTree = "<group>"; };
@@ -659,22 +659,22 @@
 		BDAD847F1E3E701B008289AE /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				BDAD84801E3E701B008289AE /* CarouselComposite.swift */,
 				BDAD84821E3E701B008289AE /* CarouselComponentCell.swift */,
+				BDAD84801E3E701B008289AE /* CarouselComposite.swift */,
 				BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */,
-				BDAD84841E3E701B008289AE /* Controller.swift */,
+				BD24030B1E4B981A005BAA19 /* Component.swift */,
 				BDAD84851E3E701B008289AE /* GridableLayout.swift */,
+				BDAD84891E3E701C008289AE /* GridComponentCell.swift */,
 				BDAD84861E3E701B008289AE /* GridComposite.swift */,
 				BDAD84871E3E701C008289AE /* GridHeaderFooterWrapper.swift */,
-				BDAD84891E3E701C008289AE /* GridComponentCell.swift */,
 				BDAD848A1E3E701C008289AE /* GridWrapper.swift */,
+				BDAD848E1E3E701C008289AE /* ListComponentCell.swift */,
 				BDAD848B1E3E701C008289AE /* ListComposite.swift */,
 				BDAD848C1E3E701C008289AE /* ListHeaderFooterWrapper.swift */,
-				BDAD848E1E3E701C008289AE /* ListComponentCell.swift */,
 				BDAD848F1E3E701C008289AE /* ListWrapper.swift */,
 				BDAD84911E3E701C008289AE /* RowComponentCell.swift */,
-				BD24030B1E4B981A005BAA19 /* Component.swift */,
 				BDAD84921E3E701C008289AE /* SpotsContentView.swift */,
+				BDAD84841E3E701B008289AE /* SpotsController.swift */,
 				BDAD84931E3E701C008289AE /* SpotsScrollView.swift */,
 			);
 			path = Classes;
@@ -688,7 +688,7 @@
 				BD9ECEC61E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift */,
 				BD9ECEC31E6EC8B8003E4388 /* Component+iOS+List.swift */,
 				BDAD84961E3E701C008289AE /* Composable+iOS.swift */,
-				BDAD84971E3E701C008289AE /* Controller+UIScrollViewDelegate.swift */,
+				BDAD84971E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift */,
 				BDB1F8B21E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift */,
 				BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */,
 				BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */,
@@ -718,21 +718,21 @@
 			children = (
 				BDAD84E71E3E7025008289AE /* CarouselComponentCell.swift */,
 				BDAD84E81E3E7025008289AE /* CollectionViewLeftLayout.swift */,
-				BDAD84E91E3E7025008289AE /* Controller.swift */,
-				BDAD84EA1E3E7025008289AE /* GridComposite.swift */,
+				BD2403101E4B9A02005BAA19 /* Component.swift */,
+				BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */,
 				BDAD84EC1E3E7025008289AE /* GridComponentCell.swift */,
 				BDAD84ED1E3E7025008289AE /* GridComponentItem.swift */,
+				BDAD84EA1E3E7025008289AE /* GridComposite.swift */,
 				BDAD84EE1E3E7025008289AE /* GridWrapper.swift */,
-				BDAD84EF1E3E7025008289AE /* ListComposite.swift */,
 				BDAD84F11E3E7025008289AE /* ListComponentCell.swift */,
 				BDAD84F21E3E7025008289AE /* ListComponentItem.swift */,
+				BDAD84EF1E3E7025008289AE /* ListComposite.swift */,
 				BDAD84F31E3E7025008289AE /* ListWrapper.swift */,
 				BDAD84F41E3E7025008289AE /* NoScrollView.swift */,
 				BDAD84F61E3E7025008289AE /* RowComponentItem.swift */,
-				BD2403101E4B9A02005BAA19 /* Component.swift */,
 				BDAD84F71E3E7025008289AE /* SpotsContentView.swift */,
+				BDAD84E91E3E7025008289AE /* SpotsController.swift */,
 				BDAD84F81E3E7025008289AE /* SpotsScrollView.swift */,
-				BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1035,7 +1035,7 @@
 				BD677E8E1DC65D63006D1654 /* Helpers.swift */,
 				D584782B1C43FF34006EBA49 /* TestComponentModel.swift */,
 				BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */,
-				BDCFCD401DCA7EFF0047E84C /* TestController.swift */,
+				BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */,
 				BD45D9861E30906300C2D6B2 /* TestLayout.swift */,
 				BD01BD0D1DAEA464009C10FF /* TestParser.swift */,
 				BD677E841DC616B2006D1654 /* TestCoreComponent.swift */,
@@ -1495,7 +1495,7 @@
 				BDDCF6D81E4DF911004B38C4 /* Item.swift in Sources */,
 				BDDCF6E21E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
 				BDB1F8B41E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */,
-				BDAD84AB1E3E701C008289AE /* Controller.swift in Sources */,
+				BDAD84AB1E3E701C008289AE /* SpotsController.swift in Sources */,
 				BDAD84C91E3E701C008289AE /* SpotsScrollView.swift in Sources */,
 				BD9ECEC81E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift in Sources */,
 				BDAD85E61E3E7032008289AE /* Layout.swift in Sources */,
@@ -1518,7 +1518,7 @@
 				52CD427C1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
 				BDAD85891E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BDAD84C71E3E701C008289AE /* SpotsContentView.swift in Sources */,
-				BDAD84CF1E3E701C008289AE /* Controller+UIScrollViewDelegate.swift in Sources */,
+				BDAD84CF1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */,
 				BDDCF6DD1E4DF91F004B38C4 /* Indexable.swift in Sources */,
 				BDAD85E91E3E7032008289AE /* Parser.swift in Sources */,
 				BDAD859E1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */,
@@ -1580,7 +1580,7 @@
 				BD43459C1E35EB7E0032EB3E /* TestInteraction.swift in Sources */,
 				BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BD45D9891E30906300C2D6B2 /* TestLayout.swift in Sources */,
-				BDCFCD431DCA7EFF0047E84C /* TestController.swift in Sources */,
+				BDCFCD431DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponentModel.swift in Sources */,
 				BD42CA861E4C9B2600A86E3B /* TestSpot.swift in Sources */,
@@ -1685,7 +1685,7 @@
 				BDAD85DE1E3E7032008289AE /* Inset.swift in Sources */,
 				BDAD84A61E3E701C008289AE /* CarouselComponentCell.swift in Sources */,
 				BDDCF6E51E4DF92F004B38C4 /* StringConvertible.swift in Sources */,
-				BDAD84CE1E3E701C008289AE /* Controller+UIScrollViewDelegate.swift in Sources */,
+				BDAD84CE1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */,
 				BDDCF6DB1E4DF91F004B38C4 /* Indexable.swift in Sources */,
 				BDAD84B81E3E701C008289AE /* ListComposite.swift in Sources */,
 				BDAD85871E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
@@ -1696,7 +1696,7 @@
 				BDDCF6EF1E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BD9ECEBE1E6EC8A5003E4388 /* Component+iOS+Carousel.swift in Sources */,
 				BDAD85C91E3E7032008289AE /* UserInterface.swift in Sources */,
-				BDAD84AA1E3E701C008289AE /* Controller.swift in Sources */,
+				BDAD84AA1E3E701C008289AE /* SpotsController.swift in Sources */,
 				BDAD85CF1E3E7032008289AE /* Wrappable.swift in Sources */,
 				BDAD84B01E3E701C008289AE /* GridHeaderFooterWrapper.swift in Sources */,
 				BDB1F8AF1E5D91BE0064F64B /* ComponentHorizontallyScrollable.swift in Sources */,
@@ -1737,7 +1737,7 @@
 				BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */,
 				D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
-				BDCFCD441DCA7F830047E84C /* TestController.swift in Sources */,
+				BDCFCD441DCA7F830047E84C /* TestSpotsController.swift in Sources */,
 				BDD9ABCE1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BDA8DAF51DCF3AED00A4A8DD /* TestRowSpot.swift in Sources */,
 				BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */,
@@ -1818,7 +1818,7 @@
 				BDAD85941E3E7032008289AE /* ComponentDelegate+Extensions.swift in Sources */,
 				BDAD850B1E3E7025008289AE /* CollectionViewLeftLayout.swift in Sources */,
 				BDAD85761E3E7032008289AE /* RegistryType.swift in Sources */,
-				BDAD850C1E3E7025008289AE /* Controller.swift in Sources */,
+				BDAD850C1E3E7025008289AE /* SpotsController.swift in Sources */,
 				BDAD85D31E3E7032008289AE /* ComponentModel.swift in Sources */,
 				BDDCF6EB1E4DF936004B38C4 /* Extensions.swift in Sources */,
 				BDAD85911E3E7032008289AE /* ItemConfigurable+Extensions.swift in Sources */,
@@ -1845,7 +1845,7 @@
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestCoreComponent.swift in Sources */,
-				BDCFCD421DCA7EFF0047E84C /* TestController.swift in Sources */,
+				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,
 				BDFC474F1E747B2B008700BF /* TestGridWrapper.swift in Sources */,
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,

--- a/SpotsTests/Shared/Helpers.swift
+++ b/SpotsTests/Shared/Helpers.swift
@@ -20,7 +20,7 @@ extension Meta: Mappable {
   }
 }
 
-extension Controller {
+extension SpotsController {
 
   func prepareController() {
     preloadView()

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -224,7 +224,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let controller = Controller(components: Parser.parse(initialComponentModels))
+    let controller = SpotsController(components: Parser.parse(initialComponentModels))
     controller.prepareController()
     controller.view.layoutIfNeeded()
 
@@ -430,7 +430,7 @@ class CompositionTests: XCTestCase {
 
   func testReloadWithComponentModelsUsingCompositionTriggeringNewComponent() {
     let initialComponentModels: [ComponentModel] = []
-    let controller = Controller(components: Parser.parse(initialComponentModels))
+    let controller = SpotsController(components: Parser.parse(initialComponentModels))
     controller.prepareController()
     controller.view.layoutIfNeeded()
 
@@ -676,7 +676,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let controller = Controller(components: Parser.parse(initialComponentModels))
+    let controller = SpotsController(components: Parser.parse(initialComponentModels))
     controller.prepareController()
     controller.view.layoutIfNeeded()
 
@@ -1011,7 +1011,7 @@ class CompositionTests: XCTestCase {
       )
     ]
 
-    let controller = Controller(components: Parser.parse(initialComponentModels))
+    let controller = SpotsController(components: Parser.parse(initialComponentModels))
     controller.prepareController()
     controller.view.layoutIfNeeded()
 

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -29,7 +29,7 @@ class CoreComponentTests: XCTestCase {
   }
 
   func testAppendingMultipleItemsToSpotInController() {
-    let controller = Controller(components: [ListComponent(model: ComponentModel(title: "ComponentModel", kind: "list", span: 1.0))])
+    let controller = SpotsController(components: [ListComponent(model: ComponentModel(title: "ComponentModel", kind: "list", span: 1.0))])
     controller.prepareController()
     var items: [Item] = []
 

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -2,12 +2,12 @@
 import Foundation
 import XCTest
 
-class ControllerTests: XCTestCase {
+class SpotsControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
     let model = ComponentModel(title: "ComponentModel", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
 
     XCTAssertEqual(controller.components.first, listComponent)
@@ -16,7 +16,7 @@ class ControllerTests: XCTestCase {
   func testUpdateSpotAtIndex() {
     let model = ComponentModel(title: "ComponentModel", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
     let items = [Item(title: "item1")]
 
@@ -35,7 +35,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
 
     XCTAssertEqual(controller.components.first?.model.items.count, 0)
@@ -61,7 +61,7 @@ class ControllerTests: XCTestCase {
   func testAppendOneMoreItemInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", items: [Item(title: "title1")])
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
 
     XCTAssertEqual(controller.components.first!.model.items.count, 1)
@@ -80,7 +80,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemsInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
 
     let items = [
@@ -100,7 +100,7 @@ class ControllerTests: XCTestCase {
   func testPrependItemsInListComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "list", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
     controller.prepareController()
 
     let items = [
@@ -124,7 +124,7 @@ class ControllerTests: XCTestCase {
       ]
     )
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -151,7 +151,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -180,7 +180,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "list")
     ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -202,7 +202,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title4", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -226,7 +226,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title4", kind: "list")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -244,7 +244,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -265,7 +265,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemsInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -286,7 +286,7 @@ class ControllerTests: XCTestCase {
   func testPrependItemsInGridComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "grid", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -310,7 +310,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "grid")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -336,7 +336,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
     let listComponent = GridComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -357,7 +357,7 @@ class ControllerTests: XCTestCase {
   func testAppendItemsInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
     let listComponent = GridComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -379,7 +379,7 @@ class ControllerTests: XCTestCase {
   func testPrependItemsInCarouselComponent() {
     let model = ComponentModel(title: "ComponentModel", kind: "carousel", span: 1.0)
     let listComponent = ListComponent(model: model)
-    let controller = Controller(component: listComponent)
+    let controller = SpotsController(component: listComponent)
 
     controller.prepareController()
 
@@ -403,7 +403,7 @@ class ControllerTests: XCTestCase {
       Item(title: "title2", kind: "carousel")
       ])
     let initialListComponent = ListComponent(model: model)
-    let controller = Controller(component: initialListComponent)
+    let controller = SpotsController(component: initialListComponent)
 
     controller.prepareController()
 
@@ -445,7 +445,7 @@ class ControllerTests: XCTestCase {
     let listComponent = ListComponent(model: ComponentModel(title: "ListComponent", kind: "list", span: 1.0))
     let listComponent2 = ListComponent(model: ComponentModel(title: "ListComponent2", kind: "list", span: 1.0))
     let gridComponent = GridComponent(model: ComponentModel(title: "GridComponent", kind: "grid", span: 1.0, items: [Item(title: "Item")]))
-    let controller = Controller(components: [listComponent, listComponent2, gridComponent])
+    let controller = SpotsController(components: [listComponent, listComponent2, gridComponent])
 
     XCTAssertNotNil(controller.resolve(component: { $1.model.title == "ListComponent" }))
     XCTAssertNotNil(controller.resolve(component: { $1.model.title == "GridComponent" }))
@@ -463,8 +463,8 @@ class ControllerTests: XCTestCase {
   func testJSONInitialiser() {
     let component = ListComponent(model: ComponentModel(kind: "list"))
     component.model.items = [Item(title: "First item")]
-    let sourceController = Controller(component: component)
-    let jsonController = Controller([
+    let sourceController = SpotsController(component: component)
+    let jsonController = SpotsController([
       "components": [
         ["kind": "list",
          "items": [
@@ -487,7 +487,7 @@ class ControllerTests: XCTestCase {
         ]
       ]
     ]
-    let jsonController = Controller(initialJSON)
+    let jsonController = SpotsController(initialJSON)
 
     XCTAssert(jsonController.components.first!.model.kind == "list")
     XCTAssert(jsonController.components.first!.model.items.count == 1)
@@ -524,8 +524,8 @@ class ControllerTests: XCTestCase {
         ]
       ]
     ]
-    let firstController = Controller(initialJSON)
-    let secondController = Controller(firstController.dictionary)
+    let firstController = SpotsController(initialJSON)
+    let secondController = SpotsController(firstController.dictionary)
 
     XCTAssertTrue(firstController.components.first!.model == secondController.components.first!.model)
   }
@@ -571,7 +571,7 @@ class ControllerTests: XCTestCase {
       ]
     ]
 
-    let controller = Controller(initialJSON)
+    let controller = SpotsController(initialJSON)
     XCTAssertTrue(controller.components[0].userInterface is TableView)
     XCTAssertEqual(controller.components[0].model.items.first?.title, "First list item")
     XCTAssertEqual(controller.components[1].model.items.first?.title, "First list item")
@@ -636,7 +636,7 @@ class ControllerTests: XCTestCase {
     ]
 
     let components = initialComponentModels.map { Component(model: $0) }
-    let controller = Controller(components: components)
+    let controller = SpotsController(components: components)
 
     let oldComponentModels: [ComponentModel] = controller.components.map { $0.model }
 
@@ -692,7 +692,7 @@ class ControllerTests: XCTestCase {
     let components = initialComponentModels.map { Component(model: $0) }
 
     /// Validate setting up a controller
-    let controller = Controller(components: components)
+    let controller = SpotsController(components: components)
     XCTAssertEqual(controller.components.count, 1)
 
     /// Test first item in the first component of the first component inside of the controller
@@ -893,13 +893,13 @@ class ControllerTests: XCTestCase {
 
     let expectation = self.expectation(description: "Wait for componentsDidReloadComponentModels to be called")
 
-    Controller.componentsDidReloadComponentModels = { controller in
+    SpotsController.componentsDidReloadComponentModels = { controller in
       XCTAssert(true)
       expectation.fulfill()
     }
 
     let components = initialComponentModels.map { Component(model: $0) }
-    let controller = Controller(components: components)
+    let controller = SpotsController(components: components)
 
     controller.prepareController()
     controller.reloadIfNeeded(newComponentModels)

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -5,11 +5,11 @@ import XCTest
 class StateCacheTests: XCTestCase {
 
   let cacheKey: String = "state-cache-test"
-  var controller: Controller!
+  var controller: SpotsController!
 
   override func setUp() {
     StateCache.removeAll()
-    controller = Controller(cacheKey: cacheKey)
+    controller = SpotsController(cacheKey: cacheKey)
   }
 
   override func tearDown() {

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -5,7 +5,7 @@ import XCTest
 class SpotsScrollViewTests: XCTestCase {
 
   var bounds: CGRect!
-  var controller: Controller!
+  var controller: SpotsController!
 
   var initialJSON: [String : Any] {
     let listItems: [[String : Any]] = [
@@ -52,7 +52,7 @@ class SpotsScrollViewTests: XCTestCase {
   override func setUp() {
     super.setUp()
     bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
-    controller = Controller(initialJSON)
+    controller = SpotsController(initialJSON)
     controller.preloadView()
     controller.view.autoresizingMask = []
     controller.view.frame.size = bounds.size

--- a/SpotsTests/iOS/TestUIViewControllerExtensions.swift
+++ b/SpotsTests/iOS/TestUIViewControllerExtensions.swift
@@ -4,10 +4,10 @@ import XCTest
 
 class UIViewControllerExtensionsTests: XCTestCase {
 
-  var controller: Controller!
+  var controller: SpotsController!
 
   override func setUp() {
-    controller = Controller(components: [])
+    controller = SpotsController(components: [])
   }
 
   override func tearDown() {


### PR DESCRIPTION
This has been a lot of back and forwards on this... but `SpotsController` is a much better name for the controller than just `Controller`. Now it is super clear where the thing comes from. And it will also avoid conflicts that it might have in other projects.

This is pretty much a search and replace operation.

So, welcome back `SpotsController`.

Aims to solve https://github.com/hyperoslo/Spots/issues/540