### PR TITLE
Fix recursion when using composition and improve composite lookup

### DIFF
--- a/Sources/Shared/Classes/ViewPreparer.swift
+++ b/Sources/Shared/Classes/ViewPreparer.swift
@@ -20,8 +20,8 @@ class ViewPreparer {
   func prepareWrappableView(_ view: Wrappable, atIndex index: Int, in component: Component, parentFrame: CGRect = CGRect.zero) {
     let identifier = component.identifier(at: index)
 
-    if identifier.contains(CompositeComponent.identifier), index < component.compositeComponents.count {
-      let composite = component.compositeComponents[index]
+    if identifier.contains(CompositeComponent.identifier),
+      let composite = component.compositeComponents.filter({ $0.itemIndex == index }).first {
       view.configure(with: composite.component.view)
       component.model.items[index].size.height = composite.component.computedHeight
     } else if let (_, customView) = Configuration.views.make(identifier, parentFrame: parentFrame),

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -292,10 +292,6 @@ import Tailor
     } else {
       layoutVerticalCollectionView(collectionView, with: size)
     }
-
-    if !compositeComponents.isEmpty {
-      prepareItems(recreateComposites: false)
-    }
   }
 
   fileprivate func resizeCollectionView(_ collectionView: CollectionView, with size: CGSize, type: ComponentResize) {
@@ -379,10 +375,5 @@ import Tailor
                         height: view.frame.height)
       layout(with: size)
     }
-
-    guard !compositeComponents.isEmpty else {
-      return
-    }
-    reload()
   }
 }


### PR DESCRIPTION
The look up for composite components was flawed, it relied on the index of the composite which is not always the same as the item index. This is now refactored to filter on the `itemIndex`.

There was a bug in Component that made it recursive when using composition. It ended up calling reload() in a loop.