### PR TITLE
Call layoutSubviews in SpotsControllerManager.update

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -572,6 +572,7 @@ public class SpotsControllerManager {
   public func update(componentAtIndex index: Int = 0, controller: SpotsController, withAnimation animation: Animation = .automatic, withCompletion completion: Completion = nil, _ closure: (_ component: Component) -> Void) {
     guard let component = controller.component(at: index) else {
       assertionFailure("Could not resolve component at index: \(index).")
+      controller.scrollView.layoutSubviews()
       completion?()
       return
     }
@@ -589,7 +590,10 @@ public class SpotsControllerManager {
         }
       #endif
 
-      component.reload(nil, withAnimation: animation, completion: completion)
+      component.reload(nil, withAnimation: animation) {
+        controller.scrollView.layoutSubviews()
+        completion?()
+      }
     }
   }
 
@@ -617,6 +621,7 @@ public class SpotsControllerManager {
     }
 
     update(componentAtIndex: index, controller: controller, withAnimation: animation, withCompletion: {
+      controller.scrollView.layoutSubviews()
       completion?()
     }, { component in
       component.model.items = items


### PR DESCRIPTION
As a convention we always call `layoutSubviews` on the controller
scrollview to make sure that the views are always laid out correctly.
We were missing some of them in the update method so now they are added
before calling the completion closure.