### PR TITLE
Remove static header property from Component

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -5,7 +5,6 @@ import UIKit
 public class Component: NSObject, ComponentHorizontallyScrollable {
 
   public static var layout: Layout = Layout(span: 0.0)
-  public static var headers: Registry = Registry()
   public static var defaultKind: ComponentKind = .grid
 
   open static var configure: ((_ view: View) -> Void)?

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -6,7 +6,6 @@ import Tailor
 @objc(SpotsComponent) public class Component: NSObject {
 
   public static var layout: Layout = Layout(span: 0.0)
-  public static var headers: Registry = Registry()
   public static var defaultKind: ComponentKind = .list
 
   open static var configure: ((_ view: View) -> Void)?


### PR DESCRIPTION
This PR removes the static header property on Component, this is not used anymore.