### PR TITLE
Set selection style to .none in ListWrapper on iOS

### DIFF
--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -9,6 +9,7 @@ public class ListWrapper: UITableViewCell, Wrappable, Cell {
 
     backgroundColor = .clear
     selectedBackgroundView = UIView()
+    selectionStyle = .none
   }
 
   required public init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
View state is handled by the ViewState protocol, having it enabled on
the wrapper will cause a conflict so now it is disabled on
`ListWrapper` on iOS.