### PR TITLE
Improve iOS implementation when using reload with components

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -358,7 +358,7 @@ public class SpotsControllerManager {
       if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
         component.reload(nil, withAnimation: animation, completion: completion)
       } else {
-        component.updateHeight(completion)
+        completion?()
       }
     }
   }

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -441,8 +441,7 @@ public extension Component {
   /// - parameter completion: A completion closure that will be run when the computations are complete.
   public func updateHeightAndIndexes(completion: Completion = nil) {
     updateHeight { [weak self] in
-      self?.refreshIndexes()
-      completion?()
+      self?.refreshIndexes(completion: completion)
     }
   }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -274,9 +274,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
   /// This method is invoked after mutations has been performed on a component.
   public func afterUpdate() {
-    if compositeComponents.isEmpty {
-      layout(with: view.frame.size)
-    } else {
+    if !compositeComponents.isEmpty {
       setup(with: view.frame.size)
     }
   }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -92,7 +92,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   #if os(iOS)
   /// A UIRefresh control.
   /// Note: Only available on iOS.
-  public lazy private(set) var refreshControl = UIRefreshControl()
+  public lazy private(set) var refreshControl: UIRefreshControl = SpotsRefreshControl()
   #endif
 
   // MARK: Initializer

--- a/Sources/iOS/Classes/SpotsRefreshControl.swift
+++ b/Sources/iOS/Classes/SpotsRefreshControl.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+/// A custom refresh control that makes sure that endRefreshing is only called
+/// when it is needed.
+class SpotsRefreshControl: UIRefreshControl {
+
+  // Must be explicitly called when the refreshing has completed
+  override func endRefreshing() {
+    // Only call endRefreshing if the refresh control is actually refreshing, otherwise
+    // scrolling will be interrupted.
+    if isRefreshing {
+      super.endRefreshing()
+    }
+  }
+}

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		BD165A371E6EAAA60023AF82 /* TestSpot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A361E6EAAA60023AF82 /* TestSpot.swift */; };
 		BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A381E6EAD750023AF82 /* HelperViews.swift */; };
 		BD165A3B1E6EAF310023AF82 /* GridableLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */; };
+		BD1D17251EA89A36000DBCF8 /* SpotsRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1D17241EA89A36000DBCF8 /* SpotsRefreshControl.swift */; };
 		BD1F9E0F1EA39DFD009C018B /* SpotsController+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F9E0E1EA39DFD009C018B /* SpotsController+iOS+Extensions.swift */; };
 		BD1F9E111EA39ED9009C018B /* Mappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F9E101EA39ED9009C018B /* Mappable+Extensions.swift */; };
 		BD1F9E121EA39ED9009C018B /* Mappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F9E101EA39ED9009C018B /* Mappable+Extensions.swift */; };
@@ -404,6 +405,7 @@
 		BD165A361E6EAAA60023AF82 /* TestSpot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpot.swift; sourceTree = "<group>"; };
 		BD165A381E6EAD750023AF82 /* HelperViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelperViews.swift; sourceTree = "<group>"; };
 		BD165A3A1E6EAF310023AF82 /* GridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridableLayout.swift; sourceTree = "<group>"; };
+		BD1D17241EA89A36000DBCF8 /* SpotsRefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsRefreshControl.swift; sourceTree = "<group>"; };
 		BD1F9E0E1EA39DFD009C018B /* SpotsController+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BD1F9E101EA39ED9009C018B /* Mappable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Mappable+Extensions.swift"; sourceTree = "<group>"; };
 		BD1F9E141EA39F02009C018B /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				BDAD84921E3E701C008289AE /* SpotsContentView.swift */,
 				BDAD84841E3E701B008289AE /* SpotsController.swift */,
 				BDAD84931E3E701C008289AE /* SpotsScrollView.swift */,
+				BD1D17241EA89A36000DBCF8 /* SpotsRefreshControl.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1646,6 +1649,7 @@
 				BD1F9E111EA39ED9009C018B /* Mappable+Extensions.swift in Sources */,
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */,
+				BD1D17251EA89A36000DBCF8 /* SpotsRefreshControl.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
 				BD24030C1E4B981A005BAA19 /* Component.swift in Sources */,
 				BDAD85A21E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,


### PR DESCRIPTION
afterUpdate will no longer call layout as that could cause the
component to blink.

SpotsController on iOS now uses a custom implementation of
UIRefreshControl called SpotsRefreshControl. It is a tiny subclass of
UIRefreshControl that overrides `endRefreshing()`. We do this to check
that the refresh control is refreshing before calling
`super.endRefreshing()`. If we don't do this, it could interrupted the
scrolling as `endRefreshing` manipulates the scroll view it belongs to.

SpotsControllerManager.reload(with changes ... moreItems) will not call
completion using component.updateHeight, this is already covered by
component internally.

Component.updateHeightAndIndexes will now call refreshIndexes with
completion as an argument.