### PR TITLE
Improve collection views on iOS

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -421,8 +421,6 @@ public extension Component {
     }
   }
 
-  func beforeUpdate() {}
-
   /// Update height and refresh indexes for the component.
   ///
   /// - parameter completion: A completion closure that will be run when the computations are complete.

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -50,7 +50,18 @@ public extension Component {
         height = collectionViewLayout.collectionViewContentSize.height
       }
       #else
-        height = collectionView.collectionViewLayout.collectionViewContentSize.height
+        if let collectionViewLayout = collectionView.collectionViewLayout as? FlowLayout {
+          switch collectionViewLayout.scrollDirection {
+          case .horizontal:
+            if let firstItem = item(at: 0), firstItem.size.height > collectionViewLayout.collectionViewContentSize.height {
+              height = firstItem.size.height + collectionViewLayout.sectionInset.top + collectionViewLayout.sectionInset.bottom
+            } else {
+              height = collectionViewLayout.collectionViewContentSize.height
+            }
+          case .vertical:
+            height = collectionView.collectionViewLayout.collectionViewContentSize.height
+          }
+        }
       #endif
     }
 
@@ -410,6 +421,8 @@ public extension Component {
     }
   }
 
+  func beforeUpdate() {}
+
   /// Update height and refresh indexes for the component.
   ///
   /// - parameter completion: A completion closure that will be run when the computations are complete.
@@ -419,8 +432,6 @@ public extension Component {
       completion?()
     }
   }
-
-  public func beforeUpdate() {}
 
   func configure(with layout: Layout) {}
 }

--- a/Sources/Shared/Extensions/Component+Mutation.swift
+++ b/Sources/Shared/Extensions/Component+Mutation.swift
@@ -385,13 +385,11 @@ public extension Component {
 
       if changes.updates.isEmpty {
         strongSelf.process(changes.updatedChildren, withAnimation: animation) {
-          strongSelf.layout(with: strongSelf.view.bounds.size)
           completion?()
         }
       } else {
         strongSelf.process(changes.updates, withAnimation: animation) {
           strongSelf.process(changes.updatedChildren, withAnimation: animation) {
-            strongSelf.layout(with: strongSelf.view.bounds.size)
             completion?()
           }
         }

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -180,13 +180,7 @@ extension SpotsProtocol {
     }
 
     let tempSpot = Component(model: newComponentModels[index])
-    tempSpot.view.frame = component.view.frame
-    tempSpot.setup(with: tempSpot.view.frame.size)
-    tempSpot.layout(with: tempSpot.view.frame.size)
-    tempSpot.view.frame.size.height = tempSpot.computedHeight
-    tempSpot.view.layoutIfNeeded()
-    tempSpot.prepareItems()
-
+    tempSpot.setup(with: component.view.frame.size)
     tempSpot.model.size = CGSize(
       width: view.frame.width,
       height: ceil(tempSpot.view.frame.height))

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -248,8 +248,15 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     )
   }
 
+  public func beforeUpdate() {
+  }
+
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
-    setup(with: view.frame.size)
+    if compositeComponents.isEmpty {
+      layout(with: view.frame.size)
+    } else {
+      setup(with: view.frame.size)
+    }
   }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -248,6 +248,10 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     )
   }
 
+  /// This method is invoked before mutations are performed on a component.
+  /// Not used at the moment.
+  func beforeUpdate() {}
+
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
     if compositeComponents.isEmpty {

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -248,9 +248,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     )
   }
 
-  public func beforeUpdate() {
-  }
-
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
     if compositeComponents.isEmpty {

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -56,9 +56,15 @@ extension Component {
       return
     }
 
+    // This fixes a constraints warning when trying to prepare a collection view
+    // before it has gotten its initial frame.
+    if collectionViewLayout.contentSize.height < collectionView.frame.size.height {
+      collectionView.frame.size.height = computedHeight
+    }
+
     collectionViewLayout.prepare()
     collectionViewLayout.invalidateLayout()
     collectionView.frame.size.width = size.width
-    collectionView.frame.size.height = collectionViewLayout.contentSize.height
+    collectionView.frame.size.height = computedHeight
   }
 }

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -368,6 +368,10 @@ import Tailor
     }
   }
 
