### PR TITLE
Update and use new features on Tailor

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ReactiveX/RxSwift" "3.4.1"
+github "ReactiveX/RxSwift" "3.3.1"
 github "hyperoslo/Cache" "2.2.2"
 github "krzyzanowskim/CryptoSwift" "0.6.9"
 github "zenangst/Tailor" "2.2.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ReactiveX/RxSwift" "3.3.1"
+github "ReactiveX/RxSwift" "3.4.1"
 github "hyperoslo/Cache" "2.2.2"
-github "krzyzanowskim/CryptoSwift" "0.6.8"
-github "zenangst/Tailor" "2.0.2"
+github "krzyzanowskim/CryptoSwift" "0.6.9"
+github "zenangst/Tailor" "2.2.1"

--- a/Sources/Shared/Extensions/Dictionary+Extensions.swift
+++ b/Sources/Shared/Extensions/Dictionary+Extensions.swift
@@ -6,15 +6,6 @@ import Tailor
 public extension Dictionary where Key: ExpressibleByStringLiteral {
 
   /**
-   - parameter name: The name of the property that you want to map
-
-   - returns: A generic type if casting succeeds, otherwise it returns nil
-   */
-  func property<T>(_ name: Item.Key) -> T? {
-    return property(name.string)
-  }
-
-  /**
    Access the value associated with the given key.
 
    - parameter key: The key associated with the value you want to get

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -112,12 +112,12 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   ///
   /// - returns: An initialized component using JSON.
   public init(_ map: [String : Any]) {
-    self.identifier = map.property("identifier")
-    self.kind      <- map.enum("kind")
-    self.header    <- map.relation("header")
-    self.footer    <- map.relation("footer")
-    self.items     <- map.relations("items")
-    self.meta      <- map.property("meta")
+    self.identifier = map.string(Key.identifier.rawValue)
+    self.kind <- map.enum(Key.kind.rawValue)
+    self.header = map.relation(Key.header.rawValue)
+    self.footer = map.relation(Key.footer.rawValue)
+    self.items <- map.relations(Key.items.rawValue)
+    self.meta <- map.property(Key.meta.rawValue)
 
     if let layoutDictionary: [String : Any] = map.property(Layout.rootKey) {
       self.layout = Layout(layoutDictionary)

--- a/Sources/Shared/Structs/Inset.swift
+++ b/Sources/Shared/Structs/Inset.swift
@@ -56,20 +56,20 @@ public struct Inset: Mappable, Equatable {
   ///
   /// - Parameter map: A JSON dictionary that will be mapped into the content insets.
   public init(_ map: [String : Any]) {
-    self.top    <- map.property(Key.top.rawValue)
-    self.left   <- map.property(Key.left.rawValue)
-    self.bottom <- map.property(Key.bottom.rawValue)
-    self.right  <- map.property(Key.right.rawValue)
+    self.top    <- map.double(Key.top.rawValue)
+    self.left   <- map.double(Key.left.rawValue)
+    self.bottom <- map.double(Key.bottom.rawValue)
+    self.right  <- map.double(Key.right.rawValue)
   }
 
   /// Configure struct with a JSON dictionary.
   ///
   /// - Parameter JSON: A JSON dictionary that will be used to configure the content insets.
   public mutating func configure(withJSON JSON: [String : Any]) {
-    self.top    <- JSON.property(Key.top.rawValue)
-    self.left   <- JSON.property(Key.left.rawValue)
-    self.bottom <- JSON.property(Key.bottom.rawValue)
-    self.right  <- JSON.property(Key.right.rawValue)
+    self.top    <- JSON.double(Key.top.rawValue)
+    self.left   <- JSON.double(Key.left.rawValue)
+    self.bottom <- JSON.double(Key.bottom.rawValue)
+    self.right  <- JSON.double(Key.right.rawValue)
   }
 
   /// Check if to content insets are equal.

--- a/Sources/Shared/Structs/Item.swift
+++ b/Sources/Shared/Structs/Item.swift
@@ -111,15 +111,15 @@ public struct Item: Mappable, Indexable, DictionaryConvertible {
    - parameter map: A JSON dictionary
    */
   public init(_ map: [String : Any]) {
-    index    <- map.property(Key.index)
-    identifier = map.property(Key.identifier)
-    title    <- map.property(Key.title)
-    subtitle <- map.property(Key.subtitle)
-    text     <- map.property(Key.text)
-    image    <- map.property(Key.image)
-    kind     <- map.property(Key.kind)
-    action   = map.property(Key.action) ?? nil
-    meta     <- map.property(Key.meta)
+    index    <- map.int(Key.index.rawValue)
+    identifier <- map.int(Key.identifier.rawValue)
+    title    <- map.string(Key.title.rawValue)
+    subtitle <- map.string(Key.subtitle.rawValue)
+    text     <- map.string(Key.text.rawValue)
+    image    <- map.string(Key.image.rawValue)
+    kind     <- map.string(Key.kind.rawValue)
+    action   = map.string(Key.action.rawValue)
+    meta     <- map.property(Key.meta.rawValue)
     children = map[.children] as? [[String : Any]] ?? []
 
     if let relation = map[.relations] as? [String : [Item]] {

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -115,12 +115,12 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// - Parameter map: A JSON dictionary.
   public mutating func configure(withJSON map: [String : Any]) {
     self.inset = Inset(map.property(Inset.rootKey) ?? [:])
-    self.itemSpacing <- map.property(Key.itemSpacing.rawValue)
-    self.lineSpacing <- map.property(Key.lineSpacing.rawValue)
-    self.dynamicSpan <- map.property(Key.dynamicSpan.rawValue)
+    self.itemSpacing <- map.double(Key.itemSpacing.rawValue)
+    self.lineSpacing <- map.double(Key.lineSpacing.rawValue)
+    self.dynamicSpan <- map.boolean(Key.dynamicSpan.rawValue)
     self.dynamicHeight <- map.property(Key.dynamicHeight.rawValue)
-    self.span <- map.property(Key.span.rawValue)
-    self.pageIndicatorPlacement <- map.enum(Key.pageIndicator.rawValue)
+    self.span <- map.double(Key.span.rawValue)
+    self.pageIndicatorPlacement = map.enum(Key.pageIndicator.rawValue)
     self.headerMode <- map.enum(Key.headerMode.rawValue)
   }
 


### PR DESCRIPTION
Runs Carthage update to get the latest frameworks, mainly targeted at
the new version of Tailor.

It refactors how we map JSON to structs, it uses the type specific
methods introduced in Tailor 2.2.x to get a better fallback than what
we had before. So now if we pass a Float where we should have a Double,
Tailor will try and convert the Float into a Double before returning
the value.