### PR TITLE
Feature reload with component models

### DIFF
--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -657,7 +657,7 @@ class SpotsControllerTests: XCTestCase {
     XCTAssertEqual(diff![5], .text)
   }
 
-  func testReloadWithComponentModels() {
+  func testReloadIfNeededWithComponentModels() {
     Configuration.registerDefault(view: DefaultItemView.self)
     Configuration.defaultViewSize = .init(width: 0, height: 44)
     let initialComponentModels = [

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -903,4 +903,24 @@ class SpotsControllerTests: XCTestCase {
 
     waitForExpectations(timeout: 10.0, handler: nil)
   }
+
+  func testReloadWithComponentModels() {
+    let controller = SpotsController(components: [])
+    let expectation = self.expectation(description: "Wait reload to complete")
+    let models = [
+      ComponentModel(header: Item(title: "foo")),
+      ComponentModel(items: [Item(title: "bar")]),
+      ComponentModel(footer: Item(title: "baz"))
+    ]
+
+    controller.reload(models) {
+      XCTAssertEqual(controller.components.count, 3)
+      XCTAssertTrue(controller.components[0].model.header! == Item(title: "foo"))
+      XCTAssertTrue(controller.components[1].model.items   == [Item(title: "bar")])
+      XCTAssertTrue(controller.components[2].model.footer! == Item(title: "baz"))
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
 }


### PR DESCRIPTION
This method is very similar to the `reload(_ json)`, it just takes a
different data type. This is especially useful for apps that use
component model factories to construct their UI. So instead of passing
`stringly` typed JSON, you can now models.