### PR TITLE
Remove guard else returns as one liners.

### DIFF
--- a/Sources/Shared/Extensions/Component+Extension.swift
+++ b/Sources/Shared/Extensions/Component+Extension.swift
@@ -27,11 +27,15 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
   /// - returns: The value associated with the given key
   subscript(key: ComponentModel.Key) -> Value? {
     set(value) {
-      guard let key = key.string as? Key else { return }
+      guard let key = key.string as? Key else {
+        return
+      }
       self[key] = value
     }
     get {
-      guard let key = key.string as? Key else { return nil }
+      guard let key = key.string as? Key else {
+        return nil
+      }
       return self[key]
     }
   }

--- a/Sources/Shared/Extensions/Extensions.swift
+++ b/Sources/Shared/Extensions/Extensions.swift
@@ -36,11 +36,15 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
    */
   subscript(key: Item.Key) -> Value? {
     set(value) {
-      guard let key = key.string as? Key else { return }
+      guard let key = key.string as? Key else {
+        return
+      }
       self[key] = value
     }
     get {
-      guard let key = key.string as? Key else { return nil }
+      guard let key = key.string as? Key else {
+        return nil
+      }
       return self[key]
     }
   }

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -149,7 +149,9 @@ public extension SpotsProtocol {
   /// - parameter index:          The index of the component that you want to scroll
   /// - parameter includeElement: A filter predicate to find a view model
   public func scrollTo(componentIndex index: Int = 0, includeElement: (Item) -> Bool) {
-    guard let itemY = component(at: index)?.scrollTo(includeElement) else { return }
+    guard let itemY = component(at: index)?.scrollTo(includeElement) else {
+      return
+    }
 
     var initialHeight: CGFloat = 0.0
     if index > 0 {

--- a/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+LiveEditing.swift
@@ -13,7 +13,9 @@ import Cache
     ///
     /// - parameter filePath: A file path string, pointing to the file that should be monitored.
     private func monitor(filePath: String) {
-      guard FileManager.default.fileExists(atPath: filePath) else { return }
+      guard FileManager.default.fileExists(atPath: filePath) else {
+        return
+      }
 
       let eventMask: DispatchSource.FileSystemEvent = [.delete, .write, .extend, .attrib, .link, .rename, .revoke]
       source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: Int32(open(filePath, O_EVTONLY)),
@@ -59,9 +61,13 @@ import Cache
     /// - parameter stateCache: An optional StateCache, used for resolving which file should be monitored.
     func liveEditing(stateCache: StateCache?) {
       #if (arch(i386) || arch(x86_64)) && os(iOS)
-        guard let stateCache = stateCache, source == nil else { return }
+        guard let stateCache = stateCache, source == nil else {
+          return
+        }
       #else
-        guard let stateCache = stateCache else { return }
+        guard let stateCache = stateCache else {
+          return
+        }
       #endif
       CacheJSONOptions.writeOptions = .prettyPrinted
       print("🎍 SPOTS: Caching...")

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -329,7 +329,9 @@ extension SpotsProtocol {
         } else {
           component.beforeUpdate()
           component.update(item, index: index, withAnimation: animation) {
-            guard index == executeClosure else { return }
+            guard index == executeClosure else {
+              return
+            }
             strongSelf.finishReloading(component: component, withCompletion: completion)
           }
         }
@@ -545,7 +547,9 @@ extension SpotsProtocol {
     component.prepareItems()
 
     Dispatch.main { [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
 
       #if !os(OSX)
         if animation != .none {
@@ -718,7 +722,9 @@ extension SpotsProtocol {
   #if os(iOS)
   public func refreshSpots(_ refreshControl: UIRefreshControl) {
     Dispatch.main { [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       strongSelf.refreshPositions.removeAll()
 
       strongSelf.refreshDelegate?.componentsDidReload(strongSelf.components, refreshControl: refreshControl) {

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -67,7 +67,9 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      guard let firstItem = component.model.items.first else { return }
+      guard let firstItem = component.model.items.first else {
+        return
+      }
 
       contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
       contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)

--- a/Sources/iOS/Classes/SpotsContentView.swift
+++ b/Sources/iOS/Classes/SpotsContentView.swift
@@ -9,7 +9,9 @@ open class SpotsContentView: UIView {
   override open func didAddSubview(_ subview: UIView) {
     super.didAddSubview(subview)
 
-    guard let containerScrollView = superview as? SpotsScrollView else { return }
+    guard let containerScrollView = superview as? SpotsScrollView else {
+      return
+    }
     containerScrollView.didAddSubviewToContainer(subview)
   }
 
@@ -19,7 +21,9 @@ open class SpotsContentView: UIView {
   override open func willRemoveSubview(_ subview: UIView) {
     super.willRemoveSubview(subview)
 
-    guard let containerScrollView = superview as? SpotsScrollView else { return }
+    guard let containerScrollView = superview as? SpotsScrollView else {
+      return
+    }
     containerScrollView.willRemoveSubview(subview)
   }
 }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -234,7 +234,9 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
       refreshControl.addTarget(self, action: #selector(refreshComponent(_:)), for: .valueChanged)
 
       guard let _ = refreshDelegate, refreshControl.superview == nil
-        else { return }
+        else {
+          return
+      }
       scrollView.insertSubview(refreshControl, at: 0)
     #endif
   }
@@ -263,7 +265,9 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     super.viewWillTransition(to: size, with: coordinator)
 
     #if os(iOS)
-      guard components_shouldAutorotate() else { return }
+      guard components_shouldAutorotate() else {
+        return
+      }
     #endif
 
     coordinator.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -60,7 +60,9 @@ open class SpotsScrollView: UIScrollView {
   func didAddSubviewToContainer(_ subview: UIView) {
     subview.autoresizingMask = UIViewAutoresizing()
 
-    guard componentsView.subviews.index(of: subview) != nil else { return }
+    guard componentsView.subviews.index(of: subview) != nil else {
+      return
+    }
 
     subviewsInLayoutOrder.removeAll()
     for subview in componentsView.subviews {
@@ -142,11 +144,15 @@ open class SpotsScrollView: UIScrollView {
   /// - parameter change:  A dictionary that describes the changes that have been made to the value of the property at the key path keyPath relative to object.
   /// - parameter context: The value that was provided when the receiver was registered to receive key-value observation notifications.
   open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-    guard let keyPath = keyPath else { return }
+    guard let keyPath = keyPath else {
+      return
+    }
 
     if let change = change, context == subviewContext {
       if let scrollView = object as? UIScrollView {
-        guard let newValue = change[NSKeyValueChangeKey.oldKey] else { return }
+        guard let newValue = change[NSKeyValueChangeKey.oldKey] else {
+          return
+        }
         if #keyPath(contentSize) == keyPath {
 
           let newContentSize = scrollView.contentSize
@@ -181,7 +187,9 @@ open class SpotsScrollView: UIScrollView {
 
   /// Layout views in linear order based of view index in `subviewsInLayoutOrder`
   func layoutViews() {
-    guard let superview = superview else { return }
+    guard let superview = superview else {
+      return
+    }
 
     componentsView.frame = bounds
     componentsView.bounds = CGRect(origin: contentOffset, size: bounds.size)
@@ -238,7 +246,9 @@ open class SpotsScrollView: UIScrollView {
     let initialContentOffset = contentOffset
     layoutViews()
 
-    guard !initialContentOffset.equalTo(contentOffset) else { return }
+    guard !initialContentOffset.equalTo(contentOffset) else {
+      return
+    }
     setNeedsLayout()
     layoutIfNeeded()
   }

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -20,7 +20,9 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter collectionView: The collection view object that is notifying you of the selection change.
   /// - parameter indexPath: The index path of the cell that was selected.
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    guard let component = component, let item = component.item(at: indexPath) else { return }
+    guard let component = component, let item = component.item(at: indexPath) else {
+      return
+    }
     component.delegate?.component(component, itemSelected: item)
   }
 

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -23,7 +23,9 @@ extension SpotsController {
       offset.y > size.height - scrollView.bounds.height * multiplier &&
       !refreshPositions.contains(size.height - itemOffset)
 
-    guard let delegate = scrollDelegate else { return }
+    guard let delegate = scrollDelegate else {
+      return
+    }
 
     if scrollView.contentOffset.y < 0 && !refreshing {
       refreshing = true

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -156,7 +156,9 @@ extension UICollectionView: UserInterface {
     let indexPaths = indexes.map { IndexPath(item: $0, section: 0) }
 
     performBatchUpdates({ [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       strongSelf.deleteItems(at: indexPaths)
       }) { _ in }
     completion?()
@@ -203,7 +205,9 @@ extension UICollectionView: UserInterface {
   public func reloadSection(_ section: Int = 0, withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
     UIView.performWithoutAnimation {
       performBatchUpdates({ [weak self] in
-        guard let strongSelf = self else { return }
+        guard let strongSelf = self else {
+          return
+        }
         strongSelf.reloadSections(IndexSet(integer: section))
       }) { _ in
         completion?()

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -23,7 +23,9 @@ public class GridableLayout: FlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      guard let firstItem = component.model.items.first else { return }
+      guard let firstItem = component.model.items.first else {
+        return
+      }
 
       contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
       contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)

--- a/Sources/macOS/Classes/SpotsContentView.swift
+++ b/Sources/macOS/Classes/SpotsContentView.swift
@@ -19,7 +19,9 @@ open class SpotsContentView: NSView {
     super.didAddSubview(subview)
 
     guard let clipView = superview,
-      let containerScrollView = clipView.superview as? SpotsScrollView else { return }
+      let containerScrollView = clipView.superview as? SpotsScrollView else {
+        return
+    }
     containerScrollView.didAddSubviewToContainer(subview)
   }
 
@@ -32,7 +34,9 @@ open class SpotsContentView: NSView {
     super.willRemoveSubview(subview)
 
     guard let clipView = superview,
-      let containerScrollView = clipView.superview as? SpotsScrollView else { return }
+      let containerScrollView = clipView.superview as? SpotsScrollView else {
+        return
+    }
     containerScrollView.willRemoveSubview(subview)
   }
 }

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -101,7 +101,9 @@ open class SpotsController: NSViewController, SpotsProtocol {
    */
   deinit {
     NotificationCenter.default.removeObserver(self)
-    components.forEach { $0.delegate = nil }
+    components.forEach { component in
+      component.delegate = nil
+    }
     delegate = nil
     scrollDelegate = nil
   }

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -115,7 +115,9 @@ open class SpotsScrollView: NSScrollView {
       }
     }
 
-    guard frame.height > 0 && frame.width > 100 else { return }
+    guard frame.height > 0 && frame.width > 100 else {
+      return
+    }
 
     if frame.origin.y < 0 {
       yOffsetOfCurrentSubview -= frame.origin.y

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -66,7 +66,9 @@ extension NSCollectionView: UserInterface {
     let set = Set<IndexPath>(indexPaths)
 
     performBatchUpdates({ [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       strongSelf.insertItems(at: set as Set<IndexPath>)
     }) { _ in
       completion?()
@@ -100,7 +102,9 @@ extension NSCollectionView: UserInterface {
     let set = Set<IndexPath>(indexPaths)
 
     performBatchUpdates({ [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       strongSelf.deleteItems(at: set as Set<IndexPath>)
     }) { _ in
       completion?()
@@ -144,7 +148,9 @@ extension NSCollectionView: UserInterface {
    **/
   public func reloadSection(_ section: Int, withAnimation animation: Animation, completion: (() -> Void)?) {
     performBatchUpdates({ [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       strongSelf.reloadSections(IndexSet(integer: section))
     }) { _ in
       completion?()

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -365,7 +365,9 @@ class ComponentTests: XCTestCase {
 
     let expectation = self.expectation(description: "Wait for cache")
     Dispatch.after(seconds: 0.25) { [weak self] in
-      guard let strongSelf = self else { return }
+      guard let strongSelf = self else {
+        return
+      }
       let cachedSpot = CarouselComponent(cacheKey: strongSelf.cachedSpot.stateCache!.key)
       XCTAssertEqual(cachedSpot.model.items.count, 1)
       cachedSpot.stateCache?.clear()


### PR DESCRIPTION
This will make the source code more debuggable, now you can set clear
breakpoints for when the guard does not succeed.

So instead of:

```swift
guard foo else { return }
```

We do:

```swift
guard foo else {
  return
}
```