### PR TITLE
Fix collection view layout warnings on macOS

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -350,10 +350,24 @@ import Tailor
   /// - Parameter indexPath: The index path of the item that should be resolved.
   /// - Returns: A `CGSize` based of the `Item`'s width and height.
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    return CGSize(
-      width:  item(at: indexPath)?.size.width  ?? 0.0,
-      height: item(at: indexPath)?.size.height ?? 0.0
+    var size = CGSize(
+      width:  round(item(at: indexPath)?.size.width ?? 0.0),
+      height: round(item(at: indexPath)?.size.height ?? 0.0)
     )
+
+    // Make sure that the item width never exceeds the frame view width.
+    // If it does exceed the maximum width, the layout span will be used to reduce the size to make sure
+    // that all items fit on the same row.
+    if let layout = model.layout, layout.span > 0 {
+      let maxWidth = size.width * CGFloat(layout.span) + CGFloat(layout.inset.left) + CGFloat(layout.inset.right)
+
+      if maxWidth > view.frame.size.width {
+        size.width -= CGFloat(layout.span)
+        size.width = round(size.width)
+      }
+    }
+
+    return size
   }
 
   public func didResize(size: CGSize, type: ComponentResize) {

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -82,9 +82,8 @@ public class GridableLayout: FlowLayout {
     var offset: CGFloat = sectionInset.left
 
     for attribute in newAttributes {
-      guard let itemAttribute = attribute.copy() as? NSCollectionViewLayoutAttributes
-        else {
-          continue
+      guard let itemAttribute = attribute.copy() as? NSCollectionViewLayoutAttributes else {
+        continue
       }
 
       guard let indexPath = itemAttribute.indexPath else {

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -12,6 +12,10 @@ extension Component {
     scrollView.scrollingEnabled = (model.items.count > 1)
     scrollView.hasHorizontalScroller = (model.items.count > 1)
 
+    if let layout = model.layout {
+      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
+    }
+
     collectionView.frame.size.height = newCollectionViewHeight
   }
 

--- a/Sources/macOS/Extensions/Component+macOS+Grid.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Grid.swift
@@ -11,6 +11,7 @@ extension Component {
       return
     }
 
+    collectionView.frame.size.width = size.width
     collectionView.frame.origin.y = headerHeight
     collectionViewLayout.prepare()
     collectionViewLayout.invalidateLayout()
@@ -28,10 +29,13 @@ extension Component {
   }
 
   func resizeVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize, type: ComponentResize) {
+
+    collectionView.collectionViewLayout?.invalidateLayout()
+
     switch type {
     case .live:
-      layout(with: size)
       prepareItems(recreateComposites: false)
+      layout(with: size)
     case .end:
       layout(with: size)
     }

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -33,7 +33,6 @@ extension DataSource: NSCollectionViewDataSource {
     }
 
     let reuseIdentifier = component.identifier(at: indexPath.item)
-
     let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
 
     switch item {


### PR DESCRIPTION
When resizing a window that contains collection view based components,
the layouts were outputting warnings as the item could exceed the
maximum size allowed in the layout.

To fix silence and fix these warnings, we now call `invalidateLayout()`
in `resizeVerticalCollectionView`.
We also prepare the items before calling layout, this way the items get
their new size before the collection view receives a new size.

For vertical layouts, we now set size before calling prepare and
invalidateLayout in Component+macOS+Grid.

The referenced warnings are these:

```The behavior of the UICollectionViewFlowLayout is not defined because:
The item height must be less than the height of the UICollectionView
minus the section insets top and bottom values.

The behavior of the UICollectionViewFlowLayout is not defined because:
The item width must be less than the width of the UICollectionView
minus the section insets left and right values.```