### PR TITLE
Keep scroll position after reload with JSON

### DIFF
--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -519,14 +519,22 @@ extension SpotsProtocol {
         strongSelf.view.addSubview(strongSelf.scrollView)
       }
 
+      let previousContentOffset = strongSelf.scrollView.contentOffset
+
       strongSelf.reloadSpotsScrollView()
       strongSelf.setupComponents(animated: animated)
+      strongSelf.components.forEach { component in
+        component.afterUpdate()
+      }
 
       completion?()
+
       if let controller = strongSelf as? SpotsController {
         SpotsController.componentsDidReloadComponentModels?(controller)
       }
+
       strongSelf.scrollView.layoutSubviews()
+      strongSelf.scrollView.contentOffset = previousContentOffset
     }
   }
 


### PR DESCRIPTION
This PR improves the controller behavior when reloading with JSON. It will now keep the scrolling position of the scroll view after the update. This why you don't have to think about when you make the update, the users scrolling should no longer be interrupted.