### PR TITLE
Refactor ComponentManager

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -439,7 +439,7 @@ public extension Component {
   /// Update height and refresh indexes for the component.
   ///
   /// - parameter completion: A completion closure that will be run when the computations are complete.
-  public func sanitize(completion: Completion = nil) {
+  public func updateHeightAndIndexes(completion: Completion = nil) {
     updateHeight { [weak self] in
       self?.refreshIndexes()
       completion?()


### PR DESCRIPTION
Adds missing layoutSubviews calls before calling completion.
It also makes sure that layoutSubviews is called before completion at all times.

Components will no longer cache automatically, it adds more flexibility
if you add this yourself when you add your implementation. If it always
does it automatically, you could end up caching twice or more which
would result in unnecessary and unwanted computation.

To reduce code duplication, the standard methods are no implemented in
a unified method called `finishComponentOperation`.

The word `sanitize` was a bit unclear what the method actually did. It
is now renamed to `updateHeightAndIndexes`, which is exactly what it
does.

This PR also clears up some `updateHeight` method calls that
occurred twice or more.