### PR TITLE
Improve reloading composite components, plus performance improvements when resizing windows on macOS

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -257,7 +257,7 @@ import Tailor
 
     collectionView.frame.size = size
 
-    prepareItems()
+    prepareItems(clean: false)
 
     collectionView.backgroundColors = [NSColor.clear]
     collectionView.isSelectable = true

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -247,7 +247,14 @@ open class SpotsController: NSViewController, SpotsProtocol {
   }
 
   public func windowDidResize(_ notification: Notification) {
-    components.forEach { component in
+    for component in components {
+      // Skip live resizing on views that use composite components.
+      // This is a huge performance improvement, the composite views will get their
+      // new size when the window is finish resizing (see windowDidEndLiveResize)
+      guard component.compositeComponents.isEmpty else {
+        continue
+      }
+
       layoutComponent(component)
     }
     scrollView.layoutSubviews()

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -11,7 +11,7 @@ extension Component {
 
     tableView.frame.size = size
 
-    prepareItems()
+    prepareItems(clean: false)
 
     tableView.backgroundColor = NSColor.clear
     tableView.allowsColumnReordering = false


### PR DESCRIPTION
This PR adds a clean variable to the configure item method. This indicates if the process should clean and remove views from the view hierarchy during it's process. More specifically, clean up composite views. This is not something that should be done when resizing a window on macOS or changing orientation on iOS.

It also drastically improve the performance when it comes to resizing windows on macOS as composite views will no longer live resize, it will get its new size when the user is finished with resizing the window.