### PR TITLE
Call configure method on the view when it will be displayed in the component delegate

### DIFF
--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -14,8 +14,6 @@ extension DataSource {
         if component.model.items[index].size.height == 0.0 {
           component.model.items[index].size = configurableView.preferredViewSize
         }
-
-        component.configure?(configurableView)
       } else {
         component.model.items[index].size.height = wrappedView.frame.size.height
       }

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -37,6 +37,11 @@ extension Delegate: UICollectionViewDelegate {
     }
 
     let view = (cell as? Wrappable)?.wrappedView ?? cell
+
+    if let itemConfigurable = view as? ItemConfigurable {
+      component.configure?(itemConfigurable)
+    }
+
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 
@@ -177,6 +182,11 @@ extension Delegate: UITableViewDelegate {
     }
 
     let view = (cell as? Wrappable)?.wrappedView ?? cell
+
+    if let itemConfigurable = view as? ItemConfigurable {
+      component.configure?(itemConfigurable)
+    }
+
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -33,6 +33,11 @@ extension Delegate: NSCollectionViewDelegate {
       else {
         return
     }
+
+    if let itemConfigurable = view as? ItemConfigurable {
+      component.configure?(itemConfigurable)
+    }
+
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 
@@ -114,12 +119,20 @@ extension Delegate: NSTableViewDelegate {
       view.contentView.frame.size.height = component.computedHeight
       view.configure(&component.model.items[row], compositeComponents: components)
     case let view as NSTableRowView:
-      (view as? ItemConfigurable)?.configure(&component.model.items[row])
+      if let itemConfigurable = view as? ItemConfigurable {
+        itemConfigurable.configure(&component.model.items[row])
+        component.configure?(itemConfigurable)
+      }
     default:
       if let view = resolvedView, !(view is NSTableRowView) {
         let wrapper = ListWrapper()
         wrapper.configure(with: view)
-        (view as? ItemConfigurable)?.configure(&component.model.items[row])
+
+        if let itemConfigurable = view as? ItemConfigurable {
+          itemConfigurable.configure(&component.model.items[row])
+          component.configure?(itemConfigurable)
+        }
+
         resolvedView = wrapper
       }
     }
@@ -139,6 +152,7 @@ extension Delegate: NSTableViewDelegate {
     }
 
     let view = (cell as? Wrappable)?.wrappedView ?? cell
+
     component.delegate?.component(component, willDisplay: view, item: item)
   }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		BD24030C1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD24030D1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD2403111E4B9A02005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2403101E4B9A02005BAA19 /* Component.swift */; };
+		BD31BB9D1EA6209C00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
+		BD31BB9E1EA6209D00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
+		BD31BB9F1EA6209E00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
 		BD4295551D81D39700E07E1C /* TestComponentiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* TestComponentiOS.swift */; };
 		BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
 		BD42CA861E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
@@ -53,6 +56,8 @@
 		BD45D9961E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
 		BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
 		BD5FC7DF1E857AD900D03038 /* FlippedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7DE1E857AD900D03038 /* FlippedView.swift */; };
+		BD5FE3451EA6222C0008749C /* TestComponentDelegate+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */; };
+		BD5FE3461EA6222D0008749C /* TestComponentDelegate+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */; };
 		BD677E851DC616B2006D1654 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
 		BD677E871DC616B2006D1654 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
 		BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E881DC61EFC006D1654 /* TestStateCache.swift */; };
@@ -82,9 +87,6 @@
 		BD798EF81EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
 		BD798EF91EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
 		BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
-		BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
-		BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
-		BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */; };
 		BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E841DC616B2006D1654 /* TestComponent.swift */; };
 		BD9ECEB71E6EC6B4003E4388 /* Component+macOS+Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */; };
 		BD9ECEB81E6EC6BC003E4388 /* Component+macOS+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */; };
@@ -325,8 +327,6 @@
 		BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */; };
 		BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
 		BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
-		BDEFF5521DD1DA8000FC0537 /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */; };
-		BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */; };
 		BDFC474F1E747B2B008700BF /* TestGridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474C1E747B2B008700BF /* TestGridWrapper.swift */; };
 		BDFC47521E747B2B008700BF /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474D1E747B2B008700BF /* TestListWrapper.swift */; };
 		D55B7AF91E423122000125C8 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
