### PR TITLE
Remove Component.index and .usesDynamicHeight

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -7,11 +7,6 @@
 // MARK: - Component extension
 public extension Component {
 
-  /// A computed value for the current index
-  public var index: Int {
-    return model.index
-  }
-
   public var usesDynamicHeight: Bool {
     get {
       return model.layout?.dynamicHeight ?? true

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -7,15 +7,6 @@
 // MARK: - Component extension
 public extension Component {
 
-  public var usesDynamicHeight: Bool {
-    get {
-      return model.layout?.dynamicHeight ?? true
-    }
-    set {
-      model.layout?.dynamicHeight = newValue
-    }
-  }
-
   /// A computed CGFloat of the total height of all items inside of a component
   public var computedHeight: CGFloat {
     guard usesDynamicHeight else {

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -9,7 +9,7 @@ public extension Component {
 
   /// A computed CGFloat of the total height of all items inside of a component
   public var computedHeight: CGFloat {
-    guard usesDynamicHeight else {
+    guard model.layout?.dynamicHeight == true else {
       return self.view.frame.height
     }
 

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -165,7 +165,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   ///
   /// - returns: An optional Component object of inferred type.
   open func component<T>(at index: Int = 0, ofType type: T.Type) -> T? {
-    return components.filter({ $0.index == index }).first as? T
+    return components.filter({ $0.model.index == index }).first as? T
   }
 
   /// A look up method for resolving a component at index as a component.
@@ -174,7 +174,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   ///
   /// - returns: An optional component.
   open func component(at index: Int = 0) -> Component? {
-    return components.filter({ $0.index == index }).first
+    return components.filter({ $0.model.index == index }).first
   }
 
   /// A generic look up method for resolving components using a closure

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -121,7 +121,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
   ///
   /// - returns: An optional component.
   open func component(at index: Int = 0) -> Component? {
-    return components.filter({ $0.index == index }).first
+    return components.filter({ $0.model.index == index }).first
   }
 
   /**


### PR DESCRIPTION
This is yet another clean up PR were some of the "convenience" methods.
Now `index` and `usesDynamicHeight` is removed from `Component`.
It will no use the model which is much clearer when going through the code.