### PR TITLE
Improve overall performance and collection view layout method

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -114,6 +114,7 @@ public extension Component {
   /// Prepare items in component
   func prepareItems(recreateComposites: Bool = true) {
     model.items = prepare(items: model.items, recreateComposites: recreateComposites)
+    Configuration.views.purge()
   }
 
   func prepare(items: [Item], recreateComposites: Bool) -> [Item] {

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -138,7 +138,7 @@ public extension Component {
         item.size.width = spanWidth
       }
 
-      if let configuredItem = configure(item: item, at: index, usesViewSize: true, clean: recreateComposites) {
+      if let configuredItem = configure(item: item, at: index, usesViewSize: true, recreateComposites: recreateComposites) {
         preparedItems[index].index = index
         preparedItems[index] = configuredItem
       }
@@ -214,9 +214,9 @@ public extension Component {
   ///
   /// - parameter index:        The index of the view model
   /// - parameter usesViewSize: A boolean value to determine if the view uses the views height
-  public func configureItem(at index: Int, usesViewSize: Bool = false, clean: Bool = true) {
+  public func configureItem(at index: Int, usesViewSize: Bool = false, recreateComposites: Bool = true) {
     guard let item = item(at: index),
-      let configuredItem = configure(item: item, at: index, usesViewSize: usesViewSize, clean: clean)
+      let configuredItem = configure(item: item, at: index, usesViewSize: usesViewSize, recreateComposites: recreateComposites)
       else {
         return
     }
@@ -224,7 +224,7 @@ public extension Component {
     model.items[index] = configuredItem
   }
 
-  func configure(item: Item, at index: Int, usesViewSize: Bool = false, clean: Bool) -> Item? {
+  func configure(item: Item, at index: Int, usesViewSize: Bool = false, recreateComposites: Bool) -> Item? {
     var item = item
     item.index = index
 
@@ -238,7 +238,7 @@ public extension Component {
 
       let view: View?
 
-      if let (_, resolvedView) = Configuration.views.make(kind, parentFrame: self.view.bounds) {
+      if let resolvedView = Configuration.views.make(kind, parentFrame: self.view.bounds, useCache: true)?.view {
         view = resolvedView
       } else {
         return nil
@@ -249,7 +249,7 @@ public extension Component {
         prepare(view: view)
       }
 
-      prepare(kind: kind, view: view as Any, item: &item, clean: clean)
+      prepare(kind: kind, view: view as Any, item: &item, recreateComposites: recreateComposites)
     #else
       if fullWidth == 0.0 {
         fullWidth = view.superview?.frame.size.width ?? view.frame.size.width
@@ -263,10 +263,10 @@ public extension Component {
           wrappable = GridWrapper()
         }
 
-        prepare(kind: kind, view: wrappable as Any, item: &item, clean: clean)
+        prepare(kind: kind, view: wrappable as Any, item: &item, recreateComposites: recreateComposites)
       } else {
-        if let resolvedView = Configuration.views.make(kind, parentFrame: self.view.frame)?.view {
-          prepare(kind: kind, view: resolvedView as Any, item: &item, clean: clean)
+        if let resolvedView = Configuration.views.make(kind, parentFrame: self.view.frame, useCache: true)?.view {
+          prepare(kind: kind, view: resolvedView as Any, item: &item, recreateComposites: recreateComposites)
         } else {
           return nil
         }
@@ -276,9 +276,9 @@ public extension Component {
     return item
   }
 
-  func prepare(kind: String, view: Any, item: inout Item, clean: Bool) {
+  func prepare(kind: String, view: Any, item: inout Item, recreateComposites: Bool) {
     if let view = view as? Wrappable, kind.contains(CompositeComponent.identifier) {
-      prepare(wrappable: view, item: &item, clean: clean)
+      prepare(wrappable: view, item: &item, recreateComposites: recreateComposites)
     } else if let view = view as? ItemConfigurable {
       view.configure(&item)
       setFallbackViewSize(to: &item, with: view)
@@ -312,10 +312,10 @@ public extension Component {
   /// - parameter usesViewSize:      A boolean value to determine if the view uses the views height
   ///
   /// - returns: The height for the item based of the composable components
-  func prepare(wrappable: Wrappable, item: inout Item, clean: Bool) {
+  func prepare(wrappable: Wrappable, item: inout Item, recreateComposites: Bool) {
     var height: CGFloat = 0.0
 
-    if clean {
+    if recreateComposites {
       compositeComponents.filter({ $0.itemIndex == item.index }).forEach {
         $0.component.view.removeFromSuperview()
 
@@ -348,7 +348,7 @@ public extension Component {
 
       height += compositeSpot.component.computedHeight
 
-      if clean {
+      if recreateComposites {
         compositeComponents.append(compositeSpot)
       }
     }

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -16,7 +16,7 @@ public struct Configuration {
 
   public static var defaultComponentKind: ComponentKind = .grid
   public static var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
-  public static var views: Registry = .init(useCache: false)
+  public static var views: Registry = .init()
 
   /// Register a nib file with identifier on the component.
   ///

--- a/Sources/iOS/Extensions/Component+iOS+Grid.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Grid.swift
@@ -9,6 +9,12 @@ extension Component {
 
     collectionViewLayout.prepare()
     collectionViewLayout.invalidateLayout()
-    collectionView.frame.size = collectionViewLayout.collectionViewContentSize
+
+    if collectionViewLayout.collectionViewContentSize.height > UIScreen.main.bounds.height {
+      collectionView.frame.size.width = collectionViewLayout.collectionViewContentSize.width
+      collectionView.frame.size.height = UIScreen.main.bounds.size.height
+    } else {
+      collectionView.frame.size = collectionViewLayout.collectionViewContentSize
+    }
   }
 }

--- a/SpotsTests/Shared/TestSpotsController.swift
+++ b/SpotsTests/Shared/TestSpotsController.swift
@@ -6,6 +6,10 @@ class ComponentDelegateMock: ComponentDelegate {}
 
 class SpotsControllerTests: XCTestCase {
 
+  override func setUp() {
+    Configuration.views.purge()
+  }
+
   func testSpotAtIndex() {
     let model = ComponentModel(layout: Layout(span: 1.0))
     let listComponent = Component(model: model)


### PR DESCRIPTION
Enables `useCache` for the item prepare method in Registry. Now it will use the cache when preparing items but not when you make a view that should be used inside a reusable view, there you always get a new instance when calling `make`.

Renames the remaining `clean` labels to `recreateComposites`.

Vertical collection views has gained an incredible speed bump as the layout method was previously flawed when using larger collections. The collection view frame was always equal to the content size which would mean that all the views would be configured at once. This could cause a UI freeze from 1 to 2 seconds when trying to render a collection that has more 1000+ items. Now we have a safe guard that the collection view can never exceed the screen size. That way it can only render what would fit on the screen. 

I made some benchmarks for the prepare items method:

| Environment | Number of items | Cache Status | Time  |
| ------------- |-------------|-------------| -----|
|Simulator | 1000 | ⛔️ |   0.35312 
|Simulator | 1000 | ✅ |    0.09667
|iPhone 6S | 1000 | ⛔️ |  0.80374
|iPhone 6S | 1000 | ✅ |   0.16130

*The benchmarks were made in a production app, don't read them as pure science
They are there to illustrating that the change has a positive impact than to be being scientifically accurate.*