### PR TITLE
Refactor SpotsControllerManager

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -256,7 +256,7 @@ public class ComponentManager {
   /// - parameter animation:  The animation that should be used (only works for Listable objects)
   /// - parameter completion: A completion closure that is performed when all mutations are performed
   public func reload(indexes: [Int]? = nil, component: Component, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    Dispatch.interactive {
+    Dispatch.main {
       component.refreshIndexes()
       Dispatch.main { [weak self] in
         if let indexes = indexes {
@@ -306,12 +306,12 @@ public class ComponentManager {
 
       if changes.updates.isEmpty {
         strongSelf.process(changes.updatedChildren, component: component, withAnimation: animation) {
-          strongSelf.finishComponentOperation(component, updateHeightAndIndexes: false, completion: completion)
+          strongSelf.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
         }
       } else {
         strongSelf.process(changes.updates, component: component, withAnimation: animation) {
           strongSelf.process(changes.updatedChildren, component: component, withAnimation: animation) {
-            strongSelf.finishComponentOperation(component, updateHeightAndIndexes: false, completion: completion)
+            strongSelf.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
           }
         }
       }

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -763,9 +763,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func delete(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.delete(indexes,
-                                                     withAnimation: animation,
-                                                     completion: completion)
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.delete(indexes,
+                       withAnimation: animation,
+                       completion: completion)
+    }
   }
 
   private func resolveComponent(atIndex componentIndex: Int, controller: SpotsController, completion: Completion, closure: (Component) -> Void) {

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -634,9 +634,7 @@ public class SpotsControllerManager {
    */
   public func append(_ item: Item, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.append(item,
-                       withAnimation: animation,
-                       completion: completion)
+      component.append(item, withAnimation: animation, completion: completion)
     }
   }
 
@@ -649,9 +647,7 @@ public class SpotsControllerManager {
    */
   public func append(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.append(items,
-                        withAnimation: animation,
-                        completion: completion)
+      component.append(items, withAnimation: animation, completion: completion)
     }
   }
 
@@ -664,9 +660,7 @@ public class SpotsControllerManager {
    */
   public func prepend(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.prepend(items,
-               withAnimation: animation,
-               completion: completion)
+      component.prepend(items, withAnimation: animation, completion: completion)
     }
   }
 
@@ -680,10 +674,7 @@ public class SpotsControllerManager {
    */
   public func insert(_ item: Item, index: Int = 0, componentIndex: Int, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.insert(item,
-                       index: index,
-                       withAnimation: animation,
-                       completion: completion)
+      component.insert(item, index: index, withAnimation: animation, completion: completion)
     }
   }
 
@@ -734,9 +725,7 @@ public class SpotsControllerManager {
    */
   public func update(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.reload(indexes,
-                       withAnimation: animation,
-                       completion: completion)
+      component.reload(indexes, withAnimation: animation, completion: completion)
     }
   }
 
@@ -749,9 +738,7 @@ public class SpotsControllerManager {
    */
   public func delete(_ index: Int, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.delete(index,
-                       withAnimation: animation,
-                       completion: completion)
+      component.delete(index, withAnimation: animation, completion: completion)
     }
   }
 
@@ -764,9 +751,7 @@ public class SpotsControllerManager {
    */
   public func delete(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
     resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
-      component.delete(indexes,
-                       withAnimation: animation,
-                       completion: completion)
+      component.delete(indexes, withAnimation: animation, completion: completion)
     }
   }
 

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -76,7 +76,6 @@ public class SpotsControllerManager {
       }
 
       guard compare(newComponentModels, oldComponentModels) else {
-        controller.cache()
         Dispatch.main {
           controller.scrollView.layoutViews()
           SpotsController.componentsDidReloadComponentModels?(controller)
@@ -90,7 +89,6 @@ public class SpotsControllerManager {
       strongSelf.process(changes: changes, controller: controller, components: newComponentModels, withAnimation: animation) {
         Dispatch.main {
           controller.scrollView.layoutSubviews()
-          controller.cache()
           SpotsController.componentsDidReloadComponentModels?(controller)
           completion?()
         }
@@ -215,26 +213,26 @@ public class SpotsControllerManager {
     }
 
     if newItems.count == component.model.items.count {
-      reload(with: changes, controller: controller, in: component, newItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates(controller: controller)
-          completion()
-        }
-      }
+      reload(with: changes,
+             controller: controller,
+             in: component,
+             newItems: newItems,
+             animation: animation,
+             completion: completion)
     } else if newItems.count < component.model.items.count {
-      reload(with: changes, controller: controller, in: component, lessItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates(controller: controller)
-          completion()
-        }
-      }
+      reload(with: changes,
+             controller: controller,
+             in: component,
+             lessItems: newItems,
+             animation: animation,
+             completion: completion)
     } else if newItems.count > component.model.items.count {
-      reload(with: changes, controller: controller, in: component, moreItems: newItems, animation: animation) { [weak self] in
-        if let strongSelf = self, let completion = completion {
-          strongSelf.completeUpdates(controller: controller)
-          completion()
-        }
-      }
+      reload(with: changes,
+             controller: controller,
+             in: component,
+             moreItems: newItems,
+             animation: animation,
+             completion: completion)
     }
 
     return false
@@ -257,8 +255,6 @@ public class SpotsControllerManager {
     var offsets = [CGPoint]()
 
     component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
-
       for item in newItems {
         let results = component.compositeComponents.filter({ $0.itemIndex == item.index })
         for compositeComponent in results {
@@ -267,11 +263,7 @@ public class SpotsControllerManager {
       }
 
       component.model.items = newItems
-    }) { [weak self] in
-      guard let strongSelf = self else {
-        return
-      }
-
+    }) {
       for (index, item) in newItems.enumerated() {
         guard index < controller.components.count else {
           break
@@ -288,7 +280,7 @@ public class SpotsControllerManager {
         }
       }
 
-      strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
+      completion?()
     }
   }
 
@@ -307,11 +299,10 @@ public class SpotsControllerManager {
                       animation: Animation,
                       completion: (() -> Void)? = nil) {
     component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
       component.model.items = newItems
-    }) { [weak self] in
-      guard let strongSelf = self, !newItems.isEmpty else {
-        self?.finishReloading(component: component, controller: controller, withCompletion: completion)
+    }) {
+      guard !newItems.isEmpty else {
+        completion?()
         return
       }
 
@@ -334,17 +325,13 @@ public class SpotsControllerManager {
         }
 
         if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-          component.beforeUpdate()
-          component.reload(nil, withAnimation: animation) {
-            strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
-          }
+          component.reload(nil, withAnimation: animation, completion: completion)
         } else {
-          component.beforeUpdate()
           component.update(item, index: index, withAnimation: animation) {
             guard index == executeClosure else {
               return
             }
-            strongSelf.finishReloading(component: component, controller: controller, withCompletion: completion)
+            completion?()
           }
         }
       }
@@ -366,25 +353,16 @@ public class SpotsControllerManager {
                       animation: Animation,
                       completion: (() -> Void)? = nil) {
     component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-      component.beforeUpdate()
       component.model.items = newItems
     }) {
       if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-        component.reload(nil, withAnimation: animation) { [weak self] in
-          self?.finishReloading(component: component, controller: controller, withCompletion: completion)
-        }
+        component.reload(nil,
+                         withAnimation: animation,
+                         completion: completion)
       } else {
-        component.updateHeight { [weak self] in
-          self?.finishReloading(component: component, controller: controller, withCompletion: completion)
-        }
+        component.updateHeight(completion)
       }
     }
-  }
-
-  private func finishReloading(component: Component, controller: SpotsController, withCompletion completion: Completion = nil) {
-    component.afterUpdate()
-    completion?()
-    controller.scrollView.layoutSubviews()
   }
 
   /// Process a collection of component model diffs.
@@ -448,7 +426,6 @@ public class SpotsControllerManager {
       }
 
       if runCompletion {
-        strongSelf.completeUpdates(controller: controller)
         finalCompletion?()
       }
     }
@@ -477,7 +454,6 @@ public class SpotsControllerManager {
       let oldComponentModels = controller.components.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
-        controller.cache()
         SpotsController.componentsDidReloadComponentModels?(controller)
         completion?()
         return
@@ -498,7 +474,6 @@ public class SpotsControllerManager {
 
       strongSelf.cleanUpComponentView(controller: controller)
       controller.setupComponents(animated: animated)
-      controller.cache()
 
       let newComposites = controller.components.flatMap { $0.compositeComponents }
 
@@ -535,7 +510,6 @@ public class SpotsControllerManager {
       }
 
       controller.components = Parser.parse(models)
-      controller.cache()
 
       if controller.scrollView.superview == nil {
         controller.view.addSubview(controller.scrollView)
@@ -570,7 +544,6 @@ public class SpotsControllerManager {
       }
 
       controller.components = Parser.parse(json)
-      controller.cache()
 
       if controller.scrollView.superview == nil {
         controller.view.addSubview(controller.scrollView)
@@ -600,12 +573,12 @@ public class SpotsControllerManager {
    */
   public func update(componentAtIndex index: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ component: Component) -> Void) {
     guard let component = controller.component(at: index) else {
+      assertionFailure("Could not resolve component at index: \(index).")
       completion?()
       return
     }
 
     closure(component)
-    component.refreshIndexes()
     component.prepareItems()
 
     Dispatch.main {
@@ -618,13 +591,7 @@ public class SpotsControllerManager {
         }
       #endif
 
-      component.reload(nil, withAnimation: animation) {
-        component.updateHeight {
-          component.afterUpdate()
-          completion?()
-          component.view.layoutIfNeeded()
-        }
-      }
+      component.reload(nil, withAnimation: animation, completion: completion)
     }
   }
 
@@ -638,7 +605,14 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that is run when the update is completed
    */
   public func updateIfNeeded(componentAtIndex index: Int = 0, controller: SpotsController, items: [Item], withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    guard let component = controller.component(at: index), !(component.model.items == items) else {
+    guard let component = controller.component(at: index) else {
+      assertionFailure("Could not resolve component at index: \(index).")
+      controller.scrollView.layoutSubviews()
+      completion?()
+      return
+    }
+
+    guard !(component.model.items == items) else {
       controller.scrollView.layoutSubviews()
       completion?()
       return
@@ -659,11 +633,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func append(_ item: Item, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.append(item, withAnimation: animation) {
-      controller.scrollView.layoutSubviews()
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.append(item,
+                       withAnimation: animation,
+                       completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /**
@@ -674,11 +648,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func append(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.append(items, withAnimation: animation) {
-      controller.scrollView.layoutSubviews()
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.append(items,
+                        withAnimation: animation,
+                        completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /**
@@ -689,11 +663,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func prepend(_ items: [Item], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.prepend(items, withAnimation: animation) {
-      controller.scrollView.layoutSubviews()
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.prepend(items,
+               withAnimation: animation,
+               completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /**
@@ -705,11 +679,12 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func insert(_ item: Item, index: Int = 0, componentIndex: Int, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.insert(item, index: index, withAnimation: animation) {
-      controller.scrollView.layoutSubviews()
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.insert(item,
+                       index: index,
+                       withAnimation: animation,
+                       completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /// Update item at index inside a specific Component object
@@ -721,10 +696,15 @@ public class SpotsControllerManager {
   /// - parameter animation:  A Animation struct that determines which animation that should be used to perform the update.
   /// - parameter completion: A completion closure that will run after the component has performed updates internally.
   public func update(_ item: Item, index: Int = 0, componentIndex: Int, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    guard let oldItem = controller.component(at: componentIndex)?.item(at: index), item != oldItem
+    guard let oldItem = controller.component(at: componentIndex)?.item(at: index)
       else {
         completion?()
         return
+    }
+
+    guard item != oldItem else {
+      completion?()
+      return
     }
 
     #if os(iOS)
@@ -733,14 +713,15 @@ public class SpotsControllerManager {
       }
     #endif
 
-    controller.component(at: componentIndex)?.update(item, index: index, withAnimation: animation) {
-      controller.scrollView.layoutSubviews()
-      completion?()
-      #if os(iOS)
-        if animation == .none {
-          CATransaction.commit()
-        }
-      #endif
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.update(item, index: index, withAnimation: animation) {
+        completion?()
+        #if os(iOS)
+          if animation == .none {
+            CATransaction.commit()
+          }
+        #endif
+      }
     }
   }
 
@@ -752,10 +733,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func update(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.reload(indexes, withAnimation: animation) {
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.reload(indexes,
+                       withAnimation: animation,
+                       completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /**
@@ -766,10 +748,11 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func delete(_ index: Int, componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.delete(index, withAnimation: animation) {
-      completion?()
+    resolveComponent(atIndex: componentIndex, controller: controller, completion: completion) { component in
+      component.delete(index,
+                       withAnimation: animation,
+                       completion: completion)
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
   }
 
   /**
@@ -780,31 +763,27 @@ public class SpotsControllerManager {
    - parameter completion: A completion closure that will run after the component has performed updates internally
    */
   public func delete(_ indexes: [Int], componentIndex: Int = 0, controller: SpotsController, withAnimation animation: Animation = .none, completion: Completion = nil) {
-    controller.component(at: componentIndex)?.delete(indexes, withAnimation: animation) {
+    controller.component(at: componentIndex)?.delete(indexes,
+                                                     withAnimation: animation,
+                                                     completion: completion)
+  }
+
+  private func resolveComponent(atIndex componentIndex: Int, controller: SpotsController, completion: Completion, closure: (Component) -> Void) {
+    guard let component = controller.component(at: componentIndex) else {
+      assertionFailure("Could not resolve component at index: \(componentIndex).")
       completion?()
+      return
     }
-    controller.component(at: componentIndex)?.refreshIndexes()
+
+    closure(component)
   }
 
   /// Remove all views from components view.
   ///
   /// - Parameter controller: A SpotsController instance.
-  fileprivate func cleanUpComponentView(controller: SpotsController) {
+  private func cleanUpComponentView(controller: SpotsController) {
     controller.scrollView.componentsView.subviews.forEach {
       $0.removeFromSuperview()
     }
-  }
-
-  /// Complete updates for controller.
-  ///
-  /// - Parameter controller: A SpotsController instance.
-  fileprivate func completeUpdates(controller: SpotsController) {
-    for component in controller.components {
-      component.afterUpdate()
-    }
-
-    #if !os(OSX)
-      controller.scrollView.layoutSubviews()
-    #endif
   }
 }

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -356,9 +356,7 @@ public class SpotsControllerManager {
       component.model.items = newItems
     }) {
       if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-        component.reload(nil,
-                         withAnimation: animation,
-                         completion: completion)
+        component.reload(nil, withAnimation: animation, completion: completion)
       } else {
         component.updateHeight(completion)
       }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -272,10 +272,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
   }
 
-  /// This method is invoked before mutations are performed on a component.
-  /// Not used at the moment.
-  func beforeUpdate() {}
-
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
     if compositeComponents.isEmpty {

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -370,10 +370,6 @@ import Tailor
     }
   }
 
-  /// This method is invoked before mutations are performed on a component.
-  /// Not used at the moment.
-  func beforeUpdate() {}
-
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
     if let superview = view.superview {


### PR DESCRIPTION
Calling cache in SpotsControllerManager has been removed, this will now
be handled by the app implementation. Same principals as for
ComponentManager, which is that if you want to do any additional
preprocessing of the information before you cache it to disk, you are
free to do so.

This also reduces the amount of component operation computation as
ComponentManager has that concern. SpotsControllerManager now simply
relays the instructions and relies on ComponentManager to call the
appropriate methods that are needed to complete the operation.

Some overhead methods are removed, such as `completeUpdates` and
`finishReloading`.

Small improvements are made to some of the guard statements to improve
debug-ablility.

SpotsControllerManager will now throw assertFailures if the component
cannot be resolved. This is done with the `resolveComponent` method
that either returns the correct component or calls `assertFailure`.

ComponentManager has one change when it comes to which queue should be
used to perform updates in `reload`, it now uses `main` instead of
`interactive`. Those methods now update height and indexes and if you
don't do that in the main queue the application could become unstable
and crash.