+  /// This method is invoked before mutations are performed on a component.
+  /// Not used at the moment.
+  func beforeUpdate() {}
+
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
     if let superview = view.superview {

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -375,4 +375,48 @@ class ComponentTests: XCTestCase {
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
+
+  func testComputedHeightForListComponent() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz"),
+      Item(title: "foo")
+    ]
+    let model = ComponentModel(kind: .list, items: items)
+    let component = Component(model: model)
+    component.setup(with: .init(width: 100, height: 100))
+
+    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight * CGFloat(items.count))
+  }
+
+  func testComputedHeightForGridComponent() {
+    let layout = Layout(span: 1)
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz"),
+      Item(title: "foo")
+    ]
+    let model = ComponentModel(kind: .grid, layout: layout, items: items)
+    let component = Component(model: model)
+    component.setup(with: .init(width: 100, height: 100))
+
+    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight * CGFloat(items.count))
+  }
+
+  func testComputedHeightForCarouselComponent() {
+    let layout = Layout(span: 1)
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz"),
+      Item(title: "foo")
+    ]
+    let model = ComponentModel(kind: .carousel, layout: layout, items: items)
+    let component = Component(model: model)
+    component.setup(with: .init(width: 100, height: 100))
+
+    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight)
+  }
 }

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -377,6 +377,7 @@ class ComponentTests: XCTestCase {
   }
 
   func testComputedHeightForListComponent() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
@@ -387,10 +388,11 @@ class ComponentTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight * CGFloat(items.count))
+    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height * CGFloat(items.count))
   }
 
   func testComputedHeightForGridComponent() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     let layout = Layout(span: 1)
     let items = [
       Item(title: "foo"),
@@ -402,10 +404,11 @@ class ComponentTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight * CGFloat(items.count))
+    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height * CGFloat(items.count))
   }
 
   func testComputedHeightForCarouselComponent() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     let layout = Layout(span: 1)
     let items = [
       Item(title: "foo"),
@@ -417,6 +420,6 @@ class ComponentTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, PlatformDefaults.defaultHeight)
+    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height)
   }
 }

--- a/SpotsTests/iOS/TestComponent.swift
+++ b/SpotsTests/iOS/TestComponent.swift
@@ -8,6 +8,7 @@ class ComponentTests: XCTestCase {
   var cachedSpot: Component!
 
   override func setUp() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     component = Component(model: ComponentModel(layout: Layout(span: 1)))
     cachedSpot = Component(cacheKey: "cached-carousel-component")
     XCTAssertNotNil(cachedSpot.stateCache)
@@ -377,7 +378,6 @@ class ComponentTests: XCTestCase {
   }
 
   func testComputedHeightForListComponent() {
-    Configuration.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
@@ -392,7 +392,6 @@ class ComponentTests: XCTestCase {
   }
 
   func testComputedHeightForGridComponent() {
-    Configuration.registerDefault(view: DefaultItemView.self)
     let layout = Layout(span: 1)
     let items = [
       Item(title: "foo"),
@@ -408,7 +407,6 @@ class ComponentTests: XCTestCase {
   }
 
   func testComputedHeightForCarouselComponent() {
-    Configuration.registerDefault(view: DefaultItemView.self)
     let layout = Layout(span: 1)
     let items = [
       Item(title: "foo"),


### PR DESCRIPTION
This PR refactors some internal processes to be more optimized for the new `Component` class.

It also fixes a bunch of collection view layout warnings that may appear  because the layout tried to prepare itself before the collection view had a frame.

Some calls to `layout` in the component mutation extension has also been removed to improve performance.

`afterUpdate` will call `layout` instead of `setup` which should fix the blinking that could happen when using infinite scrolling.

`computedHeight` has also been optimized to leverage for the component kind to figure out which size it should return.