### PR TITLE
Return wrapped view instead of wrapper view

### DIFF
--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -36,7 +36,8 @@ extension Delegate: UICollectionViewDelegate {
       return
     }
 
-    component.delegate?.component(component, willDisplay: cell, item: item)
+    let view = (cell as? Wrappable)?.wrappedView ?? cell
+    component.delegate?.component(component, willDisplay: view, item: item)
   }
 
   /// Tells the delegate that the specified cell was removed from the collection view.
@@ -50,7 +51,8 @@ extension Delegate: UICollectionViewDelegate {
       return
     }
 
-    component.delegate?.component(component, didEndDisplaying: cell, item: item)
+    let view = (cell as? Wrappable)?.wrappedView ?? cell
+    component.delegate?.component(component, didEndDisplaying: view, item: item)
   }
 
   /// Asks the delegate whether the item at the specified index path can be focused.
@@ -174,7 +176,8 @@ extension Delegate: UITableViewDelegate {
       return
     }
 
-    component.delegate?.component(component, willDisplay: cell, item: item)
+    let view = (cell as? Wrappable)?.wrappedView ?? cell
+    component.delegate?.component(component, willDisplay: view, item: item)
   }
 
   /// Tells the delegate that the specified cell was removed from the table.
@@ -187,7 +190,8 @@ extension Delegate: UITableViewDelegate {
       return
     }
 
-    component.delegate?.component(component, didEndDisplaying: cell, item: item)
+    let view = (cell as? Wrappable)?.wrappedView ?? cell
+    component.delegate?.component(component, didEndDisplaying: view, item: item)
   }
 
   /// Asks the delegate for a view object to display in the header of the specified section of the table view.

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -26,15 +26,13 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item being added.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    let view = item
-
     guard
       let component = component,
+      let view = (item as? Wrappable)?.wrappedView,
       let item = component.item(at: indexPath)
       else {
         return
     }
-
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 
@@ -44,10 +42,9 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item that was removed.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    let view = item
-
     guard
       let component = component,
+      let view = (item as? Wrappable)?.wrappedView,
       let item = component.item(at: indexPath)
       else {
         return
@@ -136,11 +133,12 @@ extension Delegate: NSTableViewDelegate {
     guard
       let component = component,
       let item = component.item(at: row),
-      let view = cell as? View
+      let cell = cell as? View
       else {
         return
     }
 
+    let view = (cell as? Wrappable)?.wrappedView ?? cell
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		BD77D1FC1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
 		BD77D1FD1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
 		BD77D1FE1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
+		BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
+		BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
+		BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD9AB9F61E44AD9700085677 /* TestCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestCoreComponent.swift */; };
 		BD9ECEB71E6EC6B4003E4388 /* Component+macOS+Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */; };
 		BD9ECEB81E6EC6BC003E4388 /* Component+macOS+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */; };
@@ -406,6 +409,7 @@
 		BD77D1F31E8537E80075A3FC /* ComponentModelDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentModelDiff.swift; sourceTree = "<group>"; };
 		BD77D1F71E8538080075A3FC /* ComponentModelKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentModelKind.swift; sourceTree = "<group>"; };
 		BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentModel+Equatable.swift"; sourceTree = "<group>"; };
+		BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentDelegate.swift; sourceTree = "<group>"; };
 		BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Carousel.swift"; sourceTree = "<group>"; };
 		BD9ECEB91E6EC6D1003E4388 /* Component+macOS+Grid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Grid.swift"; sourceTree = "<group>"; };
@@ -1018,6 +1022,7 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
+				BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1569,6 +1574,7 @@
 				BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDD9ABCF1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
+				BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */,
@@ -1700,6 +1706,7 @@
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
+				BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */,
 				D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
@@ -1805,6 +1812,7 @@
 			files = (
 				D58478E71C440645006EBA49 /* TestComponentModel.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
+				BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,

--- a/SpotsTests/Shared/TestComponentDelegate.swift
+++ b/SpotsTests/Shared/TestComponentDelegate.swift
@@ -1,0 +1,56 @@
+import XCTest
+import Spots
+
+class MockComponentDelegate: ComponentDelegate {
+
+  var testClosure: ((MockComponentDelegate) -> Void)?
+  var expectation: XCTestExpectation?
+  var didDisplayCorrectView: Bool = false
+  var didEndDisplayCorrectView: Bool = false {
+    didSet {
+      testClosure?(self)
+      expectation?.fulfill()
+    }
+  }
+
+  func component(_ component: Component, willDisplay view: ComponentView, item: Item) {
+    didDisplayCorrectView = view is DefaultItemView
+  }
+
+  func component(_ component: Component, didEndDisplaying view: ComponentView, item: Item) {
+    didEndDisplayCorrectView = view is DefaultItemView
+  }
+}
+
+class TestComponentDelegate: XCTestCase {
+
+  var mockDelegate: MockComponentDelegate!
+
+  override func setUp() {
+    mockDelegate = MockComponentDelegate()
+    Configuration.registerDefault(view: DefaultItemView.self)
+  }
+
+  func testComponentWillDisplayAndEndDisplay() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .grid, layout: Layout(span: 1), items: items)
+    let component = Component(model: model)
+    let controller = SpotsController(components: [component])
+    controller.delegate = mockDelegate
+    controller.prepareController()
+
+    XCTAssertTrue(mockDelegate.didDisplayCorrectView)
+    mockDelegate.testClosure = { mockDelegate in
+      XCTAssertTrue(mockDelegate.didEndDisplayCorrectView)
+    }
+
+    mockDelegate.expectation = self.expectation(description: "Wait for mutation")
+    controller.delete(0, componentIndex: 0, withAnimation: .automatic)
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+}

--- a/SpotsTests/macOS/TestClickInteraction.swift
+++ b/SpotsTests/macOS/TestClickInteraction.swift
@@ -15,7 +15,7 @@ class MockTableView: NSTableView {
   }
 }
 
-class MockComponentDelegate: NSObject, ComponentDelegate {
+class MockClickComponentDelegate: NSObject, ComponentDelegate {
 
   var invocation: Int = 0
 
@@ -28,7 +28,7 @@ class TestMouseClick: XCTestCase {
 
   func testMouseClick() {
     let mockTableView = MockTableView()
-    let mockDelegate = MockComponentDelegate()
+    let mockDelegate = MockClickComponentDelegate()
     let interaction = Interaction(mouseClick: .single)
     let model = ComponentModel(kind: .list, interaction: interaction, items: [
       Item(title: "foo")


### PR DESCRIPTION
Try to resolve `.wrappedView` before calling component delegate. This
will make the delegate implementation much more lean as it would not
return the wrapper but the underlaying view instead.