### PR TITLE
Feature SpotsControllerManager

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -1,0 +1,763 @@
+// swiftlint:disable type_body_length
+#if os(OSX)
+  import Foundation
+#else
+  import UIKit
+#endif
+
+public class SpotsControllerManager {
+
+  public typealias CompareClosure = ((_ lhs: [ComponentModel], _ rhs: [ComponentModel]) -> Bool)
+
+  /**
+   Reload all components.
+
+   - parameter animated:   A boolean value that indicates if animations should be applied, defaults to true
+   - parameter animation:  A ComponentAnimation struct that determines which animation that should be used for the updates
+   - parameter completion: A completion block that is run when the reloading is done
+   */
+  public func reload(controller: SpotsController, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
+    var componentsLeft = controller.components.count
+
+    Dispatch.main {
+      controller.components.forEach { component in
+        component.reload([], withAnimation: animation) {
+          componentsLeft -= 1
+
+          if componentsLeft == 0 {
+            completion?()
+          }
+        }
+      }
+    }
+  }
+
+  /// Reload if needed using JSON
+  ///
+  /// - parameter components: A collection of components that gets parsed into UI elements
+  /// - parameter compare: A closure that is used for comparing a ComponentModel collections
+  /// - parameter animated: An animation closure that can be used to perform custom animations when reloading
+  /// - parameter completion: A closure that will be run after reload has been performed on all components
+  public func reloadIfNeeded(components: [ComponentModel],
+                             controller: SpotsController,
+                             compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
+                             withAnimation animation: Animation = .automatic,
+                             completion: Completion = nil) {
+    guard !components.isEmpty else {
+      Dispatch.main {
+        controller.components.forEach {
+          $0.view.removeFromSuperview()
+        }
+        controller.components = []
+        completion?()
+      }
+      return
+    }
+
+    Dispatch.interactive { [weak self] in
+      guard let strongSelf = self else {
+        completion?()
+        return
+      }
+
+      let oldSpots = controller.components
+      let oldComponentModels = oldSpots.map { $0.model }
+      var newComponentModels = components
+
+      /// Prepare default layouts for new components based of previous Component kind.
+      for (index, _) in newComponentModels.enumerated() {
+        guard index < oldComponentModels.count else {
+          break
+        }
+
+        if newComponentModels[index].layout == nil {
+          newComponentModels[index].layout = type(of: oldSpots[index]).layout
+        }
+      }
+
+      guard compare(newComponentModels, oldComponentModels) else {
+        controller.cache()
+        Dispatch.main {
+          controller.scrollView.layoutViews()
+          SpotsController.componentsDidReloadComponentModels?(controller)
+          completion?()
+        }
+        return
+      }
+
+      let changes = strongSelf.generateChanges(from: newComponentModels, and: oldComponentModels)
+
+      strongSelf.process(changes: changes, controller: controller, components: newComponentModels, withAnimation: animation) {
+        Dispatch.main {
+          controller.scrollView.layoutSubviews()
+          controller.cache()
+          SpotsController.componentsDidReloadComponentModels?(controller)
+          completion?()
+        }
+      }
+    }
+  }
+
+  /// Generate a change set by comparing two component collections
+  ///
+  /// - parameter components:    A collection of components
+  /// - parameter oldComponentModels: A collection of components
+  ///
+  /// - returns: A ComponentModelDiff struct
+  func generateChanges(from models: [ComponentModel], and oldComponentModels: [ComponentModel]) -> [ComponentModelDiff] {
+    let oldComponentModelCount = oldComponentModels.count
+    var changes = [ComponentModelDiff]()
+    for (index, model) in models.enumerated() {
+      if index >= oldComponentModelCount {
+        changes.append(.new)
+        continue
+      }
+
+      changes.append(model.diff(model: oldComponentModels[index]))
+    }
+
+    if oldComponentModelCount > models.count {
+      oldComponentModels[models.count..<oldComponentModels.count].forEach { _ in
+        changes.append(.removed)
+      }
+    }
+
+    return changes
+  }
+
+  fileprivate func replaceComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
+    let component = Component(model: newComponentModels[index])
+    let oldSpot = controller.components[index]
+
+    /// Remove old composite components from superview and empty container
+    for compositeSpot in oldSpot.compositeComponents {
+      compositeSpot.component.view.removeFromSuperview()
+    }
+    oldSpot.compositeComponents = []
+
+    component.view.frame = oldSpot.view.frame
+
+    oldSpot.view.removeFromSuperview()
+    controller.components[index] = component
+    controller.scrollView.componentsView.insertSubview(component.view, at: index)
+    controller.setupComponent(at: index, component: component)
+
+    yOffset += component.view.frame.size.height
+  }
+
+  fileprivate func newComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
+    let component = Component(model: newComponentModels[index])
+    controller.components.append(component)
+    controller.setupComponent(at: index, component: component)
+
+    yOffset += component.view.frame.size.height
+  }
+
+  /// Remove Spot at index
+  ///
+  /// - parameter index: The index of the Component object hat you want to remove
+  fileprivate func removeComponent(atIndex index: Int, controller: SpotsController) {
+    guard index < controller.components.count else {
+      return
+    }
+    controller.components[index].view.removeFromSuperview()
+  }
+
+  /// Set up items for a Component object
+  ///
+  /// - parameter index:         The index of the Component object
+  /// - parameter newComponentModels: A collection of new components
+  /// - parameter animation:     A Animation that is used to determine which animation to use when performing the update
+  /// - parameter closure:       A completion closure that is invoked when the setup of the new items is complete
+  ///
+  /// - returns: A boolean value that determines if the closure should run in `process(changes:)`
+  fileprivate func setupItemsForComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], withAnimation animation: Animation = .automatic, completion: Completion = nil) -> Bool {
+    guard let component = controller.component(at: index) else {
+      return false
+    }
+
+    let tempSpot = Component(model: newComponentModels[index])
+    tempSpot.setup(with: component.view.frame.size)
+    tempSpot.model.size = CGSize(
+      width: controller.view.frame.width,
+      height: ceil(tempSpot.view.frame.height))
+
+    guard let diff = Item.evaluate(tempSpot.model.items, oldModels: component.model.items) else {
+      return true
+    }
+
+    let newItems = tempSpot.model.items
+    let changes: (ItemChanges) = Item.processChanges(diff)
+
+    for index in changes.updatedChildren {
+      if index < tempSpot.compositeComponents.count {
+        component.compositeComponents[index].component.view.removeFromSuperview()
+        component.compositeComponents[index] = tempSpot.compositeComponents[index]
+        component.compositeComponents[index].parentComponent = component
+      }
+    }
+
+    if newItems.count == component.model.items.count {
+      reload(with: changes, controller: controller, in: component, newItems: newItems, animation: animation) { [weak self] in
+        if let strongSelf = self, let completion = completion {
+          strongSelf.completeUpdates(controller: controller)
+          completion()
+        }
+      }
+    } else if newItems.count < component.model.items.count {
+      reload(with: changes, controller: controller, in: component, lessItems: newItems, animation: animation) { [weak self] in
+        if let strongSelf = self, let completion = completion {
+          strongSelf.completeUpdates(controller: controller)
+          completion()
+        }
+      }
+    } else if newItems.count > component.model.items.count {
+      reload(with: changes, controller: controller, in: component, moreItems: newItems, animation: animation) { [weak self] in
+        if let strongSelf = self, let completion = completion {
+          strongSelf.completeUpdates(controller: controller)
+          completion()
+        }
+      }
+    }
+
+    return false
+  }
+
+  /// Reload Component object with changes and new items.
+  ///
+  /// - parameter changes:   A ItemChanges tuple.
+  /// - parameter component:      The component that should be updated.
+  /// - parameter newItems:  The new items that should be used to updated the data source.
+  /// - parameter animation: The animation that should be used when updating.
+  /// - parameter closure:   A completion closure.
+  private func reload(with changes: (ItemChanges),
+                      controller: SpotsController,
+                      in component: Component,
+                      newItems: [Item],
+                      animation: Animation,
+                      completion: (() -> Void)? = nil) {
+    var offsets = [CGPoint]()
+
+    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
+      component.beforeUpdate()
+
+      for item in newItems {
+        let results = component.compositeComponents.filter({ $0.itemIndex == item.index })
+        for compositeSpot in results {
+          offsets.append(compositeSpot.component.view.contentOffset)
+        }
+      }
+
+      component.model.items = newItems
+    }) { [weak self] in
+      guard let strongSelf = self else {
+        return
+      }
+
+      for (index, item) in newItems.enumerated() {
+        guard index < controller.components.count else {
+          break
+        }
+
+        let compositeComponents = controller.components[item.index].compositeComponents
+          .filter({ $0.itemIndex == item.index })
+        for (index, compositeSpot) in compositeComponents.enumerated() {
+          guard index < offsets.count else {
+            continue
+          }
+
+          compositeSpot.component.view.contentOffset = offsets[index]
+        }
+      }
+
+      strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
+    }
+  }
+
+  /// Reload Component object with less items
+  ///
+  /// - parameter changes:   A ItemChanges tuple.
+  /// - parameter component:      The component that should be updated.
+  /// - parameter newItems:  The new items that should be used to updated the data source.
+  /// - parameter animation: The animation that should be used when updating.
+  /// - parameter closure:   A completion closure.
+  private func reload(with changes: (ItemChanges),
+                      controller: SpotsController,
+                      in component: Component,
+                      lessItems newItems: [Item],
+                      animation: Animation,
+                      completion: (() -> Void)? = nil) {
+    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
+      component.beforeUpdate()
+      component.model.items = newItems
+    }) { [weak self] in
+      guard let strongSelf = self, !newItems.isEmpty else {
+        self?.finishReloading(component: component, controller: controller, withCompletion: completion)
+        return
+      }
+
+      let executeClosure = newItems.count - 1
+      for (index, item) in newItems.enumerated() {
+        let components = Parser.parse(item.children).map { $0.model }
+
+        let oldSpots = controller.components.flatMap({
+          $0.compositeComponents
+        })
+
+        for removedSpot in oldSpots {
+          guard !components.contains(removedSpot.component.model) else {
+            continue
+          }
+
+          if let index = removedSpot.parentComponent?.compositeComponents.index(of: removedSpot) {
+            removedSpot.parentComponent?.compositeComponents.remove(at: index)
+          }
+        }
+
+        if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
+          component.beforeUpdate()
+          component.reload(nil, withAnimation: animation) {
+            strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
+          }
+        } else {
+          component.beforeUpdate()
+          component.update(item, index: index, withAnimation: animation) {
+            guard index == executeClosure else {
+              return
+            }
+            strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
+          }
+        }
+      }
+    }
+  }
+
+  /// Reload Component object with more items
+  ///
+  /// - parameter changes:   A ItemChanges tuple.
+  /// - parameter component:      The component that should be updated.
+  /// - parameter newItems:  The new items that should be used to updated the data source.
+  /// - parameter animation: The animation that should be used when updating.
+  /// - parameter closure:   A completion closure.
+  private func reload(with changes: (ItemChanges),
+                      controller: SpotsController,
+                      in component: Component,
+                      moreItems newItems: [Item],
+                      animation: Animation,
+                      completion: (() -> Void)? = nil) {
+    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
+      component.beforeUpdate()
+      component.model.items = newItems
+    }) {
+      if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
+        component.reload(nil, withAnimation: animation) { [weak self] in
+          self?.finishReloading(component: component, controller: controller, withCompletion: completion)
+        }
+      } else {
+        component.updateHeight { [weak self] in
+          self?.finishReloading(component: component, controller: controller, withCompletion: completion)
+        }
+      }
+    }
+  }
+
+  private func finishReloading(component: Component, controller: SpotsController, withCompletion completion: Completion = nil) {
+    component.afterUpdate()
+    completion?()
+    controller.scrollView.layoutSubviews()
+  }
+
+  func process(changes: [ComponentModelDiff],
+               controller: SpotsController,
+               components newComponentModels: [ComponentModel],
+               withAnimation animation: Animation = .automatic,
+               completion: Completion = nil) {
+    Dispatch.main { [weak self] in
+      guard let strongSelf = self else {
+        completion?()
+        return
+      }
+
+      let finalCompletion = completion
+
+      var yOffset: CGFloat = 0.0
+      var runCompletion = true
+      var completion: Completion = nil
+      var lastItemChange: Int?
+
+      for (index, change) in changes.enumerated() {
+        if change == .items {
+          lastItemChange = index
+        }
+      }
+
+      for (index, change) in changes.enumerated() {
+        switch change {
+        case .identifier, .kind, .layout, .header, .footer, .meta:
+          strongSelf.replaceComponent(atIndex: index, controller: controller, newComponentModels: newComponentModels, yOffset: &yOffset)
+        case .new:
+          strongSelf.newComponent(atIndex: index, controller: controller, newComponentModels: newComponentModels, yOffset: &yOffset)
+        case .removed:
+          strongSelf.removeComponent(atIndex: index, controller: controller)
+        case .items:
+          if index == lastItemChange {
+            completion = finalCompletion
+          }
+
+          runCompletion = strongSelf.setupItemsForComponent(atIndex: index,
+                                                            controller: controller,
+                                                            newComponentModels: newComponentModels,
+                                                            withAnimation: animation,
+                                                            completion: completion)
+        case .none: continue
+        }
+      }
+
+      for removedSpot in controller.components where removedSpot.view.superview == nil {
+        if let index = controller.components.index(where: { removedSpot.view.isEqual($0.view) }) {
+          controller.components.remove(at: index)
+        }
+      }
+
+      if runCompletion {
+        strongSelf.completeUpdates(controller: controller)
+        finalCompletion?()
+      }
+    }
+  }
+
+  ///Reload if needed using JSON
+  ///
+  /// - parameter json: A JSON dictionary that gets parsed into UI elements
+  /// - parameter compare: A closure that is used for comparing a ComponentModel collections
+  /// - parameter animated: An animation closure that can be used to perform custom animations when reloading
+  /// - parameter completion: A closure that will be run after reload has been performed on all components
+  public func reloadIfNeeded(_ json: [String : Any],
+                             controller: SpotsController,
+                             compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
+                             animated: ((_ view: View) -> Void)? = nil,
+                             completion: Completion = nil) {
+    Dispatch.main { [weak self] in
+      guard let strongSelf = self else {
+        completion?()
+        return
+      }
+
+      let newSpots: [Component] = Parser.parse(json)
+      let newComponentModels = newSpots.map { $0.model }
+      let oldComponentModels = controller.components.map { $0.model }
+
+      guard compare(newComponentModels, oldComponentModels) else {
+        controller.cache()
+        SpotsController.componentsDidReloadComponentModels?(controller)
+        completion?()
+        return
+      }
+
+      var offsets = [CGPoint]()
+      let oldComposites = controller.components.flatMap { $0.compositeComponents }
+
+      if newComponentModels.count == oldComponentModels.count {
+        offsets = controller.components.map { $0.view.contentOffset }
+      }
+
+      controller.components = newSpots
+
+      if controller.scrollView.superview == nil {
+        controller.view.addSubview(controller.scrollView)
+      }
+
+      strongSelf.reloadSpotsScrollView(controller: controller)
+      controller.setupComponents(animated: animated)
+      controller.cache()
+
+      let newComposites = controller.components.flatMap { $0.compositeComponents }
+
+      for (index, compositeSpot) in oldComposites.enumerated() {
+        if index == newComposites.count {
+          break
+        }
+
+        newComposites[index].component.view.contentOffset = compositeSpot.component.view.contentOffset
+      }
+
+      completion?()
+
+      offsets.enumerated().forEach {
+        newSpots[$0.offset].view.contentOffset = $0.element
+      }
+
+      controller.scrollView.layoutSubviews()
+      SpotsController.componentsDidReloadComponentModels?(controller)
+    }
+  }
+
+  /// Reload with component models
+  ///
+  ///- parameter component models: A collection of component models.
+  ///- parameter animated: An animation closure that can be used to perform custom animations when reloading
+  ///- parameter completion: A closure that will be run after reload has been performed on all components
+  public func reload(models: [ComponentModel], controller: SpotsController, animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
+    Dispatch.main { [weak self] in
+      guard let strongSelf = self else {
+        completion?()
+        return
+      }
+
+      controller.components = Parser.parse(models)
+      controller.cache()
+
+      if controller.scrollView.superview == nil {
+        controller.view.addSubview(controller.scrollView)
+      }
+
+      let previousContentOffset = controller.scrollView.contentOffset
+
+      strongSelf.reloadSpotsScrollView(controller: controller)
+      controller.setupComponents(animated: animated)
+      controller.components.forEach { component in
+        component.afterUpdate()
+      }
+
+      SpotsController.componentsDidReloadComponentModels?(controller)
+      controller.scrollView.layoutSubviews()
+      controller.scrollView.contentOffset = previousContentOffset
+      completion?()
+    }
+  }
+
+  /// Reload with JSON
+  ///
+  ///- parameter json: A JSON dictionary that gets parsed into UI elements
+  ///- parameter animated: An animation closure that can be used to perform custom animations when reloading
+  ///- parameter completion: A closure that will be run after reload has been performed on all components
+  public func reload(json: [String : Any], controller: SpotsController, animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
+    Dispatch.main { [weak self] in
+      guard let strongSelf = self else {
+        completion?()
+        return
+      }
+
+      controller.components = Parser.parse(json)
+      controller.cache()
+
+      if controller.scrollView.superview == nil {
+        controller.view.addSubview(controller.scrollView)
+      }
+
+      let previousContentOffset = controller.scrollView.contentOffset
+
+      strongSelf.reloadSpotsScrollView(controller: controller)
+      controller.setupComponents(animated: animated)
+      controller.components.forEach { component in
+        component.afterUpdate()
+      }
+
+      SpotsController.componentsDidReloadComponentModels?(controller)
+      controller.scrollView.layoutSubviews()
+      controller.scrollView.contentOffset = previousContentOffset
+      completion?()
+    }
+  }
+
+  /**
+   - parameter componentAtIndex: The index of the component that you want to perform updates on
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that is performed when the update is completed
+   - parameter closure: A transform closure to perform the proper modification to the target component before updating the internals
+   */
+  public func update(componentAtIndex index: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ component: Component) -> Void) {
+    guard let component = controller.component(at: index) else {
+      completion?()
+      return
+    }
+
+    closure(component)
+    component.refreshIndexes()
+    component.prepareItems()
+
+    Dispatch.main {
+      #if !os(OSX)
+        if animation != .none {
+          let isScrolling = controller.scrollView.isDragging == true || controller.scrollView.isTracking == true
+          if let superview = component.view.superview, !isScrolling {
+            component.view.frame.size.height = superview.frame.height
+          }
+        }
+      #endif
+
+      component.reload(nil, withAnimation: animation) {
+        component.updateHeight {
+          component.afterUpdate()
+          completion?()
+          component.view.layoutIfNeeded()
+        }
+      }
+    }
+  }
+
+  /**
+   Updates component only if the passed view models are not the same with the current ones.
+
+   - parameter componentAtIndex: The index of the component that you want to perform updates on
+   - parameter items: An array of view models
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that is run when the update is completed
+   */
+  public func updateIfNeeded(componentAtIndex index: Int = 0, controller: SpotsController, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
+    guard let component = controller.component(at: index), !(component.model.items == items) else {
+      controller.scrollView.layoutSubviews()
+      completion?()
+      return
+    }
+
+    update(componentAtIndex: index, controller: controller, withAnimation: animation, withCompletion: {
+      completion?()
+    }, { component in
+      component.model.items = items
+    })
+  }
+
+  /**
+   - parameter item: The view model that you want to append
+   - parameter componentIndex: The index of the component that you want to append to, defaults to 0
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func append(_ item: Item, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.append(item, withAnimation: animation) {
+      controller.scrollView.layoutSubviews()
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /**
+   - parameter items: A collection of view models
+   - parameter componentIndex: The index of the component that you want to append to, defaults to 0
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func append(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.append(items, withAnimation: animation) {
+      controller.scrollView.layoutSubviews()
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /**
+   - parameter items: A collection of view models
+   - parameter componentIndex: The index of the component that you want to prepend to, defaults to 0
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func prepend(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.prepend(items, withAnimation: animation) {
+      controller.scrollView.layoutSubviews()
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /**
+   - parameter item: The view model that you want to insert
+   - parameter index: The index that you want to insert the view model at
+   - parameter componentIndex: The index of the component that you want to insert into
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func insert(_ item: Item, index: Int = 0, componentIndex: Int, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.insert(item, index: index, withAnimation: animation) {
+      controller.scrollView.layoutSubviews()
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /// Update item at index inside a specific Component object
+  ///
+  /// - parameter item:       The view model that you want to update.
+  /// - parameter index:      The index that you want to insert the view model at.
+  /// - parameter componentIndex:  The index of the component that you want to update into.
+  /// - parameter animation:  A Animation struct that determines which animation that should be used to perform the update.
+  /// - parameter completion: A completion closure that will run after the component has performed updates internally.
+  public func update(_ item: Item, index: Int = 0, componentIndex: Int, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    guard let oldItem = controller.component(at: componentIndex)?.item(at: index), item != oldItem
+      else {
+        completion?()
+        return
+    }
+
+    #if os(iOS)
+      if animation == .none {
+        CATransaction.begin()
+      }
+    #endif
+
+    controller.component(at: componentIndex)?.update(item, index: index, withAnimation: animation) {
+      controller.scrollView.layoutSubviews()
+      completion?()
+      #if os(iOS)
+        if animation == .none {
+          CATransaction.commit()
+        }
+      #endif
+    }
+  }
+
+  /**
+   - parameter indexes: An integer array of indexes that you want to update
+   - parameter componentIndex: The index of the component that you want to update into
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func update(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.reload(indexes, withAnimation: animation) {
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /**
+   - parameter index: The index of the view model that you want to remove
+   - parameter componentIndex: The index of the component that you want to remove into
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func delete(_ index: Int, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.delete(index, withAnimation: animation) {
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  /**
+   - parameter indexes: A collection of indexes for view models that you want to remove
+   - parameter componentIndex: The index of the component that you want to remove into
+   - parameter animation: A Animation struct that determines which animation that should be used to perform the update
+   - parameter completion: A completion closure that will run after the component has performed updates internally
+   */
+  public func delete(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
+    controller.component(at: componentIndex)?.delete(indexes, withAnimation: animation) {
+      completion?()
+    }
+    controller.component(at: componentIndex)?.refreshIndexes()
+  }
+
+  fileprivate func reloadSpotsScrollView(controller: SpotsController) {
+    controller.scrollView.componentsView.subviews.forEach {
+      $0.removeFromSuperview()
+    }
+  }
+
+  fileprivate func completeUpdates(controller: SpotsController) {
+    for component in controller.components {
+      component.afterUpdate()
+    }
+
+    #if !os(OSX)
+      controller.scrollView.layoutSubviews()
+    #endif
+  }
+}

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -60,8 +60,8 @@ public class SpotsControllerManager {
         return
       }
 
-      let oldSpots = controller.components
-      let oldComponentModels = oldSpots.map { $0.model }
+      let oldComponents = controller.components
+      let oldComponentModels = oldComponents.map { $0.model }
       var newComponentModels = components
 
       /// Prepare default layouts for new components based of previous Component kind.
@@ -71,7 +71,7 @@ public class SpotsControllerManager {
         }
 
         if newComponentModels[index].layout == nil {
-          newComponentModels[index].layout = type(of: oldSpots[index]).layout
+          newComponentModels[index].layout = type(of: oldComponents[index]).layout
         }
       }
 
@@ -127,17 +127,17 @@ public class SpotsControllerManager {
 
   fileprivate func replaceComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
     let component = Component(model: newComponentModels[index])
-    let oldSpot = controller.components[index]
+    let oldComponent = controller.components[index]
 
     /// Remove old composite components from superview and empty container
-    for compositeSpot in oldSpot.compositeComponents {
-      compositeSpot.component.view.removeFromSuperview()
+    for compositeComponent in oldComponent.compositeComponents {
+      compositeComponent.component.view.removeFromSuperview()
     }
-    oldSpot.compositeComponents = []
+    oldComponent.compositeComponents = []
 
-    component.view.frame = oldSpot.view.frame
+    component.view.frame = oldComponent.view.frame
 
-    oldSpot.view.removeFromSuperview()
+    oldComponent.view.removeFromSuperview()
     controller.components[index] = component
     controller.scrollView.componentsView.insertSubview(component.view, at: index)
     controller.setupComponent(at: index, component: component)
@@ -153,7 +153,7 @@ public class SpotsControllerManager {
     yOffset += component.view.frame.size.height
   }
 
-  /// Remove Spot at index
+  /// Remove component at index
   ///
   /// - parameter index: The index of the Component object hat you want to remove
   fileprivate func removeComponent(atIndex index: Int, controller: SpotsController) {
@@ -176,23 +176,23 @@ public class SpotsControllerManager {
       return false
     }
 
-    let tempSpot = Component(model: newComponentModels[index])
-    tempSpot.setup(with: component.view.frame.size)
-    tempSpot.model.size = CGSize(
+    let tempComponent = Component(model: newComponentModels[index])
+    tempComponent.setup(with: component.view.frame.size)
+    tempComponent.model.size = CGSize(
       width: controller.view.frame.width,
-      height: ceil(tempSpot.view.frame.height))
+      height: ceil(tempComponent.view.frame.height))
 
-    guard let diff = Item.evaluate(tempSpot.model.items, oldModels: component.model.items) else {
+    guard let diff = Item.evaluate(tempComponent.model.items, oldModels: component.model.items) else {
       return true
     }
 
-    let newItems = tempSpot.model.items
+    let newItems = tempComponent.model.items
     let changes: (ItemChanges) = Item.processChanges(diff)
 
     for index in changes.updatedChildren {
-      if index < tempSpot.compositeComponents.count {
+      if index < tempComponent.compositeComponents.count {
         component.compositeComponents[index].component.view.removeFromSuperview()
-        component.compositeComponents[index] = tempSpot.compositeComponents[index]
+        component.compositeComponents[index] = tempComponent.compositeComponents[index]
         component.compositeComponents[index].parentComponent = component
       }
     }
@@ -243,8 +243,8 @@ public class SpotsControllerManager {
 
       for item in newItems {
         let results = component.compositeComponents.filter({ $0.itemIndex == item.index })
-        for compositeSpot in results {
-          offsets.append(compositeSpot.component.view.contentOffset)
+        for compositeComponent in results {
+          offsets.append(compositeComponent.component.view.contentOffset)
         }
       }
 
@@ -261,12 +261,12 @@ public class SpotsControllerManager {
 
         let compositeComponents = controller.components[item.index].compositeComponents
           .filter({ $0.itemIndex == item.index })
-        for (index, compositeSpot) in compositeComponents.enumerated() {
+        for (index, compositeComponent) in compositeComponents.enumerated() {
           guard index < offsets.count else {
             continue
           }
 
-          compositeSpot.component.view.contentOffset = offsets[index]
+          compositeComponent.component.view.contentOffset = offsets[index]
         }
       }
 
@@ -300,17 +300,17 @@ public class SpotsControllerManager {
       for (index, item) in newItems.enumerated() {
         let components = Parser.parse(item.children).map { $0.model }
 
-        let oldSpots = controller.components.flatMap({
+        let oldComponents = controller.components.flatMap({
           $0.compositeComponents
         })
 
-        for removedSpot in oldSpots {
-          guard !components.contains(removedSpot.component.model) else {
+        for removedComponent in oldComponents {
+          guard !components.contains(removedComponent.component.model) else {
             continue
           }
 
-          if let index = removedSpot.parentComponent?.compositeComponents.index(of: removedSpot) {
-            removedSpot.parentComponent?.compositeComponents.remove(at: index)
+          if let index = removedComponent.parentComponent?.compositeComponents.index(of: removedComponent) {
+            removedComponent.parentComponent?.compositeComponents.remove(at: index)
           }
         }
 
@@ -413,8 +413,8 @@ public class SpotsControllerManager {
         }
       }
 
-      for removedSpot in controller.components where removedSpot.view.superview == nil {
-        if let index = controller.components.index(where: { removedSpot.view.isEqual($0.view) }) {
+      for removedComponent in controller.components where removedComponent.view.superview == nil {
+        if let index = controller.components.index(where: { removedComponent.view.isEqual($0.view) }) {
           controller.components.remove(at: index)
         }
       }
@@ -443,8 +443,8 @@ public class SpotsControllerManager {
         return
       }
 
-      let newSpots: [Component] = Parser.parse(json)
-      let newComponentModels = newSpots.map { $0.model }
+      let newComponents: [Component] = Parser.parse(json)
+      let newComponentModels = newComponents.map { $0.model }
       let oldComponentModels = controller.components.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
@@ -461,7 +461,7 @@ public class SpotsControllerManager {
         offsets = controller.components.map { $0.view.contentOffset }
       }
 
-      controller.components = newSpots
+      controller.components = newComponents
 
       if controller.scrollView.superview == nil {
         controller.view.addSubview(controller.scrollView)
@@ -473,18 +473,18 @@ public class SpotsControllerManager {
 
       let newComposites = controller.components.flatMap { $0.compositeComponents }
 
-      for (index, compositeSpot) in oldComposites.enumerated() {
+      for (index, compositeComponent) in oldComposites.enumerated() {
         if index == newComposites.count {
           break
         }
 
-        newComposites[index].component.view.contentOffset = compositeSpot.component.view.contentOffset
+        newComposites[index].component.view.contentOffset = compositeComponent.component.view.contentOffset
       }
 
       completion?()
 
       offsets.enumerated().forEach {
-        newSpots[$0.offset].view.contentOffset = $0.element
+        newComponents[$0.offset].view.contentOffset = $0.element
       }
 
       controller.scrollView.layoutSubviews()

--- a/Sources/Shared/Extensions/SpotsController+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsController+Extensions.swift
@@ -4,7 +4,7 @@
   import UIKit
 #endif
 
-extension SpotsProtocol where Self : SpotsController {
+extension SpotsController {
 
   public typealias CompareClosure = ((_ lhs: [ComponentModel], _ rhs: [ComponentModel]) -> Bool)
 

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -36,17 +36,6 @@ extension SpotsProtocol where Self : SpotsController {
                            completion: completion)
   }
 
-  func process(changes: [ComponentModelDiff],
-               components newComponentModels: [ComponentModel],
-               withAnimation animation: Animation = .automatic,
-               completion: Completion = nil) {
-    manager.process(changes: changes,
-                    controller: self,
-                    components: newComponentModels,
-                    withAnimation: animation,
-                    completion: completion)
-  }
-
   ///Reload if needed using JSON
   ///
   /// - parameter json: A JSON dictionary that gets parsed into UI elements

--- a/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
+++ b/Sources/Shared/Extensions/SpotsProtocol+Mutation.swift
@@ -4,7 +4,7 @@
   import UIKit
 #endif
 
-extension SpotsProtocol {
+extension SpotsProtocol where Self : SpotsController {
 
   public typealias CompareClosure = ((_ lhs: [ComponentModel], _ rhs: [ComponentModel]) -> Bool)
 
@@ -16,19 +16,7 @@ extension SpotsProtocol {
    - parameter completion: A completion block that is run when the reloading is done
    */
   public func reload(_ animated: Bool = true, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    var componentsLeft = components.count
-
-    Dispatch.main { [weak self] in
-      self?.components.forEach { component in
-        component.reload([], withAnimation: animation) {
-          componentsLeft -= 1
-
-          if componentsLeft == 0 {
-            completion?()
-          }
-        }
-      }
-    }
+    manager.reload(controller: self, withAnimation: animation, completion: completion)
   }
 
   /// Reload if needed using JSON
@@ -41,387 +29,22 @@ extension SpotsProtocol {
                              compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              withAnimation animation: Animation = .automatic,
                              completion: Completion = nil) {
-    guard !components.isEmpty else {
-      Dispatch.main { [weak self] in
-        self?.components.forEach {
-          $0.view.removeFromSuperview()
-        }
-        self?.components = []
-        completion?()
-      }
-      return
-    }
-
-    Dispatch.interactive { [weak self] in
-      guard let strongSelf = self else {
-        completion?()
-        return
-      }
-
-      let oldSpots = strongSelf.components
-      let oldComponentModels = oldSpots.map { $0.model }
-      var newComponentModels = components
-
-      /// Prepare default layouts for new components based of previous Component kind.
-      for (index, _) in newComponentModels.enumerated() {
-        guard index < oldComponentModels.count else {
-          break
-        }
-
-        if newComponentModels[index].layout == nil {
-          newComponentModels[index].layout = type(of: oldSpots[index]).layout
-        }
-      }
-
-      guard compare(newComponentModels, oldComponentModels) else {
-        strongSelf.cache()
-        Dispatch.main {
-          strongSelf.scrollView.layoutViews()
-          if let controller = self as? SpotsController {
-            SpotsController.componentsDidReloadComponentModels?(controller)
-          }
-          completion?()
-        }
-        return
-      }
-
-      let changes = strongSelf.generateChanges(from: newComponentModels, and: oldComponentModels)
-
-      strongSelf.process(changes: changes, components: newComponentModels, withAnimation: animation) {
-        Dispatch.main {
-          strongSelf.scrollView.layoutSubviews()
-          strongSelf.cache()
-          if let controller = self as? SpotsController {
-            SpotsController.componentsDidReloadComponentModels?(controller)
-          }
-
-          completion?()
-        }
-      }
-    }
-  }
-
-  /// Generate a change set by comparing two component collections
-  ///
-  /// - parameter components:    A collection of components
-  /// - parameter oldComponentModels: A collection of components
-  ///
-  /// - returns: A ComponentModelDiff struct
-  func generateChanges(from models: [ComponentModel], and oldComponentModels: [ComponentModel]) -> [ComponentModelDiff] {
-    let oldComponentModelCount = oldComponentModels.count
-    var changes = [ComponentModelDiff]()
-    for (index, model) in models.enumerated() {
-      if index >= oldComponentModelCount {
-        changes.append(.new)
-        continue
-      }
-
-      changes.append(model.diff(model: oldComponentModels[index]))
-    }
-
-    if oldComponentModelCount > models.count {
-      oldComponentModels[models.count..<oldComponentModels.count].forEach { _ in
-        changes.append(.removed)
-      }
-    }
-
-    return changes
-  }
-
-  fileprivate func replaceComponent(_ index: Int, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let component = Component(model: newComponentModels[index])
-    let oldSpot = components[index]
-
-    /// Remove old composite components from superview and empty container
-    for compositeSpot in oldSpot.compositeComponents {
-      compositeSpot.component.view.removeFromSuperview()
-    }
-    oldSpot.compositeComponents = []
-
-    component.view.frame = oldSpot.view.frame
-
-    oldSpot.view.removeFromSuperview()
-    components[index] = component
-    scrollView.componentsView.insertSubview(component.view, at: index)
-    setupComponent(at: index, component: component)
-
-    yOffset += component.view.frame.size.height
-  }
-
-  fileprivate func newComponent(_ index: Int, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let component = Component(model: newComponentModels[index])
-    components.append(component)
-    setupComponent(at: index, component: component)
-
-    yOffset += component.view.frame.size.height
-  }
-
-  /// Remove Spot at index
-  ///
-  /// - parameter index: The index of the Component object hat you want to remove
-  fileprivate func removeComponent(at index: Int) {
-    guard index < components.count else {
-      return
-    }
-    components[index].view.removeFromSuperview()
-  }
-
-  /// Set up items for a Component object
-  ///
-  /// - parameter index:         The index of the Component object
-  /// - parameter newComponentModels: A collection of new components
-  /// - parameter animation:     A Animation that is used to determine which animation to use when performing the update
-  /// - parameter closure:       A completion closure that is invoked when the setup of the new items is complete
-  ///
-  /// - returns: A boolean value that determines if the closure should run in `process(changes:)`
-  fileprivate func setupItemsForComponent(at index: Int, newComponentModels: [ComponentModel], withAnimation animation: Animation = .automatic, completion: Completion = nil) -> Bool {
-    guard let component = self.component(at: index) else {
-      return false
-    }
-
-    let tempSpot = Component(model: newComponentModels[index])
-    tempSpot.setup(with: component.view.frame.size)
-    tempSpot.model.size = CGSize(
-      width: view.frame.width,
-      height: ceil(tempSpot.view.frame.height))
-
-    guard let diff = Item.evaluate(tempSpot.model.items, oldModels: component.model.items) else {
-      return true
-    }
-
-    let newItems = tempSpot.model.items
-    let changes: (ItemChanges) = Item.processChanges(diff)
-
-    for index in changes.updatedChildren {
-      if index < tempSpot.compositeComponents.count {
-        component.compositeComponents[index].component.view.removeFromSuperview()
-        component.compositeComponents[index] = tempSpot.compositeComponents[index]
-        component.compositeComponents[index].parentComponent = component
-      }
-    }
-
-    if newItems.count == component.model.items.count {
-      reload(with: changes, in: component, newItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates()
-          completion()
-        }
-      }
-    } else if newItems.count < component.model.items.count {
-      reload(with: changes, in: component, lessItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates()
-          completion()
-        }
-      }
-    } else if newItems.count > component.model.items.count {
-      reload(with: changes, in: component, moreItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates()
-          completion()
-        }
-      }
-    }
-
-    return false
-  }
-
-  /// Reload Component object with changes and new items.
-  ///
-  /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter component:      The component that should be updated.
-  /// - parameter newItems:  The new items that should be used to updated the data source.
-  /// - parameter animation: The animation that should be used when updating.
-  /// - parameter closure:   A completion closure.
-  private func reload(with changes: (ItemChanges),
-                      in component: Component,
-                      newItems: [Item],
-                      animation: Animation,
-                      completion: (() -> Void)? = nil) {
-    var offsets = [CGPoint]()
-
-    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
-
-      for item in newItems {
-        let results = component.compositeComponents.filter({ $0.itemIndex == item.index })
-        for compositeSpot in results {
-          offsets.append(compositeSpot.component.view.contentOffset)
-        }
-      }
-
-      component.model.items = newItems
-    }) { [weak self] in
-      guard let strongSelf = self else {
-        return
-      }
-
-      for (index, item) in newItems.enumerated() {
-        guard index < strongSelf.components.count else {
-          break
-        }
-
-        let compositeComponents = strongSelf.components[item.index].compositeComponents
-          .filter({ $0.itemIndex == item.index })
-        for (index, compositeSpot) in compositeComponents.enumerated() {
-          guard index < offsets.count else {
-            continue
-          }
-
-          compositeSpot.component.view.contentOffset = offsets[index]
-        }
-      }
-
-      self?.finishReloading(component: component, withCompletion: completion)
-    }
-  }
-
-  /// Reload Component object with less items
-  ///
-  /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter component:      The component that should be updated.
-  /// - parameter newItems:  The new items that should be used to updated the data source.
-  /// - parameter animation: The animation that should be used when updating.
-  /// - parameter closure:   A completion closure.
-  private func reload(with changes: (ItemChanges),
-                      in component: Component,
-                      lessItems newItems: [Item],
-                      animation: Animation,
-                      completion: (() -> Void)? = nil) {
-    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
-      component.model.items = newItems
-    }) { [weak self] in
-      guard let strongSelf = self, !newItems.isEmpty else {
-        self?.finishReloading(component: component, withCompletion: completion)
-        return
-      }
-
-      let executeClosure = newItems.count - 1
-      for (index, item) in newItems.enumerated() {
-        let components = Parser.parse(item.children).map { $0.model }
-
-        let oldSpots = strongSelf.components.flatMap({
-          $0.compositeComponents
-        })
-
-        for removedSpot in oldSpots {
-          guard !components.contains(removedSpot.component.model) else {
-            continue
-          }
-
-          if let index = removedSpot.parentComponent?.compositeComponents.index(of: removedSpot) {
-            removedSpot.parentComponent?.compositeComponents.remove(at: index)
-          }
-        }
-
-        if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-          component.beforeUpdate()
-          component.reload(nil, withAnimation: animation) {
-            strongSelf.finishReloading(component: component, withCompletion: completion)
-          }
-        } else {
-          component.beforeUpdate()
-          component.update(item, index: index, withAnimation: animation) {
-            guard index == executeClosure else {
-              return
-            }
-            strongSelf.finishReloading(component: component, withCompletion: completion)
-          }
-        }
-      }
-    }
-  }
-
-  /// Reload Component object with more items
-  ///
-  /// - parameter changes:   A ItemChanges tuple.
-  /// - parameter component:      The component that should be updated.
-  /// - parameter newItems:  The new items that should be used to updated the data source.
-  /// - parameter animation: The animation that should be used when updating.
-  /// - parameter closure:   A completion closure.
-  private func reload(with changes: (ItemChanges),
-                      in component: Component,
-                      moreItems newItems: [Item],
-                      animation: Animation,
-                      completion: (() -> Void)? = nil) {
-    component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
-      component.model.items = newItems
-    }) {
-      if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-        component.reload(nil, withAnimation: animation) { [weak self] in
-          self?.finishReloading(component: component, withCompletion: completion)
-        }
-      } else {
-        component.updateHeight { [weak self] in
-          self?.finishReloading(component: component, withCompletion: completion)
-        }
-      }
-    }
-  }
-
-  private func finishReloading(component: Component, withCompletion completion: Completion = nil) {
-    component.afterUpdate()
-    completion?()
-    scrollView.layoutSubviews()
+    manager.reloadIfNeeded(components: components,
+                           controller: self,
+                           compare: compare,
+                           withAnimation: animation,
+                           completion: completion)
   }
 
   func process(changes: [ComponentModelDiff],
                components newComponentModels: [ComponentModel],
                withAnimation animation: Animation = .automatic,
                completion: Completion = nil) {
-    Dispatch.main { [weak self] in
-      guard let strongSelf = self else {
-        completion?()
-        return
-      }
-
-      let finalCompletion = completion
-
-      var yOffset: CGFloat = 0.0
-      var runCompletion = true
-      var completion: Completion = nil
-      var lastItemChange: Int?
-
-      for (index, change) in changes.enumerated() {
-        if change == .items {
-          lastItemChange = index
-        }
-      }
-
-      for (index, change) in changes.enumerated() {
-        switch change {
-        case .identifier, .kind, .layout, .header, .footer, .meta:
-          strongSelf.replaceComponent(index, newComponentModels: newComponentModels, yOffset: &yOffset)
-        case .new:
-          strongSelf.newComponent(index, newComponentModels: newComponentModels, yOffset: &yOffset)
-        case .removed:
-          strongSelf.removeComponent(at: index)
-        case .items:
-          if index == lastItemChange {
-            completion = finalCompletion
-          }
-
-          runCompletion = strongSelf.setupItemsForComponent(at: index,
-                                                     newComponentModels: newComponentModels,
-                                                     withAnimation: animation,
-                                                     completion: completion)
-        case .none: continue
-        }
-      }
-
-      for removedSpot in strongSelf.components where removedSpot.view.superview == nil {
-        if let index = strongSelf.components.index(where: { removedSpot.view.isEqual($0.view) }) {
-          strongSelf.components.remove(at: index)
-        }
-      }
-
-      if runCompletion {
-        strongSelf.completeUpdates()
-        finalCompletion?()
-      }
-    }
+    manager.process(changes: changes,
+                    controller: self,
+                    components: newComponentModels,
+                    withAnimation: animation,
+                    completion: completion)
   }
 
   ///Reload if needed using JSON
@@ -434,64 +57,11 @@ extension SpotsProtocol {
                              compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              animated: ((_ view: View) -> Void)? = nil,
                              completion: Completion = nil) {
-    Dispatch.main { [weak self] in
-      guard let strongSelf = self else {
-        completion?()
-        return
-      }
-
-      let newSpots: [Component] = Parser.parse(json)
-      let newComponentModels = newSpots.map { $0.model }
-      let oldComponentModels = strongSelf.components.map { $0.model }
-
-      guard compare(newComponentModels, oldComponentModels) else {
-        if let controller = self as? SpotsController {
-          SpotsController.componentsDidReloadComponentModels?(controller)
-        }
-        strongSelf.cache()
-        completion?()
-        return
-      }
-
-      var offsets = [CGPoint]()
-      let oldComposites = strongSelf.components.flatMap { $0.compositeComponents }
-
-      if newComponentModels.count == oldComponentModels.count {
-        offsets = strongSelf.components.map { $0.view.contentOffset }
-      }
-
-      strongSelf.components = newSpots
-
-      if strongSelf.scrollView.superview == nil {
-        strongSelf.view.addSubview(strongSelf.scrollView)
-      }
-
-      strongSelf.reloadSpotsScrollView()
-      strongSelf.setupComponents(animated: animated)
-      strongSelf.cache()
-
-      let newComposites = strongSelf.components.flatMap { $0.compositeComponents }
-
-      for (index, compositeSpot) in oldComposites.enumerated() {
-        if index == newComposites.count {
-          break
-        }
-
-        newComposites[index].component.view.contentOffset = compositeSpot.component.view.contentOffset
-      }
-
-      completion?()
-
-      offsets.enumerated().forEach {
-        newSpots[$0.offset].view.contentOffset = $0.element
-      }
-
-      if let controller = self as? SpotsController {
-        SpotsController.componentsDidReloadComponentModels?(controller)
-      }
-
-      strongSelf.scrollView.layoutSubviews()
-    }
+    manager.reloadIfNeeded(json,
+                           controller: self,
+                           compare: compare,
+                           animated: animated,
+                           completion: completion)
   }
 
   /// Reload with component models
@@ -500,36 +70,10 @@ extension SpotsProtocol {
   ///- parameter animated: An animation closure that can be used to perform custom animations when reloading
   ///- parameter completion: A closure that will be run after reload has been performed on all components
   public func reload(_ models: [ComponentModel], animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
-    Dispatch.main { [weak self] in
-      guard let strongSelf = self else {
-        completion?()
-        return
-      }
-
-      strongSelf.components = Parser.parse(models)
-      strongSelf.cache()
-
-      if strongSelf.scrollView.superview == nil {
-        strongSelf.view.addSubview(strongSelf.scrollView)
-      }
-
-      let previousContentOffset = strongSelf.scrollView.contentOffset
-
-      strongSelf.reloadSpotsScrollView()
-      strongSelf.setupComponents(animated: animated)
-      strongSelf.components.forEach { component in
-        component.afterUpdate()
-      }
-
-      completion?()
-
-      if let controller = strongSelf as? SpotsController {
-        SpotsController.componentsDidReloadComponentModels?(controller)
-      }
-
-      strongSelf.scrollView.layoutSubviews()
-      strongSelf.scrollView.contentOffset = previousContentOffset
-    }
+    manager.reload(models: models,
+                   controller: self,
+                   animated: animated,
+                   completion: completion)
   }
 
   /// Reload with JSON
@@ -538,36 +82,10 @@ extension SpotsProtocol {
   ///- parameter animated: An animation closure that can be used to perform custom animations when reloading
   ///- parameter completion: A closure that will be run after reload has been performed on all components
   public func reload(_ json: [String : Any], animated: ((_ view: View) -> Void)? = nil, completion: Completion = nil) {
-    Dispatch.main { [weak self] in
-      guard let strongSelf = self else {
-        completion?()
-        return
-      }
-
-      strongSelf.components = Parser.parse(json)
-      strongSelf.cache()
-
-      if strongSelf.scrollView.superview == nil {
-        strongSelf.view.addSubview(strongSelf.scrollView)
-      }
-
-      let previousContentOffset = strongSelf.scrollView.contentOffset
-
-      strongSelf.reloadSpotsScrollView()
-      strongSelf.setupComponents(animated: animated)
-      strongSelf.components.forEach { component in
-        component.afterUpdate()
-      }
-
-      completion?()
-
-      if let controller = strongSelf as? SpotsController {
-        SpotsController.componentsDidReloadComponentModels?(controller)
-      }
-
-      strongSelf.scrollView.layoutSubviews()
-      strongSelf.scrollView.contentOffset = previousContentOffset
-    }
+    manager.reload(json: json,
+                   controller: self,
+                   animated: animated,
+                   completion: completion)
   }
 
   /**
@@ -577,37 +95,11 @@ extension SpotsProtocol {
    - parameter closure: A transform closure to perform the proper modification to the target component before updating the internals
    */
   public func update(componentAtIndex index: Int = 0, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ component: Component) -> Void) {
-    guard let component = self.component(at: index) else {
-      completion?()
-      return
-    }
-
-    closure(component)
-    component.refreshIndexes()
-    component.prepareItems()
-
-    Dispatch.main { [weak self] in
-      guard let strongSelf = self else {
-        return
-      }
-
-      #if !os(OSX)
-        if animation != .none {
-          let isScrolling = strongSelf.scrollView.isDragging == true || strongSelf.scrollView.isTracking == true
-          if let superview = component.view.superview, !isScrolling {
-            component.view.frame.size.height = superview.frame.height
-          }
-        }
-      #endif
-
-      component.reload(nil, withAnimation: animation) {
-        component.updateHeight {
-          component.afterUpdate()
-          completion?()
-          component.view.layoutIfNeeded()
-        }
-      }
-    }
+    manager.update(componentAtIndex: index,
+                   controller: self,
+                   withAnimation: animation,
+                   withCompletion: completion,
+                   closure)
   }
 
   /**
@@ -619,17 +111,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that is run when the update is completed
    */
   public func updateIfNeeded(componentAtIndex index: Int = 0, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    guard let component = component(at: index), !(component.model.items == items) else {
-      scrollView.layoutSubviews()
-      completion?()
-      return
-    }
-
-    update(componentAtIndex: index, withAnimation: animation, withCompletion: {
-      completion?()
-    }, { component in
-      component.model.items = items
-    })
+    manager.updateIfNeeded(componentAtIndex: index,
+                           controller: self,
+                           items: items,
+                           withAnimation: animation,
+                           completion: completion)
   }
 
   /**
@@ -639,11 +125,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func append(_ item: Item, componentIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.append(item, withAnimation: animation) { [weak self] in
-      completion?()
-      self?.scrollView.layoutSubviews()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.append(item,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -653,11 +139,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func append(_ items: [Item], componentIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.append(items, withAnimation: animation) { [weak self] in
-      completion?()
-      self?.scrollView.layoutSubviews()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.append(items,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -667,11 +153,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func prepend(_ items: [Item], componentIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.prepend(items, withAnimation: animation) { [weak self] in
-      completion?()
-      self?.scrollView.layoutSubviews()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.prepend(items,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -682,11 +168,12 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func insert(_ item: Item, index: Int = 0, componentIndex: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.insert(item, index: index, withAnimation: animation) { [weak self] in
-      completion?()
-      self?.scrollView.layoutSubviews()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.insert(item,
+                   index: index,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /// Update item at index inside a specific Component object
@@ -697,27 +184,12 @@ extension SpotsProtocol {
   /// - parameter animation:  A Animation struct that determines which animation that should be used to perform the update.
   /// - parameter completion: A completion closure that will run after the component has performed updates internally.
   public func update(_ item: Item, index: Int = 0, componentIndex: Int, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    guard let oldItem = component(at: componentIndex)?.item(at: index), item != oldItem
-      else {
-        completion?()
-        return
-    }
-
-    #if os(iOS)
-      if animation == .none {
-        CATransaction.begin()
-      }
-    #endif
-
-    component(at: componentIndex)?.update(item, index: index, withAnimation: animation) { [weak self] in
-      completion?()
-      self?.scrollView.layoutSubviews()
-      #if os(iOS)
-        if animation == .none {
-          CATransaction.commit()
-        }
-      #endif
-    }
+    manager.update(item,
+                   index: index,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -727,10 +199,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func update(_ indexes: [Int], componentIndex: Int = 0, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    component(at: componentIndex)?.reload(indexes, withAnimation: animation) {
-      completion?()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.update(indexes,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -740,10 +213,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func delete(_ index: Int, componentIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.delete(index, withAnimation: animation) {
-      completion?()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.delete(index,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   /**
@@ -753,10 +227,11 @@ extension SpotsProtocol {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func delete(_ indexes: [Int], componentIndex: Int = 0, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    component(at: componentIndex)?.delete(indexes, withAnimation: animation) {
-      completion?()
-    }
-    component(at: componentIndex)?.refreshIndexes()
+    manager.delete(indexes,
+                   componentIndex: componentIndex,
+                   controller: self,
+                   withAnimation: animation,
+                   completion: completion)
   }
 
   #if os(iOS)
@@ -773,20 +248,4 @@ extension SpotsProtocol {
     }
   }
   #endif
-
-  fileprivate func reloadSpotsScrollView() {
-    scrollView.componentsView.subviews.forEach {
-      $0.removeFromSuperview()
-    }
-  }
-
-  fileprivate func completeUpdates() {
-    for component in components {
-      component.afterUpdate()
-    }
-
-    #if !os(OSX)
-      scrollView.layoutSubviews()
-    #endif
-  }
 }

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -18,6 +18,8 @@ public protocol SpotsProtocol: class {
   var delegate: ComponentDelegate? { get }
   /// A collection of components.
   var components: [Component] { get set }
+  /// A manager that handles the updating logic for the current controller.
+  var manager: SpotsControllerManager { get set }
   /// An array of refresh position to avoid calling multiple refreshes
   var refreshPositions: [CGFloat] { get set }
   /// A view controller view

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -161,25 +161,6 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     scrollView.delegate = nil
   }
 
-  ///  A generic look up method for resolving components based on index
-  ///
-  /// - parameter index: The index of the component that you are trying to resolve.
-  /// - parameter type: The generic type for the component you are trying to resolve.
-  ///
-  /// - returns: An optional Component object of inferred type.
-  open func component<T>(at index: Int = 0, ofType type: T.Type) -> T? {
-    return components.filter({ $0.model.index == index }).first as? T
-  }
-
-  /// A look up method for resolving a component at index as a component.
-  ///
-  /// - parameter index: The index of the component that you are trying to resolve.
-  ///
-  /// - returns: An optional component.
-  open func component(at index: Int = 0) -> Component? {
-    return components.filter({ $0.model.index == index }).first
-  }
-
   /// A generic look up method for resolving components using a closure
   ///
   /// - parameter closure: A closure to perform actions on a component.

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -41,6 +41,9 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// Initial content offset for Controller, defaults to UIEdgeInsetsZero.
   open fileprivate(set) var initialInset: UIEdgeInsets = UIEdgeInsets.zero
 
+  /// A manager that handles the updating logic for the current controller.
+  public var manager: SpotsControllerManager = SpotsControllerManager()
+
   /// A collection of components.
   open var components: [Component] {
     didSet { componentsDidChange() }

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -19,6 +19,9 @@ open class SpotsController: NSViewController, SpotsProtocol {
     }
   }
 
+  /// A manager that handles the updating logic for the current controller.
+  public var manager: SpotsControllerManager = SpotsControllerManager()
+
   public var contentView: View {
     return view
   }

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -120,15 +120,6 @@ open class SpotsController: NSViewController, SpotsProtocol {
     fatalError("init(coder:) has not been implemented")
   }
 
-  /// A look up method for resolving a component at index as a component.
-  ///
-  /// - parameter index: The index of the component that you are trying to resolve.
-  ///
-  /// - returns: An optional component.
-  open func component(at index: Int = 0) -> Component? {
-    return components.filter({ $0.model.index == index }).first
-  }
-
   /**
    A generic look up method for resolving components using a closure
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		BD77D1FC1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
 		BD77D1FD1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
 		BD77D1FE1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */; };
+		BD798EF41EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
+		BD798EF51EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
+		BD798EF61EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
 		BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
@@ -413,6 +416,7 @@
 		BD77D1F31E8537E80075A3FC /* ComponentModelDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentModelDiff.swift; sourceTree = "<group>"; };
 		BD77D1F71E8538080075A3FC /* ComponentModelKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentModelKind.swift; sourceTree = "<group>"; };
 		BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentModel+Equatable.swift"; sourceTree = "<group>"; };
+		BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManager.swift; sourceTree = "<group>"; };
 		BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentDelegate.swift; sourceTree = "<group>"; };
 		BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Carousel.swift"; sourceTree = "<group>"; };
@@ -766,6 +770,7 @@
 				BDAD852B1E3E7032008289AE /* CompositeComponent.swift */,
 				BDAD852C1E3E7032008289AE /* DataSource.swift */,
 				BDAD852D1E3E7032008289AE /* Delegate.swift */,
+				BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1524,6 +1529,7 @@
 				BDAD85711E3E7032008289AE /* Animation.swift in Sources */,
 				BDAD85D71E3E7032008289AE /* Configuration.swift in Sources */,
 				BDAD85951E3E7032008289AE /* ComponentDelegate+Extensions.swift in Sources */,
+				BD798EF61EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
 				BD77D1FE1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */,
 				BD9ECEC21E6EC8AF003E4388 /* Component+iOS+Grid.swift in Sources */,
 				BDAD85651E3E7032008289AE /* DataSource.swift in Sources */,
@@ -1662,6 +1668,7 @@
 				BDAD84B81E3E701C008289AE /* ListComposite.swift in Sources */,
 				BDAD85871E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BD77D1FC1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */,
+				BD798EF41EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
 				BD9ECEC11E6EC8AF003E4388 /* Component+iOS+Grid.swift in Sources */,
 				BDAD85601E3E7032008289AE /* CompositeComponent.swift in Sources */,
 				52CD427A1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
@@ -1776,6 +1783,7 @@
 				BDAD85611E3E7032008289AE /* CompositeComponent.swift in Sources */,
 				BDAD851D1E3E7025008289AE /* DataSource+macOS+Extensions.swift in Sources */,
 				BD0AF3531E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
+				BD798EF51EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
 				BDAD858B1E3E7032008289AE /* Component+Core.swift in Sources */,
 				BDAD85C11E3E7032008289AE /* ComponentDelegate.swift in Sources */,
 				BDAD85E81E3E7032008289AE /* Parser.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -198,9 +198,9 @@
 		BDAD85991E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
 		BDAD859A1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
 		BDAD859B1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
-		BDAD859C1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */; };
-		BDAD859D1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */; };
-		BDAD859E1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */; };
+		BDAD859C1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
+		BDAD859D1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
+		BDAD859E1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
 		BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */; };
 		BDAD85A31E3E7032008289AE /* Wrappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */; };
 		BDAD85A41E3E7032008289AE /* Wrappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */; };
@@ -486,7 +486,7 @@
 		BDAD853E1E3E7032008289AE /* ComponentDelegate+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+LiveEditing.swift"; sourceTree = "<group>"; };
-		BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Mutation.swift"; sourceTree = "<group>"; };
+		BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Wrappable+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85451E3E7032008289AE /* CarouselScrollDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselScrollDelegate.swift; sourceTree = "<group>"; };
 		BDAD85471E3E7032008289AE /* Composable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Composable.swift; sourceTree = "<group>"; };
@@ -808,7 +808,7 @@
 				BDAD853A1E3E7032008289AE /* ScrollDelegate+Extensions.swift */,
 				BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */,
 				BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */,
-				BDAD85411E3E7032008289AE /* SpotsProtocol+Mutation.swift */,
+				BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */,
 				BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */,
 				BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */,
 			);
@@ -1507,7 +1507,7 @@
 				BDAD84CF1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */,
 				BDDCF6DD1E4DF91F004B38C4 /* Indexable.swift in Sources */,
 				BDAD85E91E3E7032008289AE /* Parser.swift in Sources */,
-				BDAD859E1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */,
+				BDAD859E1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */,
 				BDAD84D71E3E701C008289AE /* Inset+iOS.swift in Sources */,
 				BDAD84A31E3E701C008289AE /* CarouselComposite.swift in Sources */,
 				BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */,
@@ -1642,7 +1642,7 @@
 				BDAD85F01E3E7032008289AE /* TypeAlias.swift in Sources */,
 				BDAD84A81E3E701C008289AE /* CarouselSpotHeader.swift in Sources */,
 				BDAD85B41E3E7032008289AE /* RefreshDelegate.swift in Sources */,
-				BDAD859C1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */,
+				BDAD859C1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */,
 				BDAD85D21E3E7032008289AE /* ComponentModel.swift in Sources */,
 				BDAD85EA1E3E7032008289AE /* Registry.swift in Sources */,
 				BDAD85C61E3E7032008289AE /* SpotsProtocol.swift in Sources */,
@@ -1741,7 +1741,7 @@
 			files = (
 				BDAD85731E3E7032008289AE /* Paginate.swift in Sources */,
 				BDDCF6E61E4DF92F004B38C4 /* StringConvertible.swift in Sources */,
-				BDAD859D1E3E7032008289AE /* SpotsProtocol+Mutation.swift in Sources */,
+				BDAD859D1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */,
 				BDDCF6D71E4DF911004B38C4 /* Item.swift in Sources */,
 				BDDCF6E11E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
 				BDAD85D01E3E7032008289AE /* Wrappable.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		BD798EF41EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
 		BD798EF51EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
 		BD798EF61EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */; };
+		BD798EF81EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
+		BD798EF91EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
+		BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
 		BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
@@ -417,6 +420,7 @@
 		BD77D1F71E8538080075A3FC /* ComponentModelKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentModelKind.swift; sourceTree = "<group>"; };
 		BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentModel+Equatable.swift"; sourceTree = "<group>"; };
 		BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManager.swift; sourceTree = "<group>"; };
+		BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsControllerManager.swift; sourceTree = "<group>"; };
 		BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentDelegate.swift; sourceTree = "<group>"; };
 		BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Carousel.swift"; sourceTree = "<group>"; };
@@ -1024,6 +1028,7 @@
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
 				BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */,
 				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
+				BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1579,6 +1584,7 @@
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDD9ABCF1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
 				BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
+				BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */,
@@ -1714,6 +1720,7 @@
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
 				BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */,
+				BD798EF81EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */,
 				BD10D5251D7955AB00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDCFCD441DCA7F830047E84C /* TestSpotsController.swift in Sources */,
@@ -1835,6 +1842,7 @@
 				BD45D9961E30A8A000C2D6B2 /* TestInset.swift in Sources */,
 				BD6FBEF11E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDFC47521E747B2B008700BF /* TestListWrapper.swift in Sources */,
+				BD798EF91EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				BDB8D5941E4DFADC00220BC3 /* TestItem.swift in Sources */,
 				BDEA327C1E86FC850044B056 /* TestClickInteraction.swift in Sources */,
 				BDDF2CD01DC7C50700B766BA /* TestAnimations.swift in Sources */,

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -878,10 +878,14 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testComponentAtIndex() {
-    let model = ComponentModel(kind: .list)
-    let component = Component(model: model)
-    let controller = SpotsController(components: [component])
+    let listModel = ComponentModel(kind: .list)
+    let gridModel = ComponentModel(kind: .grid)
+    let listComponent = Component(model: listModel)
+    let gridComponent = Component(model: gridModel)
+    let controller = SpotsController(components: [listComponent, gridComponent])
 
-    XCTAssertEqual(controller.component(at: 0), component)
+    XCTAssertEqual(controller.component(at: 0), listComponent)
+    XCTAssertEqual(controller.component(at: 1), gridComponent)
+    XCTAssertEqual(controller.component(at: 2), nil)
   }
 }

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -876,4 +876,12 @@ class SpotsControllerTests: XCTestCase {
 
     waitForExpectations(timeout: 10.0, handler: nil)
   }
+
+  func testComponentAtIndex() {
+    let model = ComponentModel(kind: .list)
+    let component = Component(model: model)
+    let controller = SpotsController(components: [component])
+
+    XCTAssertEqual(controller.component(at: 0), component)
+  }
 }

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -857,53 +857,6 @@ class SpotsControllerTests: XCTestCase {
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
-  func testSpotsDidReloadComponentModels() {
-    let initialComponentModels = [
-      ComponentModel(
-        kind: .list,
-        layout: Layout(span: 1.0),
-        items: [
-          Item(title: "Fullname", subtitle: "Job title", kind: "image"),
-          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
-          Item(title: "First name", subtitle: "Input first name", kind: "info"),
-          Item(title: "Last name", subtitle: "Input last name", kind: "info"),
-          Item(title: "Twitter", subtitle: "@twitter", kind: "info"),
-          Item(title: "", subtitle: "Biography", kind: "core", meta: ["dynamic-height": true])
-        ]
-      )
-    ]
-
-    let newComponentModels = [
-      ComponentModel(
-        kind: .list,
-        layout: Layout(span: 1.0),
-        items: [
-          Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
-          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
-          Item(title: "First name", subtitle: "Input first name", text: "John", kind: "info"),
-          Item(title: "Last name", subtitle: "Input last name", text: "Hyperseed", kind: "info"),
-          Item(title: "Twitter", subtitle: "@johnhyperseed", kind: "info"),
-          Item(subtitle: "Biography", text: "John Hyperseed is a bot", kind: "core", meta: ["dynamic-height": true])
-        ]
-      )
-    ]
-
-    let expectation = self.expectation(description: "Wait for componentsDidReloadComponentModels to be called")
-
-    SpotsController.componentsDidReloadComponentModels = { controller in
-      XCTAssert(true)
-      expectation.fulfill()
-    }
-
-    let components = initialComponentModels.map { Component(model: $0) }
-    let controller = SpotsController(components: components)
-
-    controller.prepareController()
-    controller.reloadIfNeeded(newComponentModels)
-
-    waitForExpectations(timeout: 10.0, handler: nil)
-  }
-
   func testReloadWithComponentModels() {
     let controller = SpotsController(components: [])
     let expectation = self.expectation(description: "Wait reload to complete")

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -640,7 +640,7 @@ class SpotsControllerTests: XCTestCase {
 
     let oldComponentModels: [ComponentModel] = controller.components.map { $0.model }
 
-    let changes = controller.generateChanges(from: newComponentModels, and: oldComponentModels)
+    let changes = controller.manager.generateChanges(from: newComponentModels, and: oldComponentModels)
     XCTAssertEqual(changes.count, 1)
     XCTAssertEqual(changes.first, .items)
 

--- a/SpotsTests/Shared/TestSpotsControllerManager.swift
+++ b/SpotsTests/Shared/TestSpotsControllerManager.swift
@@ -400,4 +400,47 @@ class TestSpotsControllerManager: XCTestCase {
 
     waitForExpectations(timeout: 10.0, handler: nil)
   }
+
+  func testReloadWithMoreItems() {
+    let newItems = [Item(title: "foo"), Item(title: "bar"), Item(title: "baz")]
+    var newComponent = controller.components[0].model
+    newComponent.items.append(contentsOf: newItems)
+
+    let expectation = self.expectation(description: "Wait for exception to be fulfilled.")
+    controller.reloadIfNeeded([newComponent]) {
+      let items = [
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz"),
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz")
+      ]
+      XCTAssertTrue(self.controller.components[0].model.items == items)
+
+      newComponent.items = []
+      self.controller.reloadIfNeeded([newComponent]) {
+        XCTAssertTrue(self.controller.components[0].model.items.isEmpty)
+
+        let items = [
+          Item(title: "foo"),
+          Item(title: "bar"),
+          Item(title: "baz")
+        ]
+        newComponent.items = items
+        self.controller.reloadIfNeeded([newComponent]) {
+
+          let items = [
+            Item(title: "foo"),
+            Item(title: "bar"),
+            Item(title: "baz")
+          ]
+          XCTAssertTrue(self.controller.components[0].model.items == items)
+
+          expectation.fulfill()
+        }
+      }
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
 }

--- a/SpotsTests/Shared/TestSpotsControllerManager.swift
+++ b/SpotsTests/Shared/TestSpotsControllerManager.swift
@@ -16,12 +16,13 @@ class TestSpotsControllerManager: XCTestCase {
     let model = ComponentModel(kind: .list, items: items)
     let component = Component(model: model)
     controller = SpotsController(components: [component])
+    controller.prepareController()
   }
 
   func testAppendItem() {
     let expectation = self.expectation(description: "Wait for completion")
     controller.append(Item(title: "baz1")) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -40,7 +41,7 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz2")
     ]
     controller.append(items) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -60,7 +61,7 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz2")
     ]
     controller.prepend(items) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "baz1"),
         Item(title: "baz2"),
         Item(title: "foo"),
@@ -76,7 +77,7 @@ class TestSpotsControllerManager: XCTestCase {
   func testInsertItem() {
     let expectation = self.expectation(description: "Wait for completion")
     controller.insert(Item(title: "baz1"), index: 1, componentIndex: 0) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz1"),
         Item(title: "bar"),
@@ -91,14 +92,14 @@ class TestSpotsControllerManager: XCTestCase {
   func testUpdateItem() {
     let expectation = self.expectation(description: "Wait for completion")
     controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz1")
         ])
 
       self.controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-        XCTAssertTrue(self.controller.component!.model.items == [
+        XCTAssertTrue(self.controller.components.first!.model.items == [
           Item(title: "foo"),
           Item(title: "bar"),
           Item(title: "baz1")
@@ -112,11 +113,11 @@ class TestSpotsControllerManager: XCTestCase {
   func testUpdateItemsWithIndexes() {
     let expectation = self.expectation(description: "Wait for completion")
 
-    controller.component!.model.items[0] = Item(title: "foo1")
-    controller.component!.model.items[1] = Item(title: "bar1")
+    controller.components[0].model.items[0] = Item(title: "foo1")
+    controller.components[0].model.items[1] = Item(title: "bar1")
 
     controller.update([0,1], componentIndex: 0) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo1"),
         Item(title: "bar1"),
         Item(title: "baz")
@@ -130,7 +131,7 @@ class TestSpotsControllerManager: XCTestCase {
   func testDeleteItem() {
     let expectation = self.expectation(description: "Wait for completion")
     controller.delete(1) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz")
         ])
@@ -144,7 +145,7 @@ class TestSpotsControllerManager: XCTestCase {
   func testDeleteItems() {
     let expectation = self.expectation(description: "Wait for completion")
     controller.delete([0,2]) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "bar")
         ])
 
@@ -160,13 +161,13 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz2")
     ]
     controller.updateIfNeeded(componentAtIndex: 0, items: items) {
-      XCTAssertTrue(self.controller.component!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "baz1"),
         Item(title: "baz2")
         ])
 
       self.controller.updateIfNeeded(componentAtIndex: 0, items: items) {
-        XCTAssertTrue(self.controller.component!.model.items == [
+        XCTAssertTrue(self.controller.components.first!.model.items == [
           Item(title: "baz1"),
           Item(title: "baz2")
           ])

--- a/SpotsTests/Shared/TestSpotsControllerManager.swift
+++ b/SpotsTests/Shared/TestSpotsControllerManager.swift
@@ -3,26 +3,22 @@ import Spots
 
 class TestSpotsControllerManager: XCTestCase {
 
-  var controller: SpotsController!
+  let component = Component(model: ComponentModel(kind: .list, items: [
+    Item(title: "foo"),
+    Item(title: "bar"),
+    Item(title: "baz")
+    ]))
 
   override func setUp() {
     Configuration.registerDefault(view: TestView.self)
-
-    let items = [
-      Item(title: "foo"),
-      Item(title: "bar"),
-      Item(title: "baz")
-    ]
-    let model = ComponentModel(kind: .list, items: items)
-    let component = Component(model: model)
-    controller = SpotsController(components: [component])
-    controller.prepareController()
   }
 
   func testAppendItem() {
     let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.append(Item(title: "baz1")) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -40,8 +36,10 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz1"),
       Item(title: "baz2")
     ]
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.append(items) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -60,8 +58,10 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz1"),
       Item(title: "baz2")
     ]
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.prepend(items) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "baz1"),
         Item(title: "baz2"),
         Item(title: "foo"),
@@ -76,8 +76,10 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testInsertItem() {
     let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.insert(Item(title: "baz1"), index: 1, componentIndex: 0) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz1"),
         Item(title: "bar"),
@@ -91,15 +93,17 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testUpdateItem() {
     let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz1")
         ])
 
-      self.controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-        XCTAssertTrue(self.controller.components.first!.model.items == [
+      controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
+        XCTAssertTrue(controller.components.first!.model.items == [
           Item(title: "foo"),
           Item(title: "bar"),
           Item(title: "baz1")
@@ -112,12 +116,13 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testUpdateItemsWithIndexes() {
     let expectation = self.expectation(description: "Wait for completion")
-
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.components[0].model.items[0] = Item(title: "foo1")
     controller.components[0].model.items[1] = Item(title: "bar1")
 
     controller.update([0,1], componentIndex: 0) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo1"),
         Item(title: "bar1"),
         Item(title: "baz")
@@ -130,8 +135,10 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testDeleteItem() {
     let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.delete(1) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz")
         ])
@@ -144,8 +151,10 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testDeleteItems() {
     let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
     controller.delete([0,2]) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "bar")
         ])
 
@@ -155,25 +164,262 @@ class TestSpotsControllerManager: XCTestCase {
   }
 
   func testUpdateIfNeeded() {
-    let expectation = self.expectation(description: "Wait for completion")
     let items = [
       Item(title: "baz1"),
       Item(title: "baz2")
     ]
+
+    let controller = SpotsController(components: [component])
+    let expectation = self.expectation(description: "Wait for completion")
     controller.updateIfNeeded(componentAtIndex: 0, items: items) {
-      XCTAssertTrue(self.controller.components.first!.model.items == [
+      XCTAssertTrue(controller.components.first!.model.items == [
         Item(title: "baz1"),
         Item(title: "baz2")
         ])
 
-      self.controller.updateIfNeeded(componentAtIndex: 0, items: items) {
-        XCTAssertTrue(self.controller.components.first!.model.items == [
+      controller.updateIfNeeded(componentAtIndex: 0, items: items) {
+        XCTAssertTrue(controller.components.first!.model.items == [
           Item(title: "baz1"),
           Item(title: "baz2")
           ])
         expectation.fulfill()
       }
     }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testReloadController() {
+    let expectation = self.expectation(description: "Wait for completion")
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
+    controller.reload() {
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testReloadIfNeededWithComponents() {
+    let initialModels = [
+      ComponentModel(kind: .carousel, layout: Layout(span: 1.0), items: [
+        Item(title: "foo1"),
+        Item(title: "bar1"),
+        Item(title: "baz1")
+        ]
+      ),
+      ComponentModel(kind: .grid, layout: Layout(span: 3.0), items: [
+        Item(title: "foo2"),
+        Item(title: "bar2"),
+        Item(title: "baz2")
+        ]
+      ),
+      ComponentModel(kind: .list, items: [
+        Item(title: "foo3"),
+        Item(title: "bar3"),
+        Item(title: "baz3")
+        ]
+      )
+    ]
+
+    let updatedModels = [
+      ComponentModel(kind: .carousel, layout: Layout(span: 1.0), items: [
+        Item(title: "foo1"),
+        Item(title: "bar4")
+        ]
+      ),
+      ComponentModel(kind: .carousel, layout: Layout(span: 3.0), items: [
+        Item(title: "foo2"),
+        Item(title: "bar2"),
+        Item(title: "baz2"),
+        Item(title: "baz4")
+        ]
+      ),
+      ComponentModel(kind: .list, items: [
+        Item(title: "foo3"),
+        Item(title: "bar3"),
+        Item(title: "baz3")
+        ]
+      )
+    ]
+
+    let finalUpdate = [
+      ComponentModel(kind: .carousel, layout: Layout(span: 1.0), items: [
+        Item(title: "foo1"),
+        Item(title: "bar4")
+        ]
+      ),
+      ComponentModel(kind: .list, items: [
+        Item(title: "foo3"),
+        Item(title: "bar3"),
+        Item(title: "baz3")
+        ]
+      )
+    ]
+
+    var expectation: XCTestExpectation? = self.expectation(description: "Wait for completion")
+
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .list, items: items)
+    let component = Component(model: model)
+    let controller = SpotsController(components: [component])
+
+    controller.reloadIfNeeded([]) {
+      XCTAssertTrue(controller.components.isEmpty)
+
+      controller.reloadIfNeeded(initialModels) {
+
+        XCTAssertEqual(controller.components.count, 3)
+
+        XCTAssertNotNil(controller.components[0].collectionView)
+        XCTAssertNotNil(controller.components[1].collectionView)
+        XCTAssertNotNil(controller.components[2].tableView)
+
+        XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
+        XCTAssertEqual(controller.components[0].model.items[1].title, "bar1")
+        XCTAssertEqual(controller.components[0].model.items[2].title, "baz1")
+
+        XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
+        XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
+        XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
+
+        XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
+        XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
+        XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+
+        var carouselInstance = controller.components[0].collectionView
+        var gridInstance = controller.components[1].collectionView
+        var listInstance = controller.components[2].tableView
+
+        controller.reloadIfNeeded(updatedModels) {
+          XCTAssertEqual(controller.components.count, 3)
+
+          XCTAssertNotNil(controller.components[0].collectionView)
+          XCTAssertNotNil(controller.components[1].collectionView)
+          XCTAssertNotNil(controller.components[2].tableView)
+
+          XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
+          XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+
+          XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
+          XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
+          XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
+          XCTAssertEqual(controller.components[1].model.items[3].title, "baz4")
+
+          XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
+          XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
+          XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+
+          XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
+          XCTAssertNotEqual(gridInstance, controller.components[1].collectionView)
+          XCTAssertEqual(listInstance, controller.components[2].tableView)
+
+          carouselInstance = controller.components[0].collectionView
+          gridInstance = controller.components[1].collectionView
+          listInstance = controller.components[2].tableView
+
+          controller.reloadIfNeeded(updatedModels) {
+            XCTAssertEqual(controller.components.count, 3)
+
+            XCTAssertNotNil(controller.components[0].collectionView)
+            XCTAssertNotNil(controller.components[1].collectionView)
+            XCTAssertNotNil(controller.components[2].tableView)
+
+            XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
+            XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+
+            XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
+            XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
+            XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
+            XCTAssertEqual(controller.components[1].model.items[3].title, "baz4")
+
+            XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
+            XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
+            XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+
+            XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
+            XCTAssertEqual(gridInstance, controller.components[1].collectionView)
+            XCTAssertEqual(listInstance, controller.components[2].tableView)
+
+            controller.reloadIfNeeded(finalUpdate) {
+
+              guard expectation != nil else {
+                XCTFail("Exception is nil")
+                return
+              }
+
+              XCTAssertEqual(controller.components.count, 2)
+
+              XCTAssertNotNil(controller.components[0].collectionView)
+              XCTAssertNotNil(controller.components[1].tableView)
+
+              XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
+              XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+
+              XCTAssertEqual(controller.components[1].model.items[0].title, "foo3")
+              XCTAssertEqual(controller.components[1].model.items[1].title, "bar3")
+              XCTAssertEqual(controller.components[1].model.items[2].title, "baz3")
+
+              XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
+              XCTAssertNotEqual(listInstance, controller.components[1].tableView)
+
+              expectation?.fulfill()
+              expectation = nil
+            }
+          }
+        }
+      }
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testSpotsDidReloadComponentModels() {
+    let initialComponentModels = [
+      ComponentModel(
+        kind: .list,
+        layout: Layout(span: 1.0),
+        items: [
+          Item(title: "Fullname", subtitle: "Job title", kind: "image"),
+          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
+          Item(title: "First name", subtitle: "Input first name", kind: "info"),
+          Item(title: "Last name", subtitle: "Input last name", kind: "info"),
+          Item(title: "Twitter", subtitle: "@twitter", kind: "info"),
+          Item(title: "", subtitle: "Biography", kind: "core", meta: ["dynamic-height": true])
+        ]
+      )
+    ]
+
+    let newComponentModels = [
+      ComponentModel(
+        kind: .list,
+        layout: Layout(span: 1.0),
+        items: [
+          Item(title: "Fullname", subtitle: "Job title", text: "Bot", kind: "image"),
+          Item(title: "Follow", kind: "toggle", meta: ["dynamic-height": true]),
+          Item(title: "First name", subtitle: "Input first name", text: "John", kind: "info"),
+          Item(title: "Last name", subtitle: "Input last name", text: "Hyperseed", kind: "info"),
+          Item(title: "Twitter", subtitle: "@johnhyperseed", kind: "info"),
+          Item(subtitle: "Biography", text: "John Hyperseed is a bot", kind: "core", meta: ["dynamic-height": true])
+        ]
+      )
+    ]
+
+    let expectation = self.expectation(description: "Wait for componentsDidReloadComponentModels to be called")
+
+    SpotsController.componentsDidReloadComponentModels = { controller in
+      XCTAssert(true)
+      expectation.fulfill()
+    }
+
+    let components = initialComponentModels.map { Component(model: $0) }
+    let controller = SpotsController(components: components)
+
+    controller.prepareController()
+    controller.reloadIfNeeded(newComponentModels)
+
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 }

--- a/SpotsTests/Shared/TestSpotsControllerManager.swift
+++ b/SpotsTests/Shared/TestSpotsControllerManager.swift
@@ -1,0 +1,178 @@
+import XCTest
+import Spots
+
+class TestSpotsControllerManager: XCTestCase {
+
+  var controller: SpotsController!
+
+  override func setUp() {
+    Configuration.registerDefault(view: TestView.self)
+
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .list, items: items)
+    let component = Component(model: model)
+    controller = SpotsController(components: [component])
+  }
+
+  func testAppendItem() {
+    let expectation = self.expectation(description: "Wait for completion")
+    controller.append(Item(title: "baz1")) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz"),
+        Item(title: "baz1")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testAppendItems() {
+    let expectation = self.expectation(description: "Wait for completion")
+    let items = [
+      Item(title: "baz1"),
+      Item(title: "baz2")
+    ]
+    controller.append(items) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz"),
+        Item(title: "baz1"),
+        Item(title: "baz2")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testPrependItems() {
+    let expectation = self.expectation(description: "Wait for completion")
+    let items = [
+      Item(title: "baz1"),
+      Item(title: "baz2")
+    ]
+    controller.prepend(items) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "baz1"),
+        Item(title: "baz2"),
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testInsertItem() {
+    let expectation = self.expectation(description: "Wait for completion")
+    controller.insert(Item(title: "baz1"), index: 1, componentIndex: 0) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo"),
+        Item(title: "baz1"),
+        Item(title: "bar"),
+        Item(title: "baz")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testUpdateItem() {
+    let expectation = self.expectation(description: "Wait for completion")
+    controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo"),
+        Item(title: "bar"),
+        Item(title: "baz1")
+        ])
+
+      self.controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
+        XCTAssertTrue(self.controller.component!.model.items == [
+          Item(title: "foo"),
+          Item(title: "bar"),
+          Item(title: "baz1")
+          ])
+        expectation.fulfill()
+      }
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testUpdateItemsWithIndexes() {
+    let expectation = self.expectation(description: "Wait for completion")
+
+    controller.component!.model.items[0] = Item(title: "foo1")
+    controller.component!.model.items[1] = Item(title: "bar1")
+
+    controller.update([0,1], componentIndex: 0) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo1"),
+        Item(title: "bar1"),
+        Item(title: "baz")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testDeleteItem() {
+    let expectation = self.expectation(description: "Wait for completion")
+    controller.delete(1) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "foo"),
+        Item(title: "baz")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+
+  func testDeleteItems() {
+    let expectation = self.expectation(description: "Wait for completion")
+    controller.delete([0,2]) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "bar")
+        ])
+
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+
+  func testUpdateIfNeeded() {
+    let expectation = self.expectation(description: "Wait for completion")
+    let items = [
+      Item(title: "baz1"),
+      Item(title: "baz2")
+    ]
+    controller.updateIfNeeded(componentAtIndex: 0, items: items) {
+      XCTAssertTrue(self.controller.component!.model.items == [
+        Item(title: "baz1"),
+        Item(title: "baz2")
+        ])
+
+      self.controller.updateIfNeeded(componentAtIndex: 0, items: items) {
+        XCTAssertTrue(self.controller.component!.model.items == [
+          Item(title: "baz1"),
+          Item(title: "baz2")
+          ])
+        expectation.fulfill()
+      }
+    }
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
+}

--- a/SpotsTests/Shared/TestSpotsControllerManager.swift
+++ b/SpotsTests/Shared/TestSpotsControllerManager.swift
@@ -3,6 +3,7 @@ import Spots
 
 class TestSpotsControllerManager: XCTestCase {
 
+  var controller: SpotsController!
   let component = Component(model: ComponentModel(kind: .list, items: [
     Item(title: "foo"),
     Item(title: "bar"),
@@ -11,14 +12,15 @@ class TestSpotsControllerManager: XCTestCase {
 
   override func setUp() {
     Configuration.registerDefault(view: TestView.self)
+
+    controller = SpotsController(components: [component])
+    controller.prepareController()
   }
 
   func testAppendItem() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.append(Item(title: "baz1")) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -36,10 +38,9 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz1"),
       Item(title: "baz2")
     ]
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
+
     controller.append(items) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz"),
@@ -58,10 +59,8 @@ class TestSpotsControllerManager: XCTestCase {
       Item(title: "baz1"),
       Item(title: "baz2")
     ]
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.prepend(items) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "baz1"),
         Item(title: "baz2"),
         Item(title: "foo"),
@@ -76,10 +75,8 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testInsertItem() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.insert(Item(title: "baz1"), index: 1, componentIndex: 0) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz1"),
         Item(title: "bar"),
@@ -93,17 +90,15 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testUpdateItem() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "bar"),
         Item(title: "baz1")
         ])
 
-      controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
-        XCTAssertTrue(controller.components.first!.model.items == [
+      self.controller.update(Item(title: "baz1"), index: 2, componentIndex: 0) {
+        XCTAssertTrue(self.controller.components.first!.model.items == [
           Item(title: "foo"),
           Item(title: "bar"),
           Item(title: "baz1")
@@ -116,13 +111,11 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testUpdateItemsWithIndexes() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.components[0].model.items[0] = Item(title: "foo1")
     controller.components[0].model.items[1] = Item(title: "bar1")
 
     controller.update([0,1], componentIndex: 0) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo1"),
         Item(title: "bar1"),
         Item(title: "baz")
@@ -135,10 +128,8 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testDeleteItem() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.delete(1) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "foo"),
         Item(title: "baz")
         ])
@@ -151,10 +142,8 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testDeleteItems() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.delete([0,2]) {
-      XCTAssertTrue(controller.components.first!.model.items == [
+      XCTAssertTrue(self.controller.components.first!.model.items == [
         Item(title: "bar")
         ])
 
@@ -190,8 +179,6 @@ class TestSpotsControllerManager: XCTestCase {
 
   func testReloadController() {
     let expectation = self.expectation(description: "Wait for completion")
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
     controller.reload() {
       expectation.fulfill()
     }
@@ -257,113 +244,104 @@ class TestSpotsControllerManager: XCTestCase {
 
     var expectation: XCTestExpectation? = self.expectation(description: "Wait for completion")
 
-    let items = [
-      Item(title: "foo"),
-      Item(title: "bar"),
-      Item(title: "baz")
-    ]
-    let model = ComponentModel(kind: .list, items: items)
-    let component = Component(model: model)
-    let controller = SpotsController(components: [component])
-
     controller.reloadIfNeeded([]) {
-      XCTAssertTrue(controller.components.isEmpty)
+      XCTAssertTrue(self.controller.components.isEmpty)
 
-      controller.reloadIfNeeded(initialModels) {
+      self.controller.reloadIfNeeded(initialModels) {
 
-        XCTAssertEqual(controller.components.count, 3)
+        XCTAssertEqual(self.controller.components.count, 3)
 
-        XCTAssertNotNil(controller.components[0].collectionView)
-        XCTAssertNotNil(controller.components[1].collectionView)
-        XCTAssertNotNil(controller.components[2].tableView)
+        XCTAssertNotNil(self.controller.components[0].collectionView)
+        XCTAssertNotNil(self.controller.components[1].collectionView)
+        XCTAssertNotNil(self.controller.components[2].tableView)
 
-        XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
-        XCTAssertEqual(controller.components[0].model.items[1].title, "bar1")
-        XCTAssertEqual(controller.components[0].model.items[2].title, "baz1")
+        XCTAssertEqual(self.controller.components[0].model.items[0].title, "foo1")
+        XCTAssertEqual(self.controller.components[0].model.items[1].title, "bar1")
+        XCTAssertEqual(self.controller.components[0].model.items[2].title, "baz1")
 
-        XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
-        XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
-        XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
+        XCTAssertEqual(self.controller.components[1].model.items[0].title, "foo2")
+        XCTAssertEqual(self.controller.components[1].model.items[1].title, "bar2")
+        XCTAssertEqual(self.controller.components[1].model.items[2].title, "baz2")
 
-        XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
-        XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
-        XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+        XCTAssertEqual(self.controller.components[2].model.items[0].title, "foo3")
+        XCTAssertEqual(self.controller.components[2].model.items[1].title, "bar3")
+        XCTAssertEqual(self.controller.components[2].model.items[2].title, "baz3")
 
-        var carouselInstance = controller.components[0].collectionView
-        var gridInstance = controller.components[1].collectionView
-        var listInstance = controller.components[2].tableView
+        var carouselInstance = self.controller.components[0].collectionView
+        var gridInstance = self.controller.components[1].collectionView
+        var listInstance = self.controller.components[2].tableView
 
-        controller.reloadIfNeeded(updatedModels) {
-          XCTAssertEqual(controller.components.count, 3)
+        self.controller.reloadIfNeeded(updatedModels) {
+          XCTAssertEqual(self.controller.components.count, 3)
 
-          XCTAssertNotNil(controller.components[0].collectionView)
-          XCTAssertNotNil(controller.components[1].collectionView)
-          XCTAssertNotNil(controller.components[2].tableView)
+          XCTAssertNotNil(self.controller.components[0].collectionView)
+          XCTAssertNotNil(self.controller.components[1].collectionView)
+          XCTAssertNotNil(self.controller.components[2].tableView)
 
-          XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
-          XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+          XCTAssertEqual(self.controller.components[0].model.items[0].title, "foo1")
+          XCTAssertEqual(self.controller.components[0].model.items[1].title, "bar4")
 
-          XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
-          XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
-          XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
-          XCTAssertEqual(controller.components[1].model.items[3].title, "baz4")
+          XCTAssertEqual(self.controller.components[1].model.items[0].title, "foo2")
+          XCTAssertEqual(self.controller.components[1].model.items[1].title, "bar2")
+          XCTAssertEqual(self.controller.components[1].model.items[2].title, "baz2")
+          XCTAssertEqual(self.controller.components[1].model.items[3].title, "baz4")
 
-          XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
-          XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
-          XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+          XCTAssertEqual(self.controller.components[2].model.items[0].title, "foo3")
+          XCTAssertEqual(self.controller.components[2].model.items[1].title, "bar3")
+          XCTAssertEqual(self.controller.components[2].model.items[2].title, "baz3")
 
-          XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
-          XCTAssertNotEqual(gridInstance, controller.components[1].collectionView)
-          XCTAssertEqual(listInstance, controller.components[2].tableView)
+          XCTAssertEqual(carouselInstance, self.controller.components[0].collectionView)
+          XCTAssertNotEqual(gridInstance, self.controller.components[1].collectionView)
+          XCTAssertEqual(listInstance, self.controller.components[2].tableView)
 
-          carouselInstance = controller.components[0].collectionView
-          gridInstance = controller.components[1].collectionView
-          listInstance = controller.components[2].tableView
+          carouselInstance = self.controller.components[0].collectionView
+          gridInstance = self.controller.components[1].collectionView
+          listInstance = self.controller.components[2].tableView
 
-          controller.reloadIfNeeded(updatedModels) {
-            XCTAssertEqual(controller.components.count, 3)
+          self.controller.reloadIfNeeded(updatedModels) {
+            XCTAssertEqual(self.controller.components.count, 3)
 
-            XCTAssertNotNil(controller.components[0].collectionView)
-            XCTAssertNotNil(controller.components[1].collectionView)
-            XCTAssertNotNil(controller.components[2].tableView)
+            XCTAssertNotNil(self.controller.components[0].collectionView)
+            XCTAssertNotNil(self.controller.components[1].collectionView)
+            XCTAssertNotNil(self.controller.components[2].tableView)
 
-            XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
-            XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+            XCTAssertEqual(self.controller.components[0].model.items[0].title, "foo1")
+            XCTAssertEqual(self.controller.components[0].model.items[1].title, "bar4")
 
-            XCTAssertEqual(controller.components[1].model.items[0].title, "foo2")
-            XCTAssertEqual(controller.components[1].model.items[1].title, "bar2")
-            XCTAssertEqual(controller.components[1].model.items[2].title, "baz2")
-            XCTAssertEqual(controller.components[1].model.items[3].title, "baz4")
+            XCTAssertEqual(self.controller.components[1].model.items[0].title, "foo2")
+            XCTAssertEqual(self.controller.components[1].model.items[1].title, "bar2")
+            XCTAssertEqual(self.controller.components[1].model.items[2].title, "baz2")
+            XCTAssertEqual(self.controller.components[1].model.items[3].title, "baz4")
 
-            XCTAssertEqual(controller.components[2].model.items[0].title, "foo3")
-            XCTAssertEqual(controller.components[2].model.items[1].title, "bar3")
-            XCTAssertEqual(controller.components[2].model.items[2].title, "baz3")
+            XCTAssertEqual(self.controller.components[2].model.items[0].title, "foo3")
+            XCTAssertEqual(self.controller.components[2].model.items[1].title, "bar3")
+            XCTAssertEqual(self.controller.components[2].model.items[2].title, "baz3")
 
-            XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
-            XCTAssertEqual(gridInstance, controller.components[1].collectionView)
-            XCTAssertEqual(listInstance, controller.components[2].tableView)
+            XCTAssertEqual(carouselInstance, self.controller.components[0].collectionView)
+            XCTAssertEqual(gridInstance, self.controller.components[1].collectionView)
+            XCTAssertEqual(listInstance, self.controller.components[2].tableView)
 
-            controller.reloadIfNeeded(finalUpdate) {
+            self.controller.reloadIfNeeded(finalUpdate) {
 
               guard expectation != nil else {
                 XCTFail("Exception is nil")
                 return
               }
 
-              XCTAssertEqual(controller.components.count, 2)
+              XCTAssertEqual(self.controller.components.count, 2)
 
-              XCTAssertNotNil(controller.components[0].collectionView)
-              XCTAssertNotNil(controller.components[1].tableView)
+              XCTAssertNotNil(self.controller.components[0].collectionView)
+              XCTAssertNotNil(self.controller.components[1].tableView)
 
-              XCTAssertEqual(controller.components[0].model.items[0].title, "foo1")
-              XCTAssertEqual(controller.components[0].model.items[1].title, "bar4")
+              XCTAssertEqual(self.controller.components[0].model.items[0].title, "foo1")
+              XCTAssertEqual(self.controller.components[0].model.items[1].title, "bar4")
 
-              XCTAssertEqual(controller.components[1].model.items[0].title, "foo3")
-              XCTAssertEqual(controller.components[1].model.items[1].title, "bar3")
-              XCTAssertEqual(controller.components[1].model.items[2].title, "baz3")
+              XCTAssertEqual(self.controller.components[1].model.items[0].title, "foo3")
+              XCTAssertEqual(self.controller.components[1].model.items[1].title, "bar3")
+              XCTAssertEqual(self.controller.components[1].model.items[2].title, "baz3")
 
-              XCTAssertEqual(carouselInstance, controller.components[0].collectionView)
-              XCTAssertNotEqual(listInstance, controller.components[1].tableView)
+              XCTAssertEqual(carouselInstance, self.controller.components[0].collectionView)
+              XCTAssertNotEqual(listInstance, self.controller.components[1].tableView)
 
               expectation?.fulfill()
               expectation = nil

--- a/SpotsTests/iOS/TestSpot.swift
+++ b/SpotsTests/iOS/TestSpot.swift
@@ -9,6 +9,7 @@ class TestSpot: XCTestCase {
     Configuration.register(view: HeaderView.self, identifier: "Header")
     Configuration.register(view: TextView.self, identifier: "TextView")
     Configuration.register(view: FooterView.self, identifier: "Footer")
+    StateCache.removeAll()
   }
 
   func testDefaultValues() {


### PR DESCRIPTION
This PR follows the same principal as #583. But this time it takes the protocol extension `SpotProtocol+Mutation` and moves that into a separate class called `SpotsControllerManager`.
It is in charge of handling mutation on a controller level, such as reloading the controller with a
collection of components. `SpotsProtocol+Mutation` is now `SpotsController+Extensions`. It is
there to not change the public API for when working with the controller. It just relays the function
call to the manager so that it can do its job properly.

This is big as it adds a lot of new tests for `SpotsControllerManager`, other than that it is a about
copy pasting code from the old protocol extension to the new class. Same functionality but
move into a different class.

One odd thing is that I had to move one of the tests from SpotsController into SpotsControllerManager. It would break because it got confused by which method called the fulfill on the expectation.
Moving the test from one test case to another fixed the issue.