### PR TITLE
Sync contentSize between collection view and collection view layout

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -356,8 +356,12 @@ public class SpotsControllerManager {
       component.model.items = newItems
     }) {
       if !component.model.items.filter({ !$0.children.isEmpty }).isEmpty {
-        component.reload(nil, withAnimation: animation, completion: completion)
+        component.reload(nil, withAnimation: animation) {
+          controller.scrollView.layoutSubviews()
+          completion?()
+        }
       } else {
+        controller.scrollView.layoutSubviews()
         completion?()
       }
     }
@@ -424,6 +428,7 @@ public class SpotsControllerManager {
       }
 
       if runCompletion {
+        controller.scrollView.layoutSubviews()
         finalCompletion?()
       }
     }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -110,6 +110,7 @@ extension UICollectionView: UserInterface {
   public func endUpdates() {}
   public func reloadDataSource() {
     reloadData()
+    updateContentSize()
   }
 
   /// A convenience method for performing inserts on a UICollectionView
@@ -123,6 +124,7 @@ extension UICollectionView: UserInterface {
     performBatchUpdates({
       self.insertItems(at: indexPaths)
     }, completion: nil)
+    updateContentSize()
     completion?()
   }
 
@@ -143,6 +145,7 @@ extension UICollectionView: UserInterface {
     default:
       reloadItems(at: indexPaths)
       collectionViewLayout.finalizeCollectionViewUpdates()
+      updateContentSize()
       completion?()
     }
   }
@@ -161,6 +164,8 @@ extension UICollectionView: UserInterface {
       }
       strongSelf.deleteItems(at: indexPaths)
       }) { _ in }
+
+    updateContentSize()
     completion?()
   }
 
@@ -196,7 +201,17 @@ extension UICollectionView: UserInterface {
         self.deleteItems(at: deletions)
       }) { _ in }
     }
+
+    updateContentSize()
     completion?()
+  }
+
+  func updateContentSize() {
+    guard let collectionViewContentSize = (collectionViewLayout as? UICollectionViewFlowLayout)?.collectionViewContentSize else {
+      return
+    }
+
+    self.contentSize = collectionViewContentSize
   }
 
   ///  A convenience method for reloading a section


### PR DESCRIPTION
Adds `updateContentSize()` on UICollectionView+UserInterface. This method is called when performing mutation to keep the collection view and collection view layout's content size in sync.

It also adds some additional `layoutSubviews` calls in SpotsControllerManager to make the implementation more consistent.