### PR TITLE
Rename file and make extension live on SpotsController

### DIFF
--- a/Sources/Shared/Extensions/SpotsController+LiveEditing.swift
+++ b/Sources/Shared/Extensions/SpotsController+LiveEditing.swift
@@ -7,7 +7,7 @@
 import Cache
 
 #if DEVMODE
-  public extension SpotsProtocol {
+  public extension SpotsController {
 
     /// Monitor changes made to a file at file path.
     ///

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -195,9 +195,9 @@
 		BDAD85961E3E7032008289AE /* SpotsProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */; };
 		BDAD85971E3E7032008289AE /* SpotsProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */; };
 		BDAD85981E3E7032008289AE /* SpotsProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */; };
-		BDAD85991E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
-		BDAD859A1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
-		BDAD859B1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */; };
+		BDAD85991E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsController+LiveEditing.swift */; };
+		BDAD859A1E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsController+LiveEditing.swift */; };
+		BDAD859B1E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85401E3E7032008289AE /* SpotsController+LiveEditing.swift */; };
 		BDAD859C1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
 		BDAD859D1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
 		BDAD859E1E3E7032008289AE /* SpotsController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */; };
@@ -485,7 +485,7 @@
 		BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ItemConfigurable+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853E1E3E7032008289AE /* ComponentDelegate+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+Extensions.swift"; sourceTree = "<group>"; };
-		BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsProtocol+LiveEditing.swift"; sourceTree = "<group>"; };
+		BDAD85401E3E7032008289AE /* SpotsController+LiveEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+LiveEditing.swift"; sourceTree = "<group>"; };
 		BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Wrappable+Extensions.swift"; sourceTree = "<group>"; };
 		BDAD85451E3E7032008289AE /* CarouselScrollDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselScrollDelegate.swift; sourceTree = "<group>"; };
@@ -806,9 +806,9 @@
 				BDAD85381E3E7032008289AE /* Item+Extensions.swift */,
 				BDAD853D1E3E7032008289AE /* ItemConfigurable+Extensions.swift */,
 				BDAD853A1E3E7032008289AE /* ScrollDelegate+Extensions.swift */,
-				BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */,
-				BDAD85401E3E7032008289AE /* SpotsProtocol+LiveEditing.swift */,
 				BDAD85411E3E7032008289AE /* SpotsController+Extensions.swift */,
+				BDAD85401E3E7032008289AE /* SpotsController+LiveEditing.swift */,
+				BDAD853F1E3E7032008289AE /* SpotsProtocol+Extensions.swift */,
 				BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */,
 				BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */,
 			);
@@ -1495,7 +1495,7 @@
 				BDAD84A91E3E701C008289AE /* CarouselSpotHeader.swift in Sources */,
 				BDAD85741E3E7032008289AE /* Paginate.swift in Sources */,
 				BDAD84AF1E3E701C008289AE /* GridComposite.swift in Sources */,
-				BDAD859B1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */,
+				BDAD859B1E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */,
 				BDAD84D31E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */,
 				BDAD85AD1E3E7032008289AE /* Composable.swift in Sources */,
 				BDAD85681E3E7032008289AE /* Delegate.swift in Sources */,
@@ -1615,7 +1615,7 @@
 				BDAD84D01E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */,
 				BDAD84BA1E3E701C008289AE /* ListHeaderFooterWrapper.swift in Sources */,
 				BDAD858D1E3E7032008289AE /* Component+Mutation.swift in Sources */,
-				BDAD85991E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */,
+				BDAD85991E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */,
 				BD0AF3521E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDAD84DE1E3E701C008289AE /* UICollectionView+UserInterface.swift in Sources */,
 				BDB1F8B31E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */,
@@ -1774,7 +1774,7 @@
 				BDAD85B81E3E7032008289AE /* ScrollDelegate.swift in Sources */,
 				BDAD85271E3E7025008289AE /* ComponentView.swift in Sources */,
 				BDAD851C1E3E7025008289AE /* Composable+macOS.swift in Sources */,
-				BDAD859A1E3E7032008289AE /* SpotsProtocol+LiveEditing.swift in Sources */,
+				BDAD859A1E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */,
 				BDAD85231E3E7025008289AE /* NSCollectionView+UserInterface.swift in Sources */,
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,


### PR DESCRIPTION
This PR refactors the live editing extension to point to SpotsController instead of SpotProtocol.
It also renames the file.