### PR TITLE
Improve Component implementation

### DIFF
--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -148,7 +148,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   public init(identifier: String? = nil,
               header: Item? = nil,
               footer: Item? = nil,
-              kind: ComponentKind = .list,
+              kind: ComponentKind = Configuration.defaultComponentKind,
               layout: Layout? = nil,
               interaction: Interaction = .init(),
               items: [Item] = [],

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -14,6 +14,7 @@ struct PlatformDefaults {
 
 public struct Configuration {
 
+  public static var defaultComponentKind: ComponentKind = .grid
   public static var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
   public static var views: Registry = .init(useCache: false)
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -8,7 +8,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// It will default to this one if `Layout` is absent during init.
   public static var layout: Layout = Layout(span: 0.0)
   /// The default component kind that should be used.
-  public static var defaultKind: ComponentKind = .grid
+  public static var defaultKind: ComponentKind = Configuration.defaultComponentKind
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
   open static var configure: ((_ view: View) -> Void)?

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -71,7 +71,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `UITableView` or `UICollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either UICollectionView or UITableView).
-  public required init(model: ComponentModel, view: ScrollView, kind: ComponentKind = Component.defaultKind) {
+  public required init(model: ComponentModel, view: ScrollView) {
     self.model = model
     self.view = view
 
@@ -102,7 +102,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       ? TableView()
       : CollectionView(frame: CGRect.zero, collectionViewLayout: CollectionLayout())
 
-    self.init(model: model, view: view, kind: model.kind)
+    self.init(model: model, view: view)
   }
 
   /// A convenience init for creating a component with view state functionality.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -7,8 +7,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// The default layout that should be used for components.
   /// It will default to this one if `Layout` is absent during init.
   public static var layout: Layout = Layout(span: 0.0)
-  /// The default component kind that should be used.
-  public static var defaultKind: ComponentKind = Configuration.defaultComponentKind
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
   open static var configure: ((_ view: View) -> Void)?

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -8,8 +8,6 @@ import Tailor
   /// The default layout that should be used for components.
   /// It will default to this one if `Layout` is absent during init.
   public static var layout: Layout = Layout(span: 0.0)
-  /// The default component kind that should be used.
-  public static var defaultKind: ComponentKind = Configuration.defaultComponentKind
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
   open static var configure: ((_ view: View) -> Void)?

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -25,7 +25,6 @@ import Tailor
   /// The component model, it contains all the information for configuring `Component`
   /// interaction, behaviour and look-and-feel. See `ComponentModel` for more information.
   public var model: ComponentModel
-  public var componentKind: ComponentKind = .list
   /// A collection of composite components, dynamically constructed and mutated based of
   /// the contents of the `.model`.
   public var compositeComponents: [CompositeComponent] = []
@@ -138,9 +137,8 @@ import Tailor
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `NSTableView` or `NSCollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either NSCollectionView or NSTableView).
-  public required init(model: ComponentModel, userInterface: UserInterface, kind: ComponentKind = Component.defaultKind) {
+  public required init(model: ComponentModel, userInterface: UserInterface) {
     self.model = model
-    self.componentKind = kind
     self.userInterface = userInterface
 
     super.init()
@@ -171,9 +169,9 @@ import Tailor
       userInterface = collectionView
     }
 
-    self.init(model: model, userInterface: userInterface, kind: model.kind)
+    self.init(model: model, userInterface: userInterface)
 
-    if componentKind == .carousel {
+    if model.kind == .carousel {
       self.model.interaction.scrollDirection = .horizontal
       (collectionView?.collectionViewLayout as? FlowLayout)?.scrollDirection = .horizontal
     }
@@ -270,7 +268,7 @@ import Tailor
     backgroundView.wantsLayer = true
     collectionView.backgroundView = backgroundView
 
-    switch componentKind {
+    switch model.kind {
     case .carousel:
       setupHorizontalCollectionView(collectionView, with: size)
     default:
@@ -284,7 +282,7 @@ import Tailor
   ///   - collectionView: The collection view that should be configured.
   ///   - size: The size that should be used for setting the new layout for the collection view.
   fileprivate func layoutCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    if componentKind == .carousel {
+    if model.kind == .carousel {
       layoutHorizontalCollectionView(collectionView, with: size)
     } else {
       layoutVerticalCollectionView(collectionView, with: size)

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -9,7 +9,7 @@ import Tailor
   /// It will default to this one if `Layout` is absent during init.
   public static var layout: Layout = Layout(span: 0.0)
   /// The default component kind that should be used.
-  public static var defaultKind: ComponentKind = .list
+  public static var defaultKind: ComponentKind = Configuration.defaultComponentKind
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
   open static var configure: ((_ view: View) -> Void)?

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -44,6 +44,19 @@ class ComponentModelTests: XCTestCase {
     XCTAssert(jsonComponentModel == codeComponentModel)
   }
 
+  func testConfifugrationDefaultKind() {
+    Configuration.defaultComponentKind = .list
+    let firstModel = ComponentModel()
+    XCTAssertEqual(firstModel.kind, .list)
+
+    Configuration.defaultComponentKind = .grid
+    let secondModel = ComponentModel()
+    XCTAssertEqual(secondModel.kind, .grid)
+
+    // Reset configuration to the default
+    Configuration.defaultComponentKind = .grid
+  }
+
   func testEquatable() {
     let jsonComponentModel = ComponentModel(json)
     let layout = Layout(json["layout"] as! [String: Any])

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -282,7 +282,7 @@ class ComponentTests: XCTestCase {
     collectionView.itemSize = CGSize(width: 200, height: 100)
 
     let model = ComponentModel(json)
-    let component = Component(model: model, view: collectionView, kind: .carousel)
+    let component = Component(model: model, view: collectionView)
     let parentSize = CGSize(width: 300, height: 100)
 
     component.setup(with: parentSize)

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -11,7 +11,8 @@ class TestSpot: XCTestCase {
     Configuration.register(view: FooterView.self, identifier: "Footer")
   }
 
-  func testDefaultValues() {
+  func testDefaultValuesWithList() {
+    Configuration.defaultComponentKind = .list
     Configuration.defaultViewSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
     let items = [Item(title: "A"), Item(title: "B")]
     let model = ComponentModel(items: items)


### PR DESCRIPTION
This PR improves the separation of concerns between `Component` and `ComponentModel`.
`Component` no longer holds any reference to component kind. This is now handled by the model, as it should be. It also becomes a tinsy bit more flexible as `Configuration` now has a new property called `defaultComponentKind` that can be configured to set a desired default for your installation.

It is used as the default kind in `ComponentModel` now if the process fails to resolve the `kind`. Or if you just omit it from the init method.