### PR TITLE
Remove span on ComponentModel

### DIFF
--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -30,19 +30,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     }
   }
 
-  public var span: Double {
-    get {
-      return layout?.span ?? 0.0
-    }
-    set {
-      if layout == nil {
-        self.layout = Layout(span: newValue)
-      } else {
-        self.layout?.span = newValue
-      }
-    }
-  }
-
   /// Identifier
   public var identifier: String?
   /// The index of the Item when appearing in a list, should be computed and continuously updated by the data source
@@ -142,10 +129,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
       self.interaction = Interaction()
     }
 
-    if self.layout == nil {
-      self.span <- map.property("span")
-    }
-
     let width: Double = map.resolve(keyPath: "size.width") ?? 0.0
     let height: Double = map.resolve(keyPath: "size.height") ?? 0.0
     size = CGSize(width: width, height: height)
@@ -168,7 +151,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
               kind: ComponentKind = .list,
               layout: Layout? = nil,
               interaction: Interaction = .init(),
-              span: Double? = nil,
               items: [Item] = [],
               meta: [String : Any] = [:],
               hybrid: Bool = false) {
@@ -180,10 +162,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     self.footer = footer
     self.items = items
     self.meta = meta
-
-    if let span = span, layout == nil {
-      self.layout = Layout(span: span)
-    }
+    self.layout = layout
   }
 
   // MARK: - Helpers

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -46,9 +46,10 @@ class ComponentModelTests: XCTestCase {
 
   func testEquatable() {
     let jsonComponentModel = ComponentModel(json)
+    let layout = Layout(json["layout"] as! [String: Any])
     var codeComponentModel = ComponentModel(
       kind: ComponentKind(rawValue: json["kind"] as! String)!,
-      span: (json["layout"] as? [String : Any])?["span"] as? Double,
+      layout: layout,
       meta: json["meta"] as! [String : String])
     XCTAssertTrue(jsonComponentModel == codeComponentModel)
 

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -15,16 +15,16 @@ class CompositionTests: XCTestCase {
   func testComponentModelCreation() {
     var model = ComponentModel(
       kind: .grid,
-      span: 1.0
+      layout: Layout(span: 1.0)
     )
 
-    model.add(child: ComponentModel(kind: .list, span: 1.0))
+    model.add(child: ComponentModel(kind: .list, layout: Layout(span: 1.0)))
 
     XCTAssertEqual(model.items.count, 1)
 
     model.add(children: [
-      ComponentModel(kind: .list, span: 1.0),
-      ComponentModel(kind: .list, span: 1.0)
+      ComponentModel(kind: .list, layout: Layout(span: 1.0)),
+      ComponentModel(kind: .list, layout: Layout(span: 1.0))
       ]
     )
 
@@ -38,7 +38,7 @@ class CompositionTests: XCTestCase {
     model.add(children: [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "foo"),
           Item(title: "bar")
@@ -46,7 +46,7 @@ class CompositionTests: XCTestCase {
       ),
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "baz"),
           Item(title: "bal")
@@ -78,12 +78,12 @@ class CompositionTests: XCTestCase {
   }
 
   func testUICreation() {
-    var model = ComponentModel(kind: .grid, span: 2.0)
+    var model = ComponentModel(kind: .grid, layout: Layout(span: 2.0))
 
     model.add(children: [
       ComponentModel(
         kind: .list,
-        span: 1,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "foo"),
           Item(title: "bar")
@@ -91,7 +91,7 @@ class CompositionTests: XCTestCase {
       ),
       ComponentModel(
         kind: .list,
-        span: 1,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "baz"),
           Item(title: "bal")
@@ -145,11 +145,11 @@ class CompositionTests: XCTestCase {
   func testReloadWithComponentModelsUsingCompositionTriggeringReplaceComponent() {
     let initialComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -166,7 +166,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -184,11 +184,11 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -205,7 +205,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -290,11 +290,11 @@ class CompositionTests: XCTestCase {
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 1.0,
+                layout: Layout(span: 1.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -311,7 +311,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -329,11 +329,11 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 3.0,
+                layout: Layout(span: 3.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -350,7 +350,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -443,11 +443,11 @@ class CompositionTests: XCTestCase {
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 1.0,
+                layout: Layout(span: 1.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -464,7 +464,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -482,7 +482,7 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 3.0,
+                layout: Layout(span: 3.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
@@ -597,11 +597,11 @@ class CompositionTests: XCTestCase {
   func testReloadWithComponentModelsUsingCompositionTriggeringReloadMore() {
     let initialComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -618,7 +618,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -636,11 +636,11 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -657,7 +657,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -746,11 +746,11 @@ class CompositionTests: XCTestCase {
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -768,7 +768,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -786,7 +786,7 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
@@ -827,7 +827,7 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
@@ -932,11 +932,11 @@ class CompositionTests: XCTestCase {
   func testReloadWithComponentModelsUsingCompositionTriggeringReloadLess() {
     let initialComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -953,7 +953,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -971,11 +971,11 @@ class CompositionTests: XCTestCase {
         ]
       ),
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -992,7 +992,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -1087,11 +1087,11 @@ class CompositionTests: XCTestCase {
 
     let newComponentModels: [ComponentModel] = [
       ComponentModel(kind: .grid,
-                span: 2.0,
+                layout: Layout(span: 2.0),
                 items: [
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),
@@ -1108,7 +1108,7 @@ class CompositionTests: XCTestCase {
                   ),
                   Item(kind: CompositeComponent.identifier, children:
                     [
-                      ComponentModel(kind: .list, span: 1.0, items: [
+                      ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
                         Item(title: "Item 1"),
                         Item(title: "Item 2"),
                         Item(title: "Item 3"),

--- a/SpotsTests/Shared/TestCoreComponent.swift
+++ b/SpotsTests/Shared/TestCoreComponent.swift
@@ -5,7 +5,7 @@ import XCTest
 class CoreComponentTests: XCTestCase {
 
   func testAppendingMultipleItemsToComponent() {
-    let listComponent = ListComponent(model: ComponentModel(kind: .list, span: 1.0))
+    let listComponent = ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1)))
     listComponent.setup(with: CGSize(width: 100, height: 100))
     var items: [Item] = []
 
@@ -29,7 +29,7 @@ class CoreComponentTests: XCTestCase {
   }
 
   func testAppendingMultipleItemsToSpotInController() {
-    let controller = SpotsController(components: [ListComponent(model: ComponentModel(kind: .list, span: 1.0))])
+    let controller = SpotsController(components: [ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1.0)))])
     controller.prepareController()
     var items: [Item] = []
 
@@ -100,7 +100,7 @@ class CoreComponentTests: XCTestCase {
     Configuration.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
-    let component = CarouselComponent(model: ComponentModel(kind: .carousel, span: 0.0, items: items))
+    let component = CarouselComponent(model: ComponentModel(kind: .carousel, layout: Layout(span: 0.0), items: items))
     component.setup(with: CGSize(width: 100, height: 100))
 
     var invokeCount = 0

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -5,7 +5,7 @@ import XCTest
 class SpotsControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
-    let model = ComponentModel(span: 1.0)
+    let model = ComponentModel(layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -14,7 +14,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testUpdateSpotAtIndex() {
-    let model = ComponentModel(span: 1.0)
+    let model = ComponentModel(layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -33,7 +33,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -78,7 +78,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -98,7 +98,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0)
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
     controller.prepareController()
@@ -118,7 +118,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependMoreItemsInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ]
@@ -146,7 +146,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
@@ -175,7 +175,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemsInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
     ])
@@ -195,7 +195,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemAtIndexInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
@@ -219,7 +219,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemsWithIndexesInListComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list"),
       Item(title: "title3", kind: "list"),
@@ -242,7 +242,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInGridComponent() {
-    let model = ComponentModel(kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, layout: Layout(span: 1))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -263,7 +263,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInGridComponent() {
-    let model = ComponentModel(kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, layout: Layout(span: 1))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -284,7 +284,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInGridComponent() {
-    let model = ComponentModel(kind: .grid, span: 1.0)
+    let model = ComponentModel(kind: .grid, layout: Layout(span: 1))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -305,7 +305,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInGridComponent() {
-    let model = ComponentModel(kind: .grid, span: 1.0, items: [
+    let model = ComponentModel(kind: .grid, layout: Layout(span: 1), items: [
       Item(title: "title1", kind: "grid"),
       Item(title: "title2", kind: "grid")
       ])
@@ -334,7 +334,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemInCarouselComponent() {
-    let model = ComponentModel(kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 1.0))
     let listComponent = GridComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -355,7 +355,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testAppendItemsInCarouselComponent() {
-    let model = ComponentModel(kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 1.0))
     let listComponent = GridComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -377,7 +377,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testPrependItemsInCarouselComponent() {
-    let model = ComponentModel(kind: .carousel, span: 1.0)
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 1.0))
     let listComponent = ListComponent(model: model)
     let controller = SpotsController(component: listComponent)
 
@@ -398,7 +398,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testDeleteItemInCarouselComponent() {
-    let model = ComponentModel(kind: .carousel, span: 1.0, items: [
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "carousel"),
       Item(title: "title2", kind: "carousel")
       ])
@@ -427,7 +427,7 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testComputedPropertiesOnCoreComponent() {
-    let model = ComponentModel(kind: .list, span: 1.0, items: [
+    let model = ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title1", kind: "list"),
       Item(title: "title2", kind: "list")
       ])
@@ -442,9 +442,9 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testFindAndFilterComponentWithClosure() {
-    let listComponent = ListComponent(model: ComponentModel(identifier: "ListComponent", kind: .list, span: 1.0))
-    let listComponent2 = ListComponent(model: ComponentModel(identifier: "ListComponent2", kind: .list, span: 1.0))
-    let gridComponent = GridComponent(model: ComponentModel(identifier: "GridComponent", kind: .grid, span: 1.0, items: [Item(title: "Item")]))
+    let listComponent = ListComponent(model: ComponentModel(identifier: "ListComponent", kind: .list, layout: Layout(span: 1.0)))
+    let listComponent2 = ListComponent(model: ComponentModel(identifier: "ListComponent2", kind: .list, layout: Layout(span: 1.0)))
+    let gridComponent = GridComponent(model: ComponentModel(identifier: "GridComponent", kind: .grid, layout: Layout(span: 1.0), items: [Item(title: "Item")]))
     let controller = SpotsController(components: [listComponent, listComponent2, gridComponent])
 
     XCTAssertNotNil(controller.resolve(component: { $1.model.identifier == "ListComponent" }))
@@ -608,7 +608,7 @@ class SpotsControllerTests: XCTestCase {
     let initialComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
@@ -623,7 +623,7 @@ class SpotsControllerTests: XCTestCase {
     let newComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
@@ -662,7 +662,7 @@ class SpotsControllerTests: XCTestCase {
     let initialComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
@@ -677,7 +677,7 @@ class SpotsControllerTests: XCTestCase {
     let newComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
@@ -864,7 +864,7 @@ class SpotsControllerTests: XCTestCase {
     let initialComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
@@ -879,7 +879,7 @@ class SpotsControllerTests: XCTestCase {
     let newComponentModels = [
       ComponentModel(
         kind: .list,
-        span: 1.0,
+        layout: Layout(span: 1.0),
         items: [
           Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
           Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -26,7 +26,7 @@ class StateCacheTests: XCTestCase {
     /// Check that cache is empty
     XCTAssertEqual(controller.stateCache!.load().count, 0)
 
-    controller.components = [ListComponent(model: ComponentModel(span: 1.0))]
+    controller.components = [ListComponent(model: ComponentModel(layout: Layout(span: 1.0)))]
 
     let expectation = self.expectation(description: "Append item to CoreComponent object")
     controller.append(Item(title: "foo"), componentIndex: 0, withAnimation: .automatic) {

--- a/SpotsTests/iOS/TestCarouselComposite.swift
+++ b/SpotsTests/iOS/TestCarouselComposite.swift
@@ -7,13 +7,13 @@ class CarouselCompositeTests: XCTestCase {
   func testCarouselComposite() {
     let view = CarouselComposite()
     var item = Item()
-    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, span: 1)), itemIndex: 0)
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, span: 1)), itemIndex: 0)
-    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, span: 1)), itemIndex: 0)
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, layout: Layout(span: 1))), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -8,7 +8,7 @@ class ComponentTests: XCTestCase {
   var cachedSpot: CarouselComponent!
 
   override func setUp() {
-    component = CarouselComponent(model: ComponentModel(span: 1.0))
+    component = CarouselComponent(model: ComponentModel(layout: Layout(span: 1)))
     cachedSpot = CarouselComponent(cacheKey: "cached-carousel-component")
     XCTAssertNotNil(cachedSpot.stateCache)
     cachedSpot.stateCache?.clear()
@@ -20,8 +20,8 @@ class ComponentTests: XCTestCase {
   }
 
   func testConvenienceInitWithSectionInsets() {
-    let layout = Layout(itemSpacing: 5, inset: Inset(top: 5, left: 10, bottom: 5, right: 5))
-    let model = ComponentModel(kind: .grid, layout: layout, span: 1.0)
+    let layout = Layout(span: 1, itemSpacing: 5, inset: Inset(top: 5, left: 10, bottom: 5, right: 5))
+    let model = ComponentModel(kind: .grid, layout: layout)
     let component = CarouselComponent(model: model)
 
     guard let collectionViewLayout = component.collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {
@@ -34,7 +34,7 @@ class ComponentTests: XCTestCase {
   }
 
   func testDictionaryRepresentation() {
-    let model = ComponentModel(kind: .carousel, span: 3, meta: ["headerHeight": 44.0])
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 3), meta: ["headerHeight": 44.0])
     let component = CarouselComponent(model: model)
     XCTAssertEqual(model.dictionary["index"] as? Int, component.dictionary["index"] as? Int)
     XCTAssertEqual(model.dictionary["kind"] as? String, component.dictionary["kind"] as? String)
@@ -46,7 +46,7 @@ class ComponentTests: XCTestCase {
   }
 
   func testSafelyResolveKind() {
-    let model = ComponentModel(kind: .carousel, span: 1.0, items: [Item(title: "foo", kind: "custom-item-kind")])
+    let model = ComponentModel(kind: .carousel, layout: Layout(span: 1.0), items: [Item(title: "foo", kind: "custom-item-kind")])
     let carouselComponent = CarouselComponent(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
@@ -132,8 +132,7 @@ class ComponentTests: XCTestCase {
         ["title": "bazar", "kind": "carousel"]
       ],
       "interaction": Interaction(paginate: .page).dictionary,
-      "layout": Layout(
-        span: 4.0,
+      "layout": Layout(span: 4.0,
         dynamicSpan: false,
         pageIndicatorPlacement: .below
       ).dictionary
@@ -196,8 +195,7 @@ class ComponentTests: XCTestCase {
       ],
       "kind" : "carousel",
       "interaction": Interaction(paginate: .page).dictionary,
-      "layout": Layout(
-        span: 4.0,
+      "layout": Layout(span: 4.0,
         dynamicSpan: false,
         pageIndicatorPlacement: .overlay
       ).dictionary
@@ -315,7 +313,7 @@ class ComponentTests: XCTestCase {
 
   func testAppendItem() {
     let item = Item(title: "test")
-    let component = CarouselComponent(model: ComponentModel(span: 1))
+    let component = CarouselComponent(model: ComponentModel(layout: Layout(span: 1)))
     let expectation = self.expectation(description: "Append item")
     component.append(item) {
       XCTAssert(component.model.items.first! == item)
@@ -326,7 +324,7 @@ class ComponentTests: XCTestCase {
 
   func testAppendItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let component = CarouselComponent(model: ComponentModel(span: 1))
+    let component = CarouselComponent(model: ComponentModel(layout: Layout(span: 1)))
     let expectation = self.expectation(description: "Append items")
     component.append(items) {
       XCTAssert(component.model.items == items)
@@ -337,7 +335,7 @@ class ComponentTests: XCTestCase {
 
   func testInsertItem() {
     let item = Item(title: "test")
-    let component = CarouselComponent(model: ComponentModel(span: 1))
+    let component = CarouselComponent(model: ComponentModel(layout: Layout(span: 1)))
     let expectation = self.expectation(description: "Insert item")
     component.insert(item, index: 0) {
       XCTAssert(component.model.items.first! == item)
@@ -348,7 +346,7 @@ class ComponentTests: XCTestCase {
 
   func testPrependItems() {
     let items = [Item(title: "test"), Item(title: "test 2")]
-    let component = CarouselComponent(model: ComponentModel(span: 1))
+    let component = CarouselComponent(model: ComponentModel(layout: Layout(span: 1)))
     let expectation = self.expectation(description: "Prepend items")
     component.prepend(items) {
       XCTAssert(component.model.items == items)

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -6,7 +6,7 @@ class DataSourceTests: XCTestCase {
 
   func testDataSourceForListableObject() {
     Configuration.register(view: CustomListCell.self, identifier: "custom")
-    let component = ListComponent(model: ComponentModel(kind: .list, span: 1.0, items: [
+    let component = ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title 1"),
       Item(title: "title 2")
       ]))
@@ -45,7 +45,7 @@ class DataSourceTests: XCTestCase {
 
   func testDataSourceForGridableObject() {
     Configuration.register(view: CustomGridCell.self, identifier: "custom")
-    let component = GridComponent(model: ComponentModel(kind: .grid, span: 1.0, items: [
+    let component = GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1.0), items: [
       Item(title: "title 1"),
       Item(title: "title 2")
       ]))
@@ -86,7 +86,7 @@ class DataSourceTests: XCTestCase {
     let component = GridComponent(model: ComponentModel(
       header: Item(kind: "custom-header"),
       kind: .grid,
-      span: 1.0,
+      layout: Layout(span: 1.0),
       items: [
         Item(title: "title 1"),
         Item(title: "title 2")

--- a/SpotsTests/iOS/TestDelegate.swift
+++ b/SpotsTests/iOS/TestDelegate.swift
@@ -17,7 +17,7 @@ class DelegateTests: XCTestCase {
 
   func testCollectionViewDelegateSelection() {
     let delegate = TestDelegate()
-    let component = GridComponent(model: ComponentModel(kind: .grid, span: 1, items: [
+    let component = GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1), items: [
       Item(title: "title 1")
       ]))
     component.delegate = delegate
@@ -37,7 +37,7 @@ class DelegateTests: XCTestCase {
   }
 
   func testCollectionViewCanFocus() {
-    let component = GridComponent(model: ComponentModel(kind: .grid, span: 1, items: [Item(title: "title 1")]))
+    let component = GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1), items: [Item(title: "title 1")]))
 
     guard let collectionView = component.collectionView else {
       XCTFail("Unable to resolve collection view.")
@@ -52,7 +52,7 @@ class DelegateTests: XCTestCase {
 
   func testTableViewDelegateSelection() {
     let delegate = TestDelegate()
-    let component = ListComponent(model: ComponentModel(kind: .list, span: 1, items: [
+    let component = ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1), items: [
       Item(title: "title 1")
       ]))
     component.delegate = delegate
@@ -73,7 +73,7 @@ class DelegateTests: XCTestCase {
 
   func testTableViewHeightForRowOnListable() {
     Configuration.registerDefault(view: ListComponentCell.self)
-    let component = ListComponent(model: ComponentModel(kind: .list, span: 1, items: [Item(title: "title 1")]))
+    let component = ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1), items: [Item(title: "title 1")]))
     component.setup(with: CGSize(width: 100, height: 100))
 
     guard let tableView = component.tableView else {

--- a/SpotsTests/iOS/TestGridComposite.swift
+++ b/SpotsTests/iOS/TestGridComposite.swift
@@ -7,13 +7,13 @@ class GridCompositeTests: XCTestCase {
   func testGridComposite() {
     let view = GridComposite()
     var item = Item()
-    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, span: 1)), itemIndex: 0)
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, span: 1)), itemIndex: 0)
-    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, span: 1)), itemIndex: 0)
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, layout: Layout(span: 1))), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/iOS/TestLayoutExtensions.swift
+++ b/SpotsTests/iOS/TestLayoutExtensions.swift
@@ -21,7 +21,7 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableComponent() {
-    let gridComponent = GridComponent(model: ComponentModel(kind: .grid, span: 1))
+    let gridComponent = GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1)))
     let layout = Layout(json)
 
     layout.configure(component: gridComponent)
@@ -41,7 +41,7 @@ class LayoutExtensionsTests: XCTestCase {
   }
 
   func testConfigureListableComponent() {
-    let listComponent = ListComponent(model: ComponentModel(kind: .list, span: 1))
+    let listComponent = ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1)))
     let layout = Layout(json)
 
     layout.configure(component: listComponent)

--- a/SpotsTests/iOS/TestListComposite.swift
+++ b/SpotsTests/iOS/TestListComposite.swift
@@ -7,13 +7,13 @@ class ListCompositeTests: XCTestCase {
   func testListComposite() {
     let view = ListComposite()
     var item = Item()
-    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, span: 1)), itemIndex: 0)
+    let gridComponent = CompositeComponent(component: GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [gridComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 1)
 
-    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, span: 1)), itemIndex: 0)
-    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, span: 1)), itemIndex: 0)
+    let carouselComponent = CompositeComponent(component: CarouselComponent(model: ComponentModel(kind: .carousel, layout: Layout(span: 1))), itemIndex: 0)
+    let listComponent = CompositeComponent(component: ListComponent(model: ComponentModel(kind: .list, layout: Layout(span: 1))), itemIndex: 0)
     view.configure(&item, compositeComponents: [carouselComponent, listComponent])
 
     XCTAssertTrue(view.contentView.subviews.count == 3)

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -15,7 +15,7 @@ class LayoutExtensionsTests: XCTestCase {
   ]
 
   func testConfigureGridableComponent() {
-    let gridComponent = GridComponent(model: ComponentModel(kind: .grid, span: 1))
+    let gridComponent = GridComponent(model: ComponentModel(kind: .grid, layout: Layout(span: 1)))
     let gridableLayout = gridComponent.collectionView?.collectionViewLayout as? FlowLayout
     let layout = Layout(json)
 
@@ -31,7 +31,7 @@ class LayoutExtensionsTests: XCTestCase {
   }
 
   func testConfigureListableComponent() {
-    let listComponent = ListComponent(model: ComponentModel(span: 1))
+    let listComponent = ListComponent(model: ComponentModel(layout: Layout(span: 1)))
     let layout = Layout(json)
 
     layout.configure(component: listComponent)


### PR DESCRIPTION
To avoid further confusion with convenience methods and properties, `span` on `ComponentModel` is now removed. The main reason is that it would be hard to keep this working 100% correctly if the concern is split between `ComponentModel` and `Layout`. It belongs on `Layout` and that should own the property...

tl;dr

Bye bye `span`. Hello `layout.span`.