### PR TITLE
Remove legacy implementations for register and registerAndPrepare

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -422,12 +422,6 @@ public extension Component {
     }
   }
 
-  /// Register and prepare all items in the component.
-  func registerAndPrepare() {
-    register()
-    prepareItems()
-  }
-
   /// Update height and refresh indexes for the component.
   ///
   /// - parameter completion: A completion closure that will be run when the computations are complete.

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -185,7 +185,7 @@ extension SpotsProtocol {
     tempSpot.layout(with: tempSpot.view.frame.size)
     tempSpot.view.frame.size.height = tempSpot.computedHeight
     tempSpot.view.layoutIfNeeded()
-    tempSpot.registerAndPrepare()
+    tempSpot.prepareItems()
 
     tempSpot.model.size = CGSize(
       width: view.frame.width,

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -208,8 +208,4 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func afterUpdate() {
     setup(with: view.frame.size)
   }
-
-  public func register() {
-
-  }
 }

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -318,8 +318,4 @@ import Tailor
     }
     reload()
   }
-
-  public func register() {
-
-  }
 }

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -216,7 +216,6 @@ open class SpotsController: NSViewController, SpotsProtocol {
     }
 
     components[index].model.index = index
-    component.register()
     component.setup(with: CGSize(width: view.frame.width, height: view.frame.size.height))
     component.model.size = CGSize(
       width: view.frame.width,

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -32,9 +32,6 @@ extension DataSource: NSCollectionViewDataSource {
       return NSCollectionViewItem()
     }
 
-    /// This is to make sure that all views are registered on the collection view
-    component.register()
-
     let reuseIdentifier = component.identifier(at: indexPath.item)
 
     let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)


### PR DESCRIPTION
This PR cleans up some of the legacy methods that we had implemented on `Component`.
We had an empty `register` implementation that this PR removes.
It also removes `registerAndPrepare` as that method is rendered useless now that `Component`
no longer has a `register` method.

The registration of views is done in the initializer of `Component`, it pretty much tells the `UserInterface` to register all views that are registered on `Configuration.views`.