### PR TITLE
Improve layout implementation for collection views with header on macOS

### DIFF
--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -40,7 +40,15 @@ public class GridableLayout: FlowLayout {
       }
 
       contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
-      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)
+
+      let countOffset: Int
+      if let leftInset = component.model.layout?.inset.left, leftInset > 0.0 {
+        countOffset = 0
+      } else {
+        countOffset = 1
+      }
+
+      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - countOffset)
 
       contentSize.height = firstItem.size.height
       contentSize.height += component.headerHeight

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -40,7 +40,7 @@ public class GridableLayout: FlowLayout {
       }
 
       contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
-      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count)
+      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - 1)
 
       contentSize.height = firstItem.size.height
       contentSize.height += component.headerHeight

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -231,17 +231,11 @@ open class SpotsController: NSViewController, SpotsProtocol {
   open override func viewDidLayout() {
     super.viewDidLayout()
 
-    scrollView.layoutViews()
+    scrollView.layoutSubviews()
   }
 
   open func windowDidResize(_ notification: Notification) {
     for component in components {
-      // Skip live resizing on views that use composite components.
-      // This is a huge performance improvement, the composite views will get their
-      // new size when the window is finish resizing (see windowDidEndLiveResize)
-//      guard component.compositeComponents.isEmpty else {
-//        continue
-//      }
       component.didResize(size: view.frame.size, type: .live)
     }
     scrollView.layoutSubviews()

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -33,7 +33,6 @@ extension Component {
       $0.size.height > $1.size.height
     }).first?.size.height
 
-    collectionView.frame.origin.y = headerHeight
     collectionView.frame.size.width = collectionViewContentSize.width
     collectionView.frame.size.height = newCollectionViewHeight
 
@@ -43,8 +42,10 @@ extension Component {
     if let layout = model.layout {
       collectionView.frame.size.height += CGFloat(layout.inset.top + layout.inset.bottom)
       documentView.frame.size.height += CGFloat(layout.inset.top + layout.inset.bottom)
-      documentView.frame.size.width += CGFloat(layout.inset.left + layout.inset.right)
+      documentView.frame.size.width += CGFloat(layout.inset.right)
     }
+
+    collectionView.frame.size.height += headerHeight
 
     scrollView.frame.size.width = size.width
     scrollView.frame.size.height = documentView.frame.size.height

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -42,6 +42,11 @@ extension Component {
 
   func layoutHeaderFooterViews(_ size: CGSize) {
     headerView?.frame.size.width = size.width
+
+    if let layout = model.layout {
+      headerView?.frame.origin.y = CGFloat(layout.inset.top)
+    }
+
     footerView?.frame.size.width = size.width
     footerView?.frame.origin.y = scrollView.frame.height - footerHeight
   }


### PR DESCRIPTION
The content size of a horizontal collection view could end up getting
the wrong right margin because we didn't subtract on from count when
calculating the content size width. This is fixed now in the
GridableLayout.

This removes some commented code in SpotsController.windowDidResize.
Instead of calling layoutViews in SpotsController.viewDidLayout, we now
call layoutSubviews.

The position of the header view inside of carousels are now improved so
that you get the desired positions when using layout insets. Before it
was always stuck at the top which is not what you want if you add
insets to the top.