### PR TITLE
Feature scrollTo and itemOffset methods for doing interactive UI

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -202,15 +202,6 @@ public extension Component {
     stateCache?.save(dictionary)
   }
 
-  /// Scroll to Item matching predicate
-  ///
-  /// - parameter includeElement: A filter predicate to find a view model
-  ///
-  /// - returns: A calculate CGFloat based on what the includeElement matches
-  public func scrollTo(_ includeElement: (Item) -> Bool) -> CGFloat {
-    return 0.0
-  }
-
   /// Prepares a view model item before being used by the UI component
   ///
   /// - parameter index:        The index of the view model
@@ -419,6 +410,25 @@ public extension Component {
     } else {
       return Configuration.views.defaultIdentifier
     }
+  }
+
+  /// Get offset of item
+  ///
+  /// - Parameter includeElement: A predicate closure to determine the offset of the item.
+  /// - Returns: The offset based of the model data.
+  public func itemOffset(_ includeElement: (Item) -> Bool) -> CGFloat {
+    guard let item = model.items.filter(includeElement).first else {
+      return 0.0
+    }
+
+    let offset: CGFloat
+    if model.interaction.scrollDirection == .horizontal {
+      offset = model.items[0..<item.index].reduce(0, { $0 + $1.size.width })
+    } else {
+      offset = model.items[0..<item.index].reduce(0, { $0 + $1.size.height })
+    }
+
+    return offset
   }
 
   /// Update height and refresh indexes for the component.

--- a/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Extensions.swift
@@ -149,7 +149,7 @@ public extension SpotsProtocol {
   /// - parameter index:          The index of the component that you want to scroll
   /// - parameter includeElement: A filter predicate to find a view model
   public func scrollTo(componentIndex index: Int = 0, includeElement: (Item) -> Bool) {
-    guard let itemY = component(at: index)?.scrollTo(includeElement) else {
+    guard let itemY = component(at: index)?.itemOffset(includeElement) else {
       return
     }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -247,6 +247,29 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     )
   }
 
+  /// Scroll to a specific item based on predicate.
+  ///
+  /// - parameter predicate: A predicate closure to determine which item to scroll to.
+  public func scrollTo(item predicate: ((Item) -> Bool), animated: Bool = true) {
+    guard let index = model.items.index(where: predicate) else {
+      return
+    }
+
+    if let collectionView = collectionView {
+      let scrollPosition: UICollectionViewScrollPosition
+
+      if model.interaction.scrollDirection == .horizontal {
+        scrollPosition = .centeredHorizontally
+      } else {
+        scrollPosition = .centeredVertically
+      }
+
+      collectionView.scrollToItem(at: .init(item: index, section: 0), at: scrollPosition, animated: animated)
+    } else if let tableView = tableView {
+      tableView.scrollToRow(at: .init(row: index, section: 0), at: .middle, animated: animated)
+    }
+  }
+
   /// This method is invoked before mutations are performed on a component.
   /// Not used at the moment.
   func beforeUpdate() {}

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -183,7 +183,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     switch model.interaction.scrollDirection {
     case .horizontal:
-      if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement, let layout = collectionView.collectionViewLayout as? FlowLayout {
+      if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement {
         switch pageIndicatorPlacement {
         case .below:
           pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		BD24030C1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD24030D1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD2403111E4B9A02005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2403101E4B9A02005BAA19 /* Component.swift */; };
-		BD4295551D81D39700E07E1C /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* TestComponent.swift */; };
+		BD4295551D81D39700E07E1C /* TestComponentiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* TestComponentiOS.swift */; };
 		BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
 		BD42CA861E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
 		BD45D9871E30906300C2D6B2 /* TestLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9861E30906300C2D6B2 /* TestLayout.swift */; };
@@ -43,8 +43,8 @@
 		BD45D9961E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
 		BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
 		BD5FC7DF1E857AD900D03038 /* FlippedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7DE1E857AD900D03038 /* FlippedView.swift */; };
-		BD677E851DC616B2006D1654 /* TestCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestCoreComponent.swift */; };
-		BD677E871DC616B2006D1654 /* TestCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestCoreComponent.swift */; };
+		BD677E851DC616B2006D1654 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
+		BD677E871DC616B2006D1654 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
 		BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
 		BD677E8A1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
 		BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
@@ -69,7 +69,7 @@
 		BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
