### PR TITLE
Move item preparation methods into a new ItemManager class

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public class ComponentManager {
 
-  var itemManager: ItemManager = ItemManager()
+  let itemManager = ItemManager()
 
   /// Append item to collection with animation
   ///

--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public class ComponentManager {
 
+  var itemManager: ItemManager = ItemManager()
+
   /// Append item to collection with animation
   ///
   /// - parameter item: The view model that you want to append.
@@ -17,7 +19,7 @@ public class ComponentManager {
         component.userInterface?.reloadDataSource()
         self?.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
       } else {
-        component.configureItem(at: numberOfItems, usesViewSize: true)
+        self?.itemManager.configureItem(at: numberOfItems, component: component, usesViewSize: true)
         component.userInterface?.insert([numberOfItems], withAnimation: animation) {
           self?.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
         }
@@ -40,7 +42,8 @@ public class ComponentManager {
 
       items.enumerated().forEach {
         indexes.append(numberOfItems + $0.offset)
-        component.configureItem(at: numberOfItems + $0.offset, usesViewSize: true)
+
+        self?.itemManager.configureItem(at: numberOfItems + $0.offset, component: component, usesViewSize: true)
       }
 
       if numberOfItems > 0 {
@@ -71,7 +74,7 @@ public class ComponentManager {
         if numberOfItems > 0 {
           indexes.append(items.count - 1 - $0.offset)
         }
-        component.configureItem(at: $0.offset, usesViewSize: true)
+        self?.itemManager.configureItem(at: $0.offset, component: component, usesViewSize: true)
       }
 
       if !indexes.isEmpty {
@@ -104,7 +107,7 @@ public class ComponentManager {
       }
 
       if numberOfItems > 0 {
-        component.configureItem(at: numberOfItems, usesViewSize: true)
+        self?.itemManager.configureItem(at: numberOfItems, component: component, usesViewSize: true)
         component.userInterface?.insert(indexes, withAnimation: animation) {
           self?.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
         }
@@ -219,7 +222,7 @@ public class ComponentManager {
         self?.finishComponentOperation(component, updateHeightAndIndexes: false, completion: completion)
         return
       } else {
-        component.configureItem(at: index, usesViewSize: true)
+        self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
         let newItem = component.model.items[index]
 
         if newItem.kind != oldItem.kind || newItem.size.height != oldItem.size.height {
@@ -255,11 +258,11 @@ public class ComponentManager {
       Dispatch.main { [weak self] in
         if let indexes = indexes {
           indexes.forEach { index  in
-            component.configureItem(at: index, usesViewSize: true)
+            self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
           }
         } else {
           for (index, _) in component.model.items.enumerated() {
-            component.configureItem(at: index, usesViewSize: true)
+            self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
           }
         }
 

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -1,0 +1,211 @@
+#if os(macOS)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+public class ItemManager {
+
+  func prepareItems(component: Component, recreateComposites: Bool = true) {
+    component.model.items = prepare(component: component, items: component.model.items, recreateComposites: recreateComposites)
+    Configuration.views.purge()
+  }
+
+  func prepare(component: Component, items: [Item], recreateComposites: Bool) -> [Item] {
+    var preparedItems = items
+    var spanWidth: CGFloat?
+
+    if let layout = component.model.layout, layout.span > 0.0 {
+      var componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
+
+      #if !os(OSX)
+        if component.view.frame.size.width == 0.0 {
+          componentWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
+        }
+      #endif
+
+      spanWidth = (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
+    }
+
+    preparedItems.enumerated().forEach { (index: Int, item: Item) in
+      var item = item
+      if let spanWidth = spanWidth {
+        item.size.width = spanWidth
+      }
+
+      if let configuredItem = configure(component: component, item: item, at: index, usesViewSize: true, recreateComposites: recreateComposites) {
+        preparedItems[index].index = index
+        preparedItems[index] = configuredItem
+      }
+    }
+
+    return preparedItems
+  }
+
+  public func configureItem(at index: Int, component: Component, usesViewSize: Bool = false, recreateComposites: Bool = true) {
+    guard let item = component.item(at: index),
+      let configuredItem = configure(component: component, item: item, at: index, usesViewSize: usesViewSize, recreateComposites: recreateComposites)
+      else {
+        return
+    }
+
+    component.model.items[index] = configuredItem
+  }
+
+  func configure(component: Component, item: Item, at index: Int, usesViewSize: Bool = false, recreateComposites: Bool) -> Item? {
+    var item = item
+    item.index = index
+
+    var fullWidth: CGFloat = item.size.width
+    let kind = component.identifier(at: index)
+
+    #if !os(OSX)
+      if fullWidth == 0.0 {
+        fullWidth = UIScreen.main.bounds.width
+      }
+
+      let view: View?
+
+      if let resolvedView = Configuration.views.make(kind, parentFrame: component.view.bounds, useCache: true)?.view {
+        view = resolvedView
+      } else {
+        return nil
+      }
+
+      if let view = view {
+        view.frame.size.width = component.view.bounds.width
+        prepare(component: component, view: view)
+      }
+
+      prepare(component: component, kind: kind, view: view as Any, item: &item, recreateComposites: recreateComposites)
+    #else
+      if fullWidth == 0.0 {
+        fullWidth = component.view.superview?.frame.size.width ?? component.view.frame.size.width
+      }
+
+      if kind.contains(CompositeComponent.identifier) {
+        let wrappable: Wrappable
+        if kind.contains("list") {
+          wrappable = ListWrapper()
+        } else {
+          wrappable = GridWrapper()
+        }
+
+        prepare(component: component, kind: kind, view: wrappable as Any, item: &item, recreateComposites: recreateComposites)
+      } else {
+        if let resolvedView = Configuration.views.make(kind, parentFrame: component.view.frame, useCache: true)?.view {
+          prepare(component: component, kind: kind, view: resolvedView as Any, item: &item, recreateComposites: recreateComposites)
+        } else {
+          return nil
+        }
+      }
+    #endif
+
+    return item
+  }
+
+  func prepare(component: Component, kind: String, view: Any, item: inout Item, recreateComposites: Bool) {
+    if let view = view as? Wrappable, kind.contains(CompositeComponent.identifier) {
+      prepare(component: component, wrappable: view, item: &item, recreateComposites: recreateComposites)
+    } else if let view = view as? ItemConfigurable {
+      view.configure(&item)
+      setFallbackViewSize(component: component, item: &item, with: view)
+    }
+  }
+
+  #if !os(OSX)
+  /// Prepare view frame for item
+  ///
+  /// - parameter view: The view that is going to be prepared.
+  func prepare(component: Component, view: View) {
+    // Set initial size for view
+    component.view.frame.size.width = view.frame.size.width
+
+    if let itemConfigurable = view as? ItemConfigurable, view.frame.size.height == 0.0 {
+      view.frame.size = itemConfigurable.preferredViewSize
+    }
+
+    if view.frame.size.width == 0.0 {
+      view.frame.size.width = UIScreen.main.bounds.size.width
+    }
+
+    (view as? UITableViewCell)?.contentView.frame = view.bounds
+    (view as? UICollectionViewCell)?.contentView.frame = view.bounds
+  }
+  #endif
+
+  /// Prepares a composable view and returns the height for the item
+  ///
+  /// - parameter composable:        A composable object
+  /// - parameter usesViewSize:      A boolean value to determine if the view uses the views height
+  ///
+  /// - returns: The height for the item based of the composable components
+  func prepare(component: Component, wrappable: Wrappable, item: inout Item, recreateComposites: Bool) {
+    var height: CGFloat = 0.0
+
+    if recreateComposites {
+      component.compositeComponents.filter({ $0.itemIndex == item.index }).forEach {
+        $0.component.view.removeFromSuperview()
+
+        if let index = component.compositeComponents.index(of: $0) {
+          component.compositeComponents.remove(at: index)
+        }
+      }
+    }
+
+    let components: [Component] = Parser.parse(item)
+    var size = component.view.frame.size
+
+    if let layout = component.model.layout, layout.span > 0.0 {
+      let componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
+      size.width = (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
+    }
+
+    size.width = round(size.width)
+
+    components.forEach { childComponent in
+      let compositeSpot = CompositeComponent(component: childComponent,
+                                             itemIndex: item.index)
+      compositeSpot.component.parentComponent = component
+      compositeSpot.component.setup(with: size)
+
+      #if !os(OSX)
+        /// Disable scrolling for listable objects
+        compositeSpot.component.view.isScrollEnabled = !(compositeSpot.component.view is TableView)
+      #endif
+
+      height += compositeSpot.component.computedHeight
+
+      if recreateComposites {
+        component.compositeComponents.append(compositeSpot)
+      }
+    }
+
+    item.size.height = height
+  }
+
+  /// Set fallback size to view
+  ///
+  /// - Parameters:
+  ///   - item: The item struct that is being configured.
+  ///   - view: The view used for fallback size for the item.
+  private func setFallbackViewSize(component: Component, item: inout Item, with view: ItemConfigurable) {
+    let hasExplicitHeight: Bool = item.size.height == 0.0
+
+    if hasExplicitHeight {
+      item.size.height = view.preferredViewSize.height
+    }
+
+    if item.size.width == 0.0 {
+      item.size.width  = view.preferredViewSize.width
+    }
+
+    if let superview = component.view.superview, item.size.width == 0.0 {
+      item.size.width = superview.frame.width
+    }
+
+    if let view = view as? View, item.size.width == 0.0 {
+      item.size.width = view.bounds.width
+    }
+  }
+}

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -107,6 +107,9 @@
 		BD9ECEC71E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEC61E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift */; };
 		BD9ECEC81E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ECEC61E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift */; };
 		BDA25E901EB5070F002B21C0 /* Wrappable+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA25E8F1EB5070F002B21C0 /* Wrappable+macOS.swift */; };
+		BDA3D96C1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
+		BDA3D96D1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
+		BDA3D96E1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
 		BDAD84A81E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
 		BDAD84A91E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
 		BDAD84AA1E3E701C008289AE /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* SpotsController.swift */; };
@@ -434,6 +437,7 @@
 		BD9ECEC31E6EC8B8003E4388 /* Component+iOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+iOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEC61E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+iOS+HeaderFooter.swift"; sourceTree = "<group>"; };
 		BDA25E8F1EB5070F002B21C0 /* Wrappable+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Wrappable+macOS.swift"; sourceTree = "<group>"; };
+		BDA3D96B1EC6F1A400141227 /* ItemManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemManager.swift; sourceTree = "<group>"; };
 		BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpotHeader.swift; sourceTree = "<group>"; };
 		BDAD84841E3E701B008289AE /* SpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SpotsController.swift; sourceTree = "<group>"; };
 		BDAD84851E3E701B008289AE /* GridableLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridableLayout.swift; sourceTree = "<group>"; };
@@ -774,6 +778,7 @@
 				BDAD852D1E3E7032008289AE /* Delegate.swift */,
 				BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */,
 				BD99824B1EA93684000A6FD4 /* ViewPreparer.swift */,
+				BDA3D96B1EC6F1A400141227 /* ItemManager.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1473,6 +1478,7 @@
 				BDAD84BB1E3E701C008289AE /* ListHeaderFooterWrapper.swift in Sources */,
 				BDDCF6E71E4DF92F004B38C4 /* StringConvertible.swift in Sources */,
 				BDAD85C21E3E7032008289AE /* ComponentDelegate.swift in Sources */,
+				BDA3D96E1EC6F1A400141227 /* ItemManager.swift in Sources */,
 				BDAD85EF1E3E7032008289AE /* StateCache.swift in Sources */,
 				BD0AF3541E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDDCF6D81E4DF911004B38C4 /* Item.swift in Sources */,
@@ -1657,6 +1663,7 @@
 				BDAD85631E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
 				BD1F9E191EA39F2E009C018B /* Dictionary+Extensions.swift in Sources */,
+				BDA3D96C1EC6F1A400141227 /* ItemManager.swift in Sources */,
 				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
 				BD99824C1EA93684000A6FD4 /* ViewPreparer.swift in Sources */,
 				D5D2826B1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
@@ -1766,6 +1773,7 @@
 				BDAD85271E3E7025008289AE /* ComponentView.swift in Sources */,
 				BDAD859A1E3E7032008289AE /* SpotsController+LiveEditing.swift in Sources */,
 				BDAD85231E3E7025008289AE /* NSCollectionView+UserInterface.swift in Sources */,
+				BDA3D96D1EC6F1A400141227 /* ItemManager.swift in Sources */,
 				BDAD85641E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD85881E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BD2403111E4B9A02005BAA19 /* Component.swift in Sources */,


### PR DESCRIPTION
Reduces the magic located on the Component+Core protocol extension by moving all item preparation and size calculation methods into a new class called `ItemManager`. It resides on `ComponentManager` and is used to set sizes on component model items.