### PR TITLE
Fix page indicator position

### DIFF
--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -4,12 +4,12 @@ import Tailor
 extension Component {
 
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let layout = collectionView.collectionViewLayout as? GridableLayout else {
+    guard let collectionViewLayout = collectionView.collectionViewLayout as? GridableLayout else {
       return
     }
 
     collectionView.isScrollEnabled = true
-    layout.scrollDirection = .horizontal
+    collectionViewLayout.scrollDirection = .horizontal
     #if os(iOS)
       collectionView.isPagingEnabled = model.interaction.paginate == .page
     #endif
@@ -27,27 +27,16 @@ extension Component {
       collectionView.frame.size.height = newCollectionViewHeight
 
       if collectionView.frame.size.height > 0 {
-        collectionView.frame.size.height += layout.sectionInset.top + layout.sectionInset.bottom
+        collectionView.frame.size.height += collectionViewLayout.sectionInset.top + collectionViewLayout.sectionInset.bottom
       }
     }
 
     configureCollectionViewHeader(collectionView, with: size)
 
-    collectionView.frame.size.height += layout.headerReferenceSize.height
+    collectionView.frame.size.height += collectionViewLayout.headerReferenceSize.height
 
     if let componentLayout = model.layout {
       collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
-    }
-
-    if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement {
-      switch pageIndicatorPlacement {
-      case .below:
-        layout.sectionInset.bottom += pageControl.frame.height
-        pageControl.frame.origin.y = collectionView.frame.height
-      case .overlay:
-        let verticalAdjustment = CGFloat(2)
-        pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
-      }
     }
   }
 
@@ -66,5 +55,22 @@ extension Component {
     collectionViewLayout.invalidateLayout()
     collectionView.frame.size.width = size.width
     collectionView.frame.size.height = computedHeight
+
+    configurePageControl(collectionView: collectionView, collectionViewLayout: collectionViewLayout)
+  }
+
+  private func configurePageControl(collectionView: UICollectionView, collectionViewLayout: UICollectionViewFlowLayout) {
+    guard let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement else {
+      return
+    }
+    
+    switch pageIndicatorPlacement {
+    case .below:
+      collectionViewLayout.sectionInset.bottom += pageControl.frame.height
+      pageControl.frame.origin.y = collectionView.frame.height
+    case .overlay:
+      let verticalAdjustment = CGFloat(2)
+      pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height - verticalAdjustment
+    }
   }
 }


### PR DESCRIPTION
We had an issue where the page indicator did not appear on screen, this
happened because it tried to configure the page control before the
collection had gotten its size. Now the implementation has been moved
into a separate method. It is now called in the layout method which
would mean that even if the collection view would dynamically change
size because a new payload has larger items, the page control would
update with its new position.

It also renames some of the optional assignment variable to  be more
consistent with the rest of the implementations. Layout is not a good
word for the collection view layout as it might be mixed up with the
`Layout` struct.