### PR TITLE
Add A protocol extension on RawRepresentable

### DIFF
--- a/Sources/Shared/Protocols/StringConvertible.swift
+++ b/Sources/Shared/Protocols/StringConvertible.swift
@@ -19,3 +19,18 @@ extension String: StringConvertible {
     return self
   }
 }
+
+/**
+ A protocol extension on RawRepresentable to make it conform to StringConvertible
+ */
+extension StringConvertible where Self: RawRepresentable, Self.RawValue == String {
+
+  /**
+   The required implementation for RawRepresentable to make it conform to StringConvertible
+
+   - returns: rawValue as string
+   */
+  public var string: String {
+    return rawValue
+  }
+}


### PR DESCRIPTION
Add a protocol extension on `RawRepresentable` to make it conform to `StringConvertible`. I think we write this code in projects anyway.