### PR TITLE
Move page indicator related code to layout instead of setup

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -166,17 +166,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     switch model.interaction.scrollDirection {
     case .horizontal:
       setupHorizontalCollectionView(collectionView, with: size)
-
-      if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement, let layout = collectionView.collectionViewLayout as? FlowLayout {
-        switch pageIndicatorPlacement {
-        case .below:
-          layout.sectionInset.bottom += pageControl.frame.height
-          pageControl.frame.origin.y = collectionView.frame.height
-        case .overlay:
-          let verticalAdjustment = CGFloat(2)
-          pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
-        }
-      }
     case .vertical:
       setupVerticalCollectionView(collectionView, with: size)
     }
@@ -194,6 +183,16 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     switch model.interaction.scrollDirection {
     case .horizontal:
+      if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement, let layout = collectionView.collectionViewLayout as? FlowLayout {
+        switch pageIndicatorPlacement {
+        case .below:
+          pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height
+        case .overlay:
+          let verticalAdjustment = CGFloat(2)
+          pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
+        }
+      }
+
       layoutHorizontalCollectionView(collectionView, with: size)
     case .vertical:
       layoutVerticalCollectionView(collectionView, with: size)


### PR DESCRIPTION
If the layout changes after the setup, the page indicator needs to
adjust its location. Moving the positioning code of the page indicator
to the layout method fixes this issue.