### PR TITLE
⚠️ Refactor configure closure on Component to use self instead of just the view.

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -8,7 +8,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public static var layout: Layout = Layout(span: 0.0)
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
-  open static var configure: ((_ view: View) -> Void)?
+  open static var configure: ((Component) -> Void)?
   /// A focus delegate that returns which component is focused.
   weak public var focusDelegate: ComponentFocusDelegate?
   /// A component delegate, used for interaction and to pick up on mutation made to
@@ -151,8 +151,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///
   /// - Parameter size: A `CGSize` that is used to set the frame of the user interface.
   public func setup(with size: CGSize) {
-    Component.configure?(view)
-
     view.frame.size = size
 
     setupFooter(with: &model)
@@ -166,6 +164,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     layout(with: size)
     configurePageControl()
+    Component.configure?(self)
   }
 
   /// Configure the view frame with a given size.

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -10,7 +10,7 @@ import Tailor
   public static var layout: Layout = Layout(span: 0.0)
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
-  open static var configure: ((_ view: View) -> Void)?
+  open static var configure: ((Component) -> Void)?
   /// A focus delegate that returns which component is focused.
   weak public var focusDelegate: ComponentFocusDelegate?
   /// A component delegate, used for interaction and to pick up on mutation made to
@@ -221,16 +221,15 @@ import Tailor
     configureDataSourceAndDelegate()
 
     if let tableView = self.tableView {
-      Component.configure?(tableView)
       documentView.addSubview(tableView)
       setupTableView(tableView, with: size)
     } else if let collectionView = self.collectionView {
-      Component.configure?(collectionView)
       documentView.addSubview(collectionView)
       setupCollectionView(collectionView, with: size)
     }
 
     layout(with: size)
+    Component.configure?(self)
   }
 
   /// Configure the view frame with a given size.
@@ -277,7 +276,7 @@ import Tailor
     case .carousel:
       setupHorizontalCollectionView(collectionView, with: size)
     default:
-      setupVerticalCollectionView(collectionView, with: size)
+      break
     }
   }
 

--- a/Sources/macOS/Extensions/Component+macOS+Grid.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Grid.swift
@@ -2,10 +2,6 @@ import Cocoa
 
 extension Component {
 
-  func setupVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    Component.configure?(collectionView)
-  }
-
   func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     guard let collectionViewLayout = collectionView.collectionViewLayout else {
       return


### PR DESCRIPTION
⚠️ Breaking change ⚠️

In the static configuration closure for Component, we used to pass the
view of the component so that you could use that for styling. Now we
will pass the entire component so that you can pinpoint and identify a
specific component to apply the style that you want for that component.

The configuration closure is also moved to the end of the setup method.