### PR TITLE
Remove setting layer to Component.collectionView

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -267,7 +267,6 @@ import Tailor
     collectionView.isSelectable = true
     collectionView.allowsMultipleSelection = false
     collectionView.allowsEmptySelection = true
-    collectionView.layer = CALayer()
     collectionView.wantsLayer = true
 
     let backgroundView = NSView()


### PR DESCRIPTION
Remove setting layer to collection view, this is handled by Cocoa when
setting `wantsLayer` to true which is located on the next line.