-		BD9AB9F61E44AD9700085677 /* TestCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestCoreComponent.swift */; };
+		BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
 		BD9ECEB71E6EC6B4003E4388 /* Component+macOS+Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */; };
 		BD9ECEB81E6EC6BC003E4388 /* Component+macOS+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */; };
 		BD9ECEBA1E6EC6D1003E4388 /* Component+macOS+Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB91E6EC6D1003E4388 /* Component+macOS+Grid.swift */; };
@@ -390,7 +390,7 @@
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
-		BD4295541D81D39700E07E1C /* TestComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponent.swift; sourceTree = "<group>"; };
+		BD4295541D81D39700E07E1C /* TestComponentiOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentiOS.swift; sourceTree = "<group>"; };
 		BD42CA841E4C9B2600A86E3B /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD45D9861E30906300C2D6B2 /* TestLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayout.swift; sourceTree = "<group>"; };
 		BD45D98A1E30909700C2D6B2 /* TestLayoutExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayoutExtensions.swift; sourceTree = "<group>"; };
@@ -399,7 +399,7 @@
 		BD45D9981E30B0F700C2D6B2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BD45D9991E30B0F700C2D6B2 /* Spots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Spots.podspec; sourceTree = "<group>"; };
 		BD5FC7DE1E857AD900D03038 /* FlippedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlippedView.swift; sourceTree = "<group>"; };
-		BD677E841DC616B2006D1654 /* TestCoreComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCoreComponent.swift; sourceTree = "<group>"; };
+		BD677E841DC616B2006D1654 /* TestComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponent.swift; sourceTree = "<group>"; };
 		BD677E881DC61EFC006D1654 /* TestStateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStateCache.swift; sourceTree = "<group>"; };
 		BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIViewControllerExtensions.swift; sourceTree = "<group>"; };
 		BD677E8E1DC65D63006D1654 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Helpers.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -990,7 +990,7 @@
 			children = (
 				BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */,
 				BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */,
-				BD4295541D81D39700E07E1C /* TestComponent.swift */,
+				BD4295541D81D39700E07E1C /* TestComponentiOS.swift */,
 				BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */,
 				BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */,
 				BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */,
@@ -1012,7 +1012,7 @@
 				BD677E8E1DC65D63006D1654 /* Helpers.swift */,
 				D584782B1C43FF34006EBA49 /* TestComponentModel.swift */,
 				BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */,
-				BD677E841DC616B2006D1654 /* TestCoreComponent.swift */,
+				BD677E841DC616B2006D1654 /* TestComponent.swift */,
 				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
 				BDEA327E1E87A6FF0044B056 /* TestInteraction.swift */,
 				BDB8D5921E4DFADC00220BC3 /* TestItem.swift */,
@@ -1566,7 +1566,7 @@
 				D5D282741E547742004BF251 /* TestListWrapper.swift in Sources */,
 				BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */,
 				BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
-				BD677E871DC616B2006D1654 /* TestCoreComponent.swift in Sources */,
+				BD677E871DC616B2006D1654 /* TestComponent.swift in Sources */,
 				BDDF2CCD1DC7C23500B766BA /* TestAnimations.swift in Sources */,
 				BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD01BD1A1DAEA7FD009C10FF /* TestListComposite.swift in Sources */,
@@ -1691,13 +1691,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				D5D282761E547D1D004BF251 /* TestGridWrapper.swift in Sources */,
-				BD4295551D81D39700E07E1C /* TestComponent.swift in Sources */,
+				BD4295551D81D39700E07E1C /* TestComponentiOS.swift in Sources */,
 				D58478571C43FFFD006EBA49 /* TestComponentModel.swift in Sources */,
 				BD45D98B1E30909700C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BDDF2CCC1DC7C23500B766BA /* TestAnimations.swift in Sources */,
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */,
-				BD677E851DC616B2006D1654 /* TestCoreComponent.swift in Sources */,
+				BD677E851DC616B2006D1654 /* TestComponent.swift in Sources */,
 				BD45D9871E30906300C2D6B2 /* TestLayout.swift in Sources */,
 				BDB8D5931E4DFADC00220BC3 /* TestItem.swift in Sources */,
 				BD6FBEF01E12B5F000AA58BD /* TestComposition.swift in Sources */,
@@ -1817,7 +1817,7 @@
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
-				BD9AB9F61E44AD9700085677 /* TestCoreComponent.swift in Sources */,
+				BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,
 				BDFC474F1E747B2B008700BF /* TestGridWrapper.swift in Sources */,

--- a/SpotsTests/Shared/TestComponent.swift
+++ b/SpotsTests/Shared/TestComponent.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-class CoreComponentTests: XCTestCase {
+class ComponentTests: XCTestCase {
 
   func testAppendingMultipleItemsToComponent() {
     let listComponent = Component(model: ComponentModel(kind: .list, layout: Layout(span: 1)))
@@ -126,5 +126,47 @@ class CoreComponentTests: XCTestCase {
 
     // This should be invoked twice, once for each view.
     XCTAssertEqual(invokeCount, 2)
+  }
+
+  func testListItemOffset() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .list,items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(component.itemOffset({ $0.title == "bar" }), PlatformDefaults.defaultHeight)
+    XCTAssertEqual(component.itemOffset({ $0.title == "bal" }), 0)
+  }
+
+  func testGridItemOffset() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .grid, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(component.itemOffset({ $0.title == "bar" }), PlatformDefaults.defaultHeight)
+    XCTAssertEqual(component.itemOffset({ $0.title == "bal" }), 0)
+  }
+
+  func testCarouselItemOffset() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .carousel, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(component.itemOffset({ $0.title == "bar" }), 100)
+    XCTAssertEqual(component.itemOffset({ $0.title == "bal" }), 0)
   }
 }

--- a/SpotsTests/iOS/TestComponentiOS.swift
+++ b/SpotsTests/iOS/TestComponentiOS.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-class ComponentTests: XCTestCase {
+class ComponentTestsOniOS: XCTestCase {
 
   var component: Component!
   var cachedSpot: Component!
@@ -419,5 +419,57 @@ class ComponentTests: XCTestCase {
     component.setup(with: .init(width: 100, height: 100))
 
     XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height)
+  }
+
+  func testListScrollTo() {
+    let items = [
+      Item(title: "item1"),
+      Item(title: "item2"),
+      Item(title: "item3"),
+      Item(title: "item4"),
+      Item(title: "item5"),
+      Item(title: "item6")
+    ]
+    let model = ComponentModel(kind: .list,items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    component.scrollTo(item: { $0.title == "item5" }, animated: false)
+
+    XCTAssertEqual(component.view.contentOffset.y, 148)
+  }
+
+  func testGridScrollTo() {
+    let items = [
+      Item(title: "item1"),
+      Item(title: "item2"),
+      Item(title: "item3"),
+      Item(title: "item4"),
+      Item(title: "item5"),
+      Item(title: "item6")
+    ]
+    let model = ComponentModel(kind: .grid, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    component.view.frame.size.height = 100
+    component.scrollTo(item: { $0.title == "item5" }, animated: false)
+
+    XCTAssertEqual(component.view.contentOffset.y, 148)
+  }
+
+  func testCarouselScrollTo() {
+    let items = [
+      Item(title: "item1"),
+      Item(title: "item2"),
+      Item(title: "item3"),
+      Item(title: "item4"),
+      Item(title: "item5"),
+      Item(title: "item6")
+    ]
+    let model = ComponentModel(kind: .carousel, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    component.scrollTo(item: { $0.title == "item5" })
+
+    XCTAssertEqual(component.view.contentOffset.x, 400)
   }
 }

--- a/SpotsTests/iOS/TestComponentiOS.swift
+++ b/SpotsTests/iOS/TestComponentiOS.swift
@@ -422,6 +422,7 @@ class ComponentTestsOniOS: XCTestCase {
   }
 
   func testListScrollTo() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "item1"),
       Item(title: "item2"),
@@ -435,10 +436,11 @@ class ComponentTestsOniOS: XCTestCase {
     component.setup(with: CGSize(width: 100, height: 100))
     component.scrollTo(item: { $0.title == "item5" }, animated: false)
 
-    XCTAssertEqual(component.view.contentOffset.y, 148)
+    XCTAssertEqual(component.view.contentOffset.y, 346)
   }
 
   func testGridScrollTo() {
+    Configuration.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "item1"),
       Item(title: "item2"),
@@ -453,7 +455,7 @@ class ComponentTestsOniOS: XCTestCase {
     component.view.frame.size.height = 100
     component.scrollTo(item: { $0.title == "item5" }, animated: false)
 
-    XCTAssertEqual(component.view.contentOffset.y, 148)
+    XCTAssertEqual(component.view.contentOffset.y, 346)
   }
 
   func testCarouselScrollTo() {


### PR DESCRIPTION
This PR adds features that previously resided on core components. Now `Component` has the same kind of functionality. Basically it adds to methods on `Component`. One for getting the offset of an item using a predicate and another one for easily scrolling to an item without having to know about orientation or what underlaying UI implementation the `Component` uses to render itself.