@@ -411,6 +411,7 @@
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
+		BD31BB991EA6208600D1FC8A /* TestDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDelegate.swift; sourceTree = "<group>"; };
 		BD4295541D81D39700E07E1C /* TestComponentiOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentiOS.swift; sourceTree = "<group>"; };
 		BD42CA841E4C9B2600A86E3B /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD45D9861E30906300C2D6B2 /* TestLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayout.swift; sourceTree = "<group>"; };
@@ -432,7 +433,6 @@
 		BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentModel+Equatable.swift"; sourceTree = "<group>"; };
 		BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManager.swift; sourceTree = "<group>"; };
 		BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsControllerManager.swift; sourceTree = "<group>"; };
-		BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentDelegate.swift; sourceTree = "<group>"; };
 		BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Carousel.swift"; sourceTree = "<group>"; };
 		BD9ECEB91E6EC6D1003E4388 /* Component+macOS+Grid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Grid.swift"; sourceTree = "<group>"; };
@@ -542,7 +542,7 @@
 		BDEA327E1E87A6FF0044B056 /* TestInteraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInteraction.swift; sourceTree = "<group>"; };
 		BDEED2E71D8446400030B475 /* TestSpotsScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsScrollView.swift; sourceTree = "<group>"; };
 		BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDataSource.swift; sourceTree = "<group>"; };
-		BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDelegate.swift; sourceTree = "<group>"; };
+		BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TestComponentDelegate+iOS.swift"; sourceTree = "<group>"; };
 		BDFC474C1E747B2B008700BF /* TestGridWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridWrapper.swift; sourceTree = "<group>"; };
 		BDFC474D1E747B2B008700BF /* TestListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListWrapper.swift; sourceTree = "<group>"; };
 		D55B7B021E423122000125C8 /* RxSpots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSpots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1009,7 +1009,7 @@
 				BDD9ABCD1DB53475005D8C04 /* TestCarouselComposite.swift */,
 				BD4295541D81D39700E07E1C /* TestComponentiOS.swift */,
 				BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */,
-				BDEFF5511DD1DA8000FC0537 /* TestDelegate.swift */,
+				BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */,
 				BDD9ABCA1DB533CE005D8C04 /* TestGridComposite.swift */,
 				BD45D98A1E30909700C2D6B2 /* TestLayoutExtensions.swift */,
 				BD01BD141DAEA7EE009C10FF /* TestListComposite.swift */,
@@ -1039,9 +1039,9 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
-				BD91F3F51E90F74500F22943 /* TestComponentDelegate.swift */,
 				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
 				BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */,
+				BD31BB991EA6208600D1FC8A /* TestDelegate.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1584,12 +1584,12 @@
 				BDCFCD431DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponentModel.swift in Sources */,
+				BD5FE3451EA6222C0008749C /* TestComponentDelegate+iOS.swift in Sources */,
 				BD42CA861E4C9B2600A86E3B /* TestSpot.swift in Sources */,
 				BDB8D5951E4DFADC00220BC3 /* TestItem.swift in Sources */,
 				BDEA32811E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				D5D282741E547742004BF251 /* TestListWrapper.swift in Sources */,
 				BD21C2551E4358CE00FE2B26 /* TestGridableLayout.swift in Sources */,
-				BDEFF5531DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
 				BD677E871DC616B2006D1654 /* TestComponent.swift in Sources */,
 				BDDF2CCD1DC7C23500B766BA /* TestAnimations.swift in Sources */,
 				BD01BD131DAEA523009C10FF /* TestParser.swift in Sources */,
@@ -1598,11 +1598,11 @@
 				BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDD9ABCF1DB53475005D8C04 /* TestCarouselComposite.swift in Sources */,
-				BD91F3F81E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */,
+				BD31BB9F1EA6209E00D1FC8A /* TestDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1734,9 +1734,10 @@
 				BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD677E8F1DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
+				BD31BB9D1EA6209C00D1FC8A /* TestDelegate.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
+				BD5FE3461EA6222D0008749C /* TestComponentDelegate+iOS.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
-				BD91F3F61E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */,
 				BD798EF81EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				D5D282731E54773C004BF251 /* TestListWrapper.swift in Sources */,
@@ -1749,7 +1750,6 @@
 				BD45D9951E30A8A000C2D6B2 /* TestInset.swift in Sources */,
 				BDEA327F1E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BDD9ABCB1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
-				BDEFF5521DD1DA8000FC0537 /* TestDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1846,12 +1846,12 @@
 			files = (
 				D58478E71C440645006EBA49 /* TestComponentModel.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
-				BD91F3F71E90F74500F22943 /* TestComponentDelegate.swift in Sources */,
 				BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */,
+				BD31BB9E1EA6209D00D1FC8A /* TestDelegate.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BDE44B171EA0F0E50021EAC8 /* TestComponentManager.swift in Sources */,
 				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -40,9 +40,9 @@
 		BD24030C1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD24030D1E4B981A005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24030B1E4B981A005BAA19 /* Component.swift */; };
 		BD2403111E4B9A02005BAA19 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2403101E4B9A02005BAA19 /* Component.swift */; };
-		BD31BB9D1EA6209C00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
-		BD31BB9E1EA6209D00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
-		BD31BB9F1EA6209E00D1FC8A /* TestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* TestDelegate.swift */; };
+		BD31BB9D1EA6209C00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
+		BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
+		BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
 		BD4295551D81D39700E07E1C /* TestComponentiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* TestComponentiOS.swift */; };
 		BD42CA851E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
 		BD42CA861E4C9B2600A86E3B /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* TestSpot.swift */; };
@@ -411,7 +411,7 @@
 		BD21C2511E4358B900FE2B26 /* TestGridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridableLayout.swift; sourceTree = "<group>"; };
 		BD24030B1E4B981A005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD2403101E4B9A02005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
-		BD31BB991EA6208600D1FC8A /* TestDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDelegate.swift; sourceTree = "<group>"; };
+		BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateConfigurationClosureTests.swift; sourceTree = "<group>"; };
 		BD4295541D81D39700E07E1C /* TestComponentiOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentiOS.swift; sourceTree = "<group>"; };
 		BD42CA841E4C9B2600A86E3B /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD45D9861E30906300C2D6B2 /* TestLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayout.swift; sourceTree = "<group>"; };
@@ -1026,22 +1026,22 @@
 		D584782A1C43FF34006EBA49 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */,
 				BD677E8E1DC65D63006D1654 /* Helpers.swift */,
+				BD677E841DC616B2006D1654 /* TestComponent.swift */,
+				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
 				D584782B1C43FF34006EBA49 /* TestComponentModel.swift */,
 				BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */,
-				BD677E841DC616B2006D1654 /* TestComponent.swift */,
 				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
 				BDEA327E1E87A6FF0044B056 /* TestInteraction.swift */,
 				BDB8D5921E4DFADC00220BC3 /* TestItem.swift */,
 				BD45D9861E30906300C2D6B2 /* TestLayout.swift */,
 				BD01BD0D1DAEA464009C10FF /* TestParser.swift */,
 				BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */,
+				BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */,
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
-				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
-				BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */,
-				BD31BB991EA6208600D1FC8A /* TestDelegate.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1602,7 +1602,7 @@
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDD9ABCC1DB533CE005D8C04 /* TestGridComposite.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */,
-				BD31BB9F1EA6209E00D1FC8A /* TestDelegate.swift in Sources */,
+				BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1734,7 +1734,7 @@
 				BD677E891DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD677E8F1DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD01BD111DAEA522009C10FF /* TestParser.swift in Sources */,
-				BD31BB9D1EA6209C00D1FC8A /* TestDelegate.swift in Sources */,
+				BD31BB9D1EA6209C00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 				BD01BD181DAEA7FC009C10FF /* TestListComposite.swift in Sources */,
 				BD5FE3461EA6222D0008749C /* TestComponentDelegate+iOS.swift in Sources */,
 				BD677E8D1DC62575006D1654 /* TestUIViewControllerExtensions.swift in Sources */,
@@ -1851,7 +1851,7 @@
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */,
-				BD31BB9E1EA6209D00D1FC8A /* TestDelegate.swift in Sources */,
+				BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BDE44B171EA0F0E50021EAC8 /* TestComponentManager.swift in Sources */,
 				BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */,

--- a/SpotsTests/Shared/DelegateConfigurationClosureTests.swift
+++ b/SpotsTests/Shared/DelegateConfigurationClosureTests.swift
@@ -41,7 +41,6 @@ class DelegateConfigurationClosureTests: XCTestCase {
 
     var invocations: Int = 0
 
-    /// Verify that the configuration closure is called again when you reassign it.
     component.configure = { item in
       invocations += 1
     }
@@ -49,6 +48,7 @@ class DelegateConfigurationClosureTests: XCTestCase {
     component.setup(with: CGSize(width: 200, height: 200))
     XCTAssertEqual(invocations, 3)
 
+    /// Verify that the configuration closure is called again when you reassign it.
     component.configure = { item in
       invocations += 1
     }

--- a/SpotsTests/Shared/DelegateConfigurationClosureTests.swift
+++ b/SpotsTests/Shared/DelegateConfigurationClosureTests.swift
@@ -1,9 +1,9 @@
 import XCTest
 import Spots
 
-class TestDelegate: XCTestCase {
+class DelegateConfigurationClosureTests: XCTestCase {
 
-  func testWillDisplayInList() {
+  func testConfigureCalledOncePerSetupInListComponent() {
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
@@ -22,6 +22,7 @@ class TestDelegate: XCTestCase {
 
     XCTAssertEqual(invocations, 3)
 
+    /// Verify that the configuration closure is called again when you reassign it.
     component.configure = { item in
       invocations += 1
     }
@@ -29,7 +30,7 @@ class TestDelegate: XCTestCase {
     XCTAssertEqual(invocations, 6)
   }
 
-  func testWillDisplayInGrid() {
+  func testConfigureCalledOncePerSetupInGridComponent() {
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),
@@ -40,6 +41,7 @@ class TestDelegate: XCTestCase {
 
     var invocations: Int = 0
 
+    /// Verify that the configuration closure is called again when you reassign it.
     component.configure = { item in
       invocations += 1
     }

--- a/SpotsTests/Shared/TestDelegate.swift
+++ b/SpotsTests/Shared/TestDelegate.swift
@@ -21,6 +21,12 @@ class TestDelegate: XCTestCase {
     component.setup(with: CGSize(width: 200, height: 200))
 
     XCTAssertEqual(invocations, 3)
+
+    component.configure = { item in
+      invocations += 1
+    }
+
+    XCTAssertEqual(invocations, 6)
   }
 
   func testWillDisplayInGrid() {
@@ -40,5 +46,11 @@ class TestDelegate: XCTestCase {
 
     component.setup(with: CGSize(width: 200, height: 200))
     XCTAssertEqual(invocations, 3)
+
+    component.configure = { item in
+      invocations += 1
+    }
+
+    XCTAssertEqual(invocations, 6)
   }
 }

--- a/SpotsTests/Shared/TestDelegate.swift
+++ b/SpotsTests/Shared/TestDelegate.swift
@@ -1,0 +1,44 @@
+import XCTest
+import Spots
+
+class TestDelegate: XCTestCase {
+
+  func testWillDisplayInList() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .list, items: items)
+    let component = Component(model: model)
+
+    var invocations: Int = 0
+
+    component.configure = { item in
+      invocations += 1
+    }
+
+    component.setup(with: CGSize(width: 200, height: 200))
+
+    XCTAssertEqual(invocations, 3)
+  }
+
+  func testWillDisplayInGrid() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let model = ComponentModel(kind: .grid, items: items)
+    let component = Component(model: model)
+
+    var invocations: Int = 0
+
+    component.configure = { item in
+      invocations += 1
+    }
+
+    component.setup(with: CGSize(width: 200, height: 200))
+    XCTAssertEqual(invocations, 3)
+  }
+}

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-class MockComponentDelegate: NSObject, ComponentDelegate {}
+class MockComponentDelegate: ComponentDelegate {}
 
 class SpotsControllerTests: XCTestCase {
 
@@ -900,7 +900,7 @@ class SpotsControllerTests: XCTestCase {
     let mockDelegate = MockComponentDelegate()
     controller.delegate = mockDelegate
 
-    XCTAssertTrue(mockDelegate.isEqual(listComponent.delegate!))
-    XCTAssertTrue(mockDelegate.isEqual(gridComponent.delegate!))
+    XCTAssertTrue(mockDelegate === listComponent.delegate!)
+    XCTAssertTrue(mockDelegate === gridComponent.delegate!)
   }
 }

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -2,6 +2,8 @@
 import Foundation
 import XCTest
 
+class MockComponentDelegate: NSObject, ComponentDelegate {}
+
 class SpotsControllerTests: XCTestCase {
 
   func testSpotAtIndex() {
@@ -887,5 +889,18 @@ class SpotsControllerTests: XCTestCase {
     XCTAssertEqual(controller.component(at: 0), listComponent)
     XCTAssertEqual(controller.component(at: 1), gridComponent)
     XCTAssertEqual(controller.component(at: 2), nil)
+  }
+
+  func testUpdatingDelegates() {
+    let listModel = ComponentModel(kind: .list)
+    let gridModel = ComponentModel(kind: .grid)
+    let listComponent = Component(model: listModel)
+    let gridComponent = Component(model: gridModel)
+    let controller = SpotsController(components: [listComponent, gridComponent])
+    let mockDelegate = MockComponentDelegate()
+    controller.delegate = mockDelegate
+
+    XCTAssertTrue(mockDelegate.isEqual(listComponent.delegate!))
+    XCTAssertTrue(mockDelegate.isEqual(gridComponent.delegate!))
   }
 }

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-class MockComponentDelegate: ComponentDelegate {}
+class ComponentDelegateMock: ComponentDelegate {}
 
 class SpotsControllerTests: XCTestCase {
 
@@ -897,7 +897,7 @@ class SpotsControllerTests: XCTestCase {
     let listComponent = Component(model: listModel)
     let gridComponent = Component(model: gridModel)
     let controller = SpotsController(components: [listComponent, gridComponent])
-    let mockDelegate = MockComponentDelegate()
+    let mockDelegate = ComponentDelegateMock()
     controller.delegate = mockDelegate
 
     XCTAssertTrue(mockDelegate === listComponent.delegate!)

--- a/SpotsTests/iOS/TestComponentDelegate+iOS.swift
+++ b/SpotsTests/iOS/TestComponentDelegate+iOS.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-class TestDelegate: ComponentDelegate {
+class MockComponentiOSDelegate: ComponentDelegate {
   var countsInvoked = 0
 
   func component(_ component: Component, itemSelected item: Item) {
@@ -11,12 +11,12 @@ class TestDelegate: ComponentDelegate {
   }
 }
 
-class DelegateTests: XCTestCase {
+class ComponentDelegateiOSTests: XCTestCase {
 
   // MARK: - UICollectionView
 
   func testCollectionViewDelegateSelection() {
-    let delegate = TestDelegate()
+    let delegate = MockComponentiOSDelegate()
     let component = Component(model: ComponentModel(kind: .grid, layout: Layout(span: 1), items: [
       Item(title: "title 1")
       ]))
@@ -51,7 +51,7 @@ class DelegateTests: XCTestCase {
   // MARK: - UITableView
 
   func testTableViewDelegateSelection() {
-    let delegate = TestDelegate()
+    let delegate = MockComponentiOSDelegate()
     let component = Component(model: ComponentModel(kind: .list, layout: Layout(span: 1), items: [
       Item(title: "title 1")
       ]))


### PR DESCRIPTION
With the previous implementation, views that are not inside of the current visible rectangle would not be configured. Calling the configure method for each view when they appear on inside of the visible rectangle fixes this issue.

The implementation is a bit different for `NSTableView` on `macOS` but that should also be covered by the new tests.