### PR TITLE
Remove title property from ComponentModel

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -396,7 +396,7 @@ extension SpotsProtocol {
 
       for (index, change) in changes.enumerated() {
         switch change {
-        case .identifier, .title, .kind, .layout, .header, .footer, .meta:
+        case .identifier, .kind, .layout, .header, .footer, .meta:
           strongSelf.replaceComponent(index, newComponentModels: newComponentModels, yOffset: &yOffset)
         case .new:
           strongSelf.newComponent(index, newComponentModels: newComponentModels, yOffset: &yOffset)

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -19,7 +19,7 @@ import Tailor
 /// - removed:    Indicates that the component was removed
 /// - none:       Indicates that nothing did change
 public enum ComponentModelDiff {
-  case identifier, title, kind, layout, header, footer, meta, items, new, removed, none
+  case identifier, kind, layout, header, footer, meta, items, new, removed, none
 }
 
 /// An enum for identifing the ComponentModel kind

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -50,7 +50,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   public enum Key: String, StringConvertible {
     case index
     case identifier
-    case title
     case header
     case kind
     case meta
@@ -86,8 +85,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   public var identifier: String?
   /// The index of the Item when appearing in a list, should be computed and continuously updated by the data source
   public var index: Int = 0
-  /// The title for the component
-  public var title: String = ""
   /// Determines which component that should be used.
   /// Default kinds are: list, grid and carousel
   public var kind: ComponentKind = .list
@@ -152,10 +149,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     JSONComponentModels[Key.interaction] = interaction.dictionary
     JSONComponentModels[Key.identifier.string] = identifier
 
-    if !title.isEmpty {
-      JSONComponentModels[Key.title.string] = title
-    }
-
     JSONComponentModels[Key.header.string] = header?.dictionary
     JSONComponentModels[Key.footer.string] = footer?.dictionary
 
@@ -173,7 +166,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   /// - returns: An initialized component using JSON.
   public init(_ map: [String : Any]) {
     self.identifier = map.property("identifier")
-    self.title     <- map.property("title")
     self.kind      <- map.enum("kind")
     self.header    <- map.relation("header")
     self.footer    <- map.relation("footer")
@@ -202,8 +194,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
 
   /// Initializes a component and configures it with the provided parameters
   ///
-  /// - parameter identifier: A optional string
-  /// - parameter title: The title for your UI model.
+  /// - parameter identifier: A optional string.
   /// - parameter header: Determines which header item that should be used for the model.
   /// - parameter kind: The type of ComponentModel that should be used.
   /// - parameter layout: Configures the layout properties for the model.
@@ -214,7 +205,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   ///
   /// - returns: An initialized component
   public init(identifier: String? = nil,
-              title: String = "",
               header: Item? = nil,
               footer: Item? = nil,
               kind: ComponentKind = .list,
@@ -225,7 +215,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
               meta: [String : Any] = [:],
               hybrid: Bool = false) {
     self.identifier = identifier
-    self.title = title
     self.kind = kind
     self.layout = layout
     self.interaction = interaction
@@ -308,11 +297,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     // Check if meta data for the component changed, this can be up to the developer to decide what course of action to take.
     if !(meta as NSDictionary).isEqual(to: model.meta) {
       return .meta
-    }
-
-    // Check if title changed
-    if title != model.title {
-      return .title
     }
 
     // Check if the items have changed
@@ -439,7 +423,6 @@ public func == (lhs: ComponentModel, rhs: ComponentModel) -> Bool {
 
   let result = headersAreEqual == true &&
     footersAreEqual == true &&
-    lhs.title == rhs.title &&
     lhs.kind == rhs.kind &&
     lhs.layout == rhs.layout &&
     (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary)
@@ -474,7 +457,6 @@ public func === (lhs: ComponentModel, rhs: ComponentModel) -> Bool {
 
   return headersAreEqual &&
     footersAreEqual &&
-    lhs.title == rhs.title &&
     lhs.kind == rhs.kind &&
     lhs.layout == rhs.layout &&
     (lhs.meta as NSDictionary).isEqual(rhs.meta as NSDictionary) &&

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -8,7 +8,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public static var headers: Registry = Registry()
   public static var defaultKind: ComponentKind = .grid
 
-
   open static var configure: ((_ view: View) -> Void)?
 
   weak public var focusDelegate: ComponentFocusDelegate?

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -148,25 +148,6 @@ extension Delegate: UITableViewDelegate {
     return height
   }
 
-  /// Asks the data source for the title of the header of the specified section of the table view.
-  ///
-  /// - parameter tableView: The table-view object asking for the title.
-  /// - parameter section: An index number identifying a section of tableView.
-  ///
-  /// - returns: A string to use as the title of the section header. Will return `nil` if title is not present on ComponentModel
-  @nonobjc public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    guard let component = component else {
-      return nil
-    }
-
-    let kind: String = component.model.header?.kind ?? ""
-    guard Configuration.views.make(kind) == nil else {
-      return nil
-    }
-
-    return !component.model.title.isEmpty ? component.model.title : nil
-  }
-
   /// Tells the delegate that the specified row is now selected.
   ///
   /// - parameter tableView: A table-view object informing the delegate about the new row selection.

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -279,6 +279,25 @@ class ComponentModelTests: XCTestCase {
     XCTAssertEqual(lhs.diff(model: rhs), ComponentModelDiff.identifier)
   }
 
+  func testComponentModelsCompareOperators() {
+    let lhs = [ComponentModel(identifier: "foo")]
+    var rhs = [ComponentModel(identifier: "foo")]
+
+    // Expect the collections to be equal.
+    XCTAssertTrue(lhs == rhs)
+    XCTAssertFalse(lhs != rhs)
+
+    // Expect the collections to not be equal because the identifiers differ.
+    rhs = [ComponentModel(identifier: "bar")]
+    XCTAssertFalse(lhs == rhs)
+    XCTAssertTrue(lhs != rhs)
+
+    // Expect the collections to not be equal as the object count differs.
+    rhs = [ComponentModel(identifier: "foo"), ComponentModel(identifier: "foo")]
+    XCTAssertFalse(lhs == rhs)
+    XCTAssertTrue(lhs != rhs)
+  }
+
   func testComponentModelCompareWithMeta() {
     let meta = ["foo" : "bar"]
     let lhs = ComponentModel(meta: meta)

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -5,7 +5,6 @@ import XCTest
 class ComponentModelTests: XCTestCase {
 
   let json: [String : Any] = [
-    "title": "title1",
     "kind": "list",
     "layout": [
       "span": 1.0
@@ -17,7 +16,6 @@ class ComponentModelTests: XCTestCase {
   func testInit() {
     // Test component created with JSON
     let jsonComponentModel = ComponentModel(json)
-    XCTAssertEqual(jsonComponentModel.title, json["title"] as? String)
     XCTAssertEqual(jsonComponentModel.kind.string, json["kind"] as? String)
     XCTAssertEqual(jsonComponentModel.layout?.span, (json["layout"] as? [String : Any])?["span"] as? Double)
 
@@ -31,13 +29,11 @@ class ComponentModelTests: XCTestCase {
 
     // Test component created programmatically
     let codeComponentModel = ComponentModel(
-      title: json["title"] as! String,
       kind: ComponentKind(rawValue: json["kind"] as! String)!,
       layout: layout,
       items: [item],
       meta: json["meta"] as! [String : String])
 
-    XCTAssertEqual(codeComponentModel.title, json["title"] as? String)
     XCTAssertEqual(codeComponentModel.kind.string, json["kind"] as? String)
     XCTAssertEqual(codeComponentModel.layout?.span, (json["layout"] as? [String : Any])?["span"] as? Double)
 
@@ -51,7 +47,6 @@ class ComponentModelTests: XCTestCase {
   func testEquatable() {
     let jsonComponentModel = ComponentModel(json)
     var codeComponentModel = ComponentModel(
-      title: json["title"] as! String,
       kind: ComponentKind(rawValue: json["kind"] as! String)!,
       span: (json["layout"] as? [String : Any])?["span"] as? Double,
       meta: json["meta"] as! [String : String])
@@ -284,19 +279,6 @@ class ComponentModelTests: XCTestCase {
     XCTAssertEqual(lhs.diff(model: rhs), ComponentModelDiff.identifier)
   }
 
-  func testComponentModelCompareWithTitle() {
-    let lhs = ComponentModel(title: "foo")
-    var rhs = ComponentModel(title: "foo")
-
-    XCTAssertEqual(lhs, rhs)
-    XCTAssertEqual(lhs.diff(model: rhs), ComponentModelDiff.none)
-
-    rhs.title = "bar"
-
-    XCTAssertNotEqual(lhs, rhs)
-    XCTAssertEqual(lhs.diff(model: rhs), ComponentModelDiff.title)
-  }
-
   func testComponentModelCompareWithMeta() {
     let meta = ["foo" : "bar"]
     let lhs = ComponentModel(meta: meta)
@@ -309,18 +291,5 @@ class ComponentModelTests: XCTestCase {
 
     XCTAssertNotEqual(lhs, rhs)
     XCTAssertEqual(lhs.diff(model: rhs), ComponentModelDiff.meta)
-  }
-
-  func testCompareCollectionOfComponentModels() {
-    let lhs = [ComponentModel(title: "foo")]
-    var rhs = [ComponentModel(title: "bar")]
-
-    XCTAssertFalse(lhs == rhs)
-
-    rhs = [ComponentModel(title: "foo")]
-    XCTAssertTrue(lhs == rhs)
-
-    rhs.append(ComponentModel(title: "bar"))
-    XCTAssertFalse(lhs == rhs)
   }
 }

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -284,16 +284,19 @@ class ComponentModelTests: XCTestCase {
     var rhs = [ComponentModel(identifier: "foo")]
 
     // Expect the collections to be equal.
+    XCTAssertTrue(lhs === rhs)
     XCTAssertTrue(lhs == rhs)
     XCTAssertFalse(lhs != rhs)
 
     // Expect the collections to not be equal because the identifiers differ.
     rhs = [ComponentModel(identifier: "bar")]
+    XCTAssertFalse(lhs === rhs)
     XCTAssertFalse(lhs == rhs)
     XCTAssertTrue(lhs != rhs)
 
     // Expect the collections to not be equal as the object count differs.
     rhs = [ComponentModel(identifier: "foo"), ComponentModel(identifier: "foo")]
+    XCTAssertFalse(lhs === rhs)
     XCTAssertFalse(lhs == rhs)
     XCTAssertTrue(lhs != rhs)
   }

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -5,7 +5,7 @@ import XCTest
 class CoreComponentTests: XCTestCase {
 
   func testAppendingMultipleItemsToComponent() {
-    let listComponent = ListComponent(model: ComponentModel(title: "ComponentModel", kind: .list, span: 1.0))
+    let listComponent = ListComponent(model: ComponentModel(kind: .list, span: 1.0))
     listComponent.setup(with: CGSize(width: 100, height: 100))
     var items: [Item] = []
 
@@ -29,7 +29,7 @@ class CoreComponentTests: XCTestCase {
   }
 
   func testAppendingMultipleItemsToSpotInController() {
-    let controller = SpotsController(components: [ListComponent(model: ComponentModel(title: "ComponentModel", kind: .list, span: 1.0))])
+    let controller = SpotsController(components: [ListComponent(model: ComponentModel(kind: .list, span: 1.0))])
     controller.prepareController()
     var items: [Item] = []
 

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -5,7 +5,7 @@ import XCTest
 class SpotsControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
-    let model = ComponentModel(title: "ComponentModel", span: 1.0)
+    let model = ComponentModel(span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -14,7 +14,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testUpdateSpotAtIndex() {
-    let model = ComponentModel(title: "ComponentModel", span: 1.0)
+    let model = ComponentModel(span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -33,7 +33,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -59,7 +59,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendOneMoreItemInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, items: [Item(title: "title1")])
+    let model = ComponentModel(kind: .list, items: [Item(title: "title1")])
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -78,7 +78,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -98,7 +98,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -118,7 +118,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependMoreItemsInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ]
@@ -146,7 +146,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
@@ -175,7 +175,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemsInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
     ])
@@ -195,7 +195,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemAtIndexInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
@@ -219,7 +219,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemsWithIndexesInListComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
@@ -242,7 +242,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInGridComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -263,7 +263,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInGridComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -284,7 +284,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInGridComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -305,7 +305,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInGridComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .grid, span: 1.0, items: [
+    let model = ComponentModel(kind: .grid, span: 1.0, items: [
       Item(title: "title1", kind: "grid"),
       Item(title: "title2", kind: "grid")
       ])
@@ -334,7 +334,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInCarouselComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, span: 1.0)
     let listComponent = GridComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -355,7 +355,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInCarouselComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, span: 1.0)
     let listComponent = GridComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -377,7 +377,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInCarouselComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, span: 1.0)
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -398,7 +398,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInCarouselComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .carousel, span: 1.0, items: [
+    let model = ComponentModel(kind: .carousel, span: 1.0, items: [
       Item(title: "title1", kind: "carousel"),
       Item(title: "title2", kind: "carousel")
       ])
@@ -427,7 +427,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testComputedPropertiesOnCoreComponent() {
-    let model = ComponentModel(title: "ComponentModel", kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, span: 1.0, items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
@@ -441,20 +441,20 @@ class SpotsControllerTests: XCTestCase {
     XCTAssert(component.model.items == newItems)
   }
 
-  func testFindAndFilterSpotWithClosure() {
-    let listComponent = ListComponent(model: ComponentModel(title: "ListComponent", kind: .list, span: 1.0))
-    let listComponent2 = ListComponent(model: ComponentModel(title: "ListComponent2", kind: .list, span: 1.0))
-    let gridComponent = GridComponent(model: ComponentModel(title: "GridComponent", kind: .grid, span: 1.0, items: [Item(title: "Item")]))
+  func testFindAndFilterComponentWithClosure() {
+    let listComponent = ListComponent(model: ComponentModel(identifier: "ListComponent", kind: .list, span: 1.0))
+    let listComponent2 = ListComponent(model: ComponentModel(identifier: "ListComponent2", kind: .list, span: 1.0))
+    let gridComponent = GridComponent(model: ComponentModel(identifier: "GridComponent", kind: .grid, span: 1.0, items: [Item(title: "Item")]))
     let controller = SpotsController(components: [listComponent, listComponent2, gridComponent])
 
-    XCTAssertNotNil(controller.resolve(component: { $1.model.title == "ListComponent" }))
-    XCTAssertNotNil(controller.resolve(component: { $1.model.title == "GridComponent" }))
+    XCTAssertNotNil(controller.resolve(component: { $1.model.identifier == "ListComponent" }))
+    XCTAssertNotNil(controller.resolve(component: { $1.model.identifier == "GridComponent" }))
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is TableView }))
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is CollectionView }))
     XCTAssertNotNil(controller.resolve(component: { $1.model.items.filter { $0.title == "Item" }.first != nil }))
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 0 })?.model.title, "ListComponent")
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 1 })?.model.title, "ListComponent2")
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 2 })?.model.title, "GridComponent")
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 0 })?.model.identifier, "ListComponent")
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 1 })?.model.identifier, "ListComponent2")
+    XCTAssertEqual(controller.resolve(component: { $0.0 == 2 })?.model.identifier, "GridComponent")
 
     XCTAssertEqual(controller.filter(components: { $0.userInterface is TableView }).count, 2)
     XCTAssertEqual(controller.filter(components: { $0.userInterface is CollectionView }).count, 1)

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -34,10 +34,9 @@ class ComponentTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let model = ComponentModel(title: "CarouselComponent", kind: .carousel, span: 3, meta: ["headerHeight": 44.0])
+    let model = ComponentModel(kind: .carousel, span: 3, meta: ["headerHeight": 44.0])
     let component = CarouselComponent(model: model)
     XCTAssertEqual(model.dictionary["index"] as? Int, component.dictionary["index"] as? Int)
-    XCTAssertEqual(model.dictionary["title"] as? String, component.dictionary["title"] as? String)
     XCTAssertEqual(model.dictionary["kind"] as? String, component.dictionary["kind"] as? String)
     XCTAssertEqual(model.dictionary["span"] as? Int, component.dictionary["span"] as? Int)
     XCTAssertEqual(
@@ -47,7 +46,7 @@ class ComponentTests: XCTestCase {
   }
 
   func testSafelyResolveKind() {
-    let model = ComponentModel(title: "CarouselComponent", kind: .carousel, span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let model = ComponentModel(kind: .carousel, span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
     let carouselComponent = CarouselComponent(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -85,46 +85,6 @@ class DelegateTests: XCTestCase {
     XCTAssertEqual(component.componentDelegate?.tableView(tableView, heightForRowAt: IndexPath(row: 1, section: 0)), 0.0)
   }
 
-  func testDelegateTitleForHeader() {
-    Configuration.register(view: CustomListHeaderView.self, identifier: "list")
-    let component = ListComponent(model: ComponentModel(
-      title: "title",
-      header: Item(kind: "list"),
-      kind: .list,
-      span: 1,
-      items: [
-        Item(title: "title 1"),
-        Item(title: "title 2")
-      ]))
-    component.setup(with: CGSize(width: 100, height: 100))
-    component.view.layoutSubviews()
-
-    guard let tableView = component.tableView else {
-      XCTFail("Unable to resolve table view.")
-      return
-    }
-
-    var view = component.componentDelegate?.tableView(tableView, viewForHeaderInSection: 0) as? ListHeaderFooterWrapper
-    XCTAssert(view?.wrappedView is CustomListHeaderView)
-
-    /// Expect to return nil if header is in use.
-    var title = component.componentDelegate?.tableView(tableView, titleForHeaderInSection: 0)
-    XCTAssertEqual(title, nil)
-
-    /// Expect to return title if header is empty.
-    component.model.header = nil
-    title = component.componentDelegate?.tableView(tableView, titleForHeaderInSection: 0)
-    XCTAssertEqual(title, component.model.title)
-
-    /// Expect to return nil if title and header is empty.
-    component.model.title = ""
-    title = component.componentDelegate?.tableView(tableView, titleForHeaderInSection: 0)
-    XCTAssertEqual(title, nil)
-
-    view = component.componentDelegate?.tableView(tableView, viewForHeaderInSection: 0) as! ListHeaderFooterWrapper?
-    XCTAssertEqual(view, nil)
-  }
-
   func testTableViewHeaderHeight() {
     Configuration.register(view: RegularView.self, identifier: "regular-header")
     Configuration.register(view: ItemConfigurableView.self, identifier: "item-configurable-header")


### PR DESCRIPTION
This PR removes the `title` property from the `ComponentModel`. It felt redundant to keep this around as the new preferred way of adding a header is to add an `Item` on the `ComponentModel`.
This will also cause less confusion as a custom header would not gain access to `title` because of the scope of the data based to the view configuration method.

It also removes one of the delegate methods on `UITableView`, more specifically:

```swift
func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? 
```

That might give a tinsy tiny performance boost as that method no longer need to resolve a view to check which configuration should be used (title or custom view).