### PR TITLE
Set background to clear instead of white in GridWrapper on iOS/tvOS

### DIFF
--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -6,7 +6,7 @@ public class GridWrapper: UICollectionViewCell, Wrappable, Cell {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
-    backgroundColor = .white
+    backgroundColor = .clear
   }
 
   required public init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This PR fixes the `GridWrapper` on `iOS/tvOS`. It was always setting a background color to the view which is not really what you want seeing that it is only a wrapper view.

This PR sets it to clear.