### PR TITLE
Feature items per row

### DIFF
--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -39,6 +39,15 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// For a horizontally scrolling layout, the value represents the minimum spacing between successive columns.
   public var lineSpacing: Double = 0.0
 
+  /// Items per row is used in horizontal `Component`'s to configure how many items should be displayed
+  /// in per row. It defaults two 1, which means that all items end up on the same row.
+  /// 
+  /// Example with `itemsPerRow` set to 1.
+  /// |item 1|item 2|item 3|item 4|
+  ///
+  /// Example with `itemsPerRow` set to 2.
+  /// |item 1|item 3|
+  /// |item 2|item 4|
   public var itemsPerRow: Int = 1
 
   /// Defines how many items to show per row for `Gridable` components.

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -65,6 +65,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   public var dictionary: [String : Any] {
     var dictionary: [String : Any] = [
       Inset.rootKey: inset.dictionary,
+      Key.itemsPerRow.rawValue: itemsPerRow,
       Key.itemSpacing.rawValue: itemSpacing,
       Key.lineSpacing.rawValue: lineSpacing,
       Key.span.rawValue: span,

--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -20,6 +20,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// - pageIndicator: Used to map if component should display a page indicator.
   enum Key: String {
     case itemSpacing = "item-spacing"
+    case itemsPerRow = "items-per-row"
     case lineSpacing = "line-spacing"
     case span
     case dynamicSpan = "dynamic-span"
@@ -37,6 +38,9 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// For a vertically scrolling layout, the value represents the minimum spacing between successive rows.
   /// For a horizontally scrolling layout, the value represents the minimum spacing between successive columns.
   public var lineSpacing: Double = 0.0
+
+  public var itemsPerRow: Int = 1
+
   /// Defines how many items to show per row for `Gridable` components.
   public var span: Double = 0.0
   /// If enabled and the item count is less than the span, the CarouselComponent will even out the space between the items to align them.
@@ -73,6 +77,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     self.dynamicSpan = false
     self.itemSpacing = 0.0
     self.lineSpacing = 0.0
+    self.itemsPerRow = 1
     self.inset = Inset()
     self.headerMode = .default
   }
@@ -87,11 +92,12 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   ///   - itemSpacing: Sets minimum item spacing for the model.
   ///   - lineSpacing: Sets minimum lines spacing for items in model.
   ///   - inset: An inset struct used to insert margins for the model.
-  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init(), headerMode: HeaderMode = .default) {
+  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemsPerRow: Int = 1, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init(), headerMode: HeaderMode = .default) {
     self.span = span
     self.dynamicSpan = dynamicSpan
     self.dynamicHeight = dynamicHeight
     self.itemSpacing = itemSpacing
+    self.itemsPerRow = itemsPerRow
     self.lineSpacing = lineSpacing
     self.inset = inset
     self.pageIndicatorPlacement = pageIndicatorPlacement
@@ -115,6 +121,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// - Parameter map: A JSON dictionary.
   public mutating func configure(withJSON map: [String : Any]) {
     self.inset = Inset(map.property(Inset.rootKey) ?? [:])
+    self.itemsPerRow <- map.int(Key.itemsPerRow.rawValue)
     self.itemSpacing <- map.double(Key.itemSpacing.rawValue)
     self.lineSpacing <- map.double(Key.lineSpacing.rawValue)
     self.dynamicSpan <- map.boolean(Key.dynamicSpan.rawValue)
@@ -143,6 +150,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   public static func == (lhs: Layout, rhs: Layout) -> Bool {
     return lhs.inset == rhs.inset &&
     lhs.itemSpacing == rhs.itemSpacing &&
+    lhs.itemsPerRow == rhs.itemsPerRow &&
     lhs.lineSpacing == rhs.lineSpacing &&
     lhs.span == rhs.span &&
     lhs.dynamicSpan == rhs.dynamicSpan &&

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -52,8 +52,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      contentSize.width = 0.0
-      contentSize.height = 0.0
+      contentSize = .zero
 
       if let firstItem = component.model.items.first {
         contentSize.height = (firstItem.size.height + minimumLineSpacing) * CGFloat(layout.itemsPerRow)

--- a/Sources/iOS/Classes/GridableLayout.swift
+++ b/Sources/iOS/Classes/GridableLayout.swift
@@ -65,7 +65,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
       contentSize.height -= minimumLineSpacing
 
       for (index, item) in component.model.items.enumerated() {
-        guard index % layout.itemsPerRow == layout.itemsPerRow - 1 else {
+        guard indexEligibleForItemsPerRow(index: index, itemsPerRow: layout.itemsPerRow) else {
           continue
         }
 
@@ -134,7 +134,7 @@ open class GridableLayout: UICollectionViewFlowLayout {
 
           itemAttribute.frame.origin.x = nextX
 
-          if layout.itemsPerRow == 1 || itemAttribute.indexPath.item % layout.itemsPerRow == layout.itemsPerRow - 1 {
+          if indexEligibleForItemsPerRow(index: itemAttribute.indexPath.item, itemsPerRow: layout.itemsPerRow) {
             nextX += itemAttribute.size.width + minimumInteritemSpacing
             nextY = component.headerHeight + sectionInset.top
           } else {
@@ -162,5 +162,16 @@ open class GridableLayout: UICollectionViewFlowLayout {
   /// - returns: Always returns true
   open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
     return newBounds.size.height >= contentSize.height
+  }
+
+  /// Check if the current index is eligible for performing itemsPerRow calculations.
+  /// If `itemsPerRow` is set to 1, it will always return `true`.
+  ///
+  /// - Parameters:
+  ///   - index: The index that should be checked if it is eligible or not.
+  ///   - itemsPerRow: The amount of items that should appear on per row, see `itemsPerRow on `Layout`.
+  /// - Returns: True if `index` is equal to the remainder of `itemsPerRow` or `itemsPerRow` is set to 1.
+  private func indexEligibleForItemsPerRow(index: Int, itemsPerRow: Int) -> Bool {
+    return itemsPerRow == 1 || index % itemsPerRow == itemsPerRow - 1
   }
 }

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -36,8 +36,7 @@ public class GridableLayout: FlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      contentSize.width = 0.0
-      contentSize.height = 0.0
+      contentSize = .zero
 
       if let firstItem = component.model.items.first {
         contentSize.height = firstItem.size.height * CGFloat(layout.itemsPerRow)

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -47,7 +47,7 @@ public class GridableLayout: FlowLayout {
       }
 
       for (index, item) in component.model.items.enumerated() {
-        guard layout.itemsPerRow == 1 || index % layout.itemsPerRow == layout.itemsPerRow - 1 else {
+        guard indexEligibleForItemsPerRow(index: index, itemsPerRow: layout.itemsPerRow) else {
           continue
         }
 
@@ -110,7 +110,7 @@ public class GridableLayout: FlowLayout {
 
         itemAttribute.frame.origin.x = nextX
 
-        if layout.itemsPerRow == 1 || indexPath.item % layout.itemsPerRow == layout.itemsPerRow - 1 {
+        if indexEligibleForItemsPerRow(index: indexPath.item, itemsPerRow: layout.itemsPerRow) {
           nextX += itemAttribute.size.width + minimumInteritemSpacing
           nextY = 0
         } else {
@@ -137,5 +137,16 @@ public class GridableLayout: FlowLayout {
     let shouldInvalidateLayout = newBounds.size.height != collectionView.frame.height + offset
 
     return shouldInvalidateLayout
+  }
+
+  /// Check if the current index is eligible for performing itemsPerRow calculations.
+  /// If `itemsPerRow` is set to 1, it will always return `true`.
+  ///
+  /// - Parameters:
+  ///   - index: The index that should be checked if it is eligible or not.
+  ///   - itemsPerRow: The amount of items that should appear on per row, see `itemsPerRow on `Layout`.
+  /// - Returns: True if `index` is equal to the remainder of `itemsPerRow` or `itemsPerRow` is set to 1.
+  private func indexEligibleForItemsPerRow(index: Int, itemsPerRow: Int) -> Bool {
+    return itemsPerRow == 1 || index % itemsPerRow == itemsPerRow - 1
   }
 }

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -16,7 +16,8 @@ public class GridableLayout: FlowLayout {
 
   open override func prepare() {
     guard let delegate = collectionView?.delegate as? Delegate,
-      let component = delegate.component
+      let component = delegate.component,
+      let layout = component.model.layout
       else {
         return
     }
@@ -35,24 +36,29 @@ public class GridableLayout: FlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      guard let firstItem = component.model.items.first else {
-        return
+      contentSize.width = 0.0
+      contentSize.height = 0.0
+
+      if let firstItem = component.model.items.first {
+        contentSize.height = firstItem.size.height * CGFloat(layout.itemsPerRow)
+
+        if component.model.items.count % layout.itemsPerRow == 1 {
+          contentSize.width += firstItem.size.width + minimumLineSpacing
+        }
       }
 
-      contentSize.width = component.model.items.reduce(0, { $0 + floor($1.size.width) })
+      for (index, item) in component.model.items.enumerated() {
+        guard index % layout.itemsPerRow == layout.itemsPerRow - 1 else {
+          continue
+        }
 
-      let countOffset: Int
-      if let leftInset = component.model.layout?.inset.left, leftInset > 0.0 {
-        countOffset = 0
-      } else {
-        countOffset = 1
+        contentSize.width += item.size.width + minimumInteritemSpacing
       }
 
-      contentSize.width += minimumInteritemSpacing * CGFloat(component.model.items.count - countOffset)
-
-      contentSize.height = firstItem.size.height
       contentSize.height += component.headerHeight
       contentSize.height += component.footerHeight
+      contentSize.width -= minimumInteritemSpacing
+      contentSize.width += CGFloat(layout.inset.right)
     case .vertical:
       contentSize.width = component.view.frame.width
       contentSize.height = super.collectionViewContentSize.height
@@ -60,9 +66,7 @@ public class GridableLayout: FlowLayout {
       contentSize.height += component.footerHeight
     }
 
-    if let componentLayout = component.model.layout {
-      contentSize.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
-    }
+    contentSize.height += CGFloat(layout.inset.top + layout.inset.bottom)
   }
 
   public override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
@@ -70,7 +74,8 @@ public class GridableLayout: FlowLayout {
 
     guard let collectionView = collectionView,
       let dataSource = collectionView.dataSource as? DataSource,
-      let component = dataSource.component
+      let component = dataSource.component,
+      let layout = component.model.layout
       else {
         return attributes
     }
@@ -79,7 +84,8 @@ public class GridableLayout: FlowLayout {
       return attributes
     }
 
-    var offset: CGFloat = sectionInset.left
+    var nextX: CGFloat = sectionInset.left
+    var nextY: CGFloat = 0.0
 
     for attribute in newAttributes {
       guard let itemAttribute = attribute.copy() as? NSCollectionViewLayoutAttributes else {
@@ -93,10 +99,24 @@ public class GridableLayout: FlowLayout {
       itemAttribute.size = component.sizeForItem(at: indexPath)
 
       if scrollDirection == .horizontal {
-        itemAttribute.frame.origin.y = component.headerHeight + sectionInset.top
-        itemAttribute.frame.origin.x = offset
+        if layout.itemsPerRow > 1 {
+          if indexPath.item % Int(layout.itemsPerRow) == 0 {
+            itemAttribute.frame.origin.y += sectionInset.top + component.headerHeight
+          } else {
+            itemAttribute.frame.origin.y = nextY
+          }
+        } else {
+          itemAttribute.frame.origin.y += component.headerHeight
+        }
 
-        offset += itemAttribute.size.width + minimumInteritemSpacing
+        itemAttribute.frame.origin.x = nextX
+
+        if layout.itemsPerRow == 1 || indexPath.item % layout.itemsPerRow == layout.itemsPerRow - 1 {
+          nextX += itemAttribute.size.width + minimumInteritemSpacing
+          nextY = 0
+        } else {
+          nextY = itemAttribute.frame.maxY
+        }
       } else {
         itemAttribute.frame.origin.y += component.headerHeight
       }

--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -48,7 +48,7 @@ public class GridableLayout: FlowLayout {
       }
 
       for (index, item) in component.model.items.enumerated() {
-        guard index % layout.itemsPerRow == layout.itemsPerRow - 1 else {
+        guard layout.itemsPerRow == 1 || index % layout.itemsPerRow == layout.itemsPerRow - 1 else {
           continue
         }
 

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -4,17 +4,18 @@ import Tailor
 extension Component {
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     var newCollectionViewHeight: CGFloat = 0.0
-
     newCollectionViewHeight <- model.items.sorted(by: {
       $0.size.height > $1.size.height
     }).first?.size.height
 
-    scrollView.scrollingEnabled = (model.items.count > 1)
-    scrollView.hasHorizontalScroller = (model.items.count > 1)
-
     if let layout = model.layout {
+      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
+      newCollectionViewHeight += headerHeight
       newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
     }
+
+    scrollView.scrollingEnabled = (model.items.count > 1)
+    scrollView.hasHorizontalScroller = (model.items.count > 1)
 
     collectionView.frame.size.height = newCollectionViewHeight
   }
@@ -32,10 +33,15 @@ extension Component {
     }
 
     var newCollectionViewHeight: CGFloat = 0.0
-
     newCollectionViewHeight <- model.items.sorted(by: {
       $0.size.height > $1.size.height
     }).first?.size.height
+
+    if let layout = model.layout {
+      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
+      newCollectionViewHeight += headerHeight
+      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
+    }
 
     collectionView.frame.size.width = collectionViewContentSize.width
     collectionView.frame.size.height = newCollectionViewHeight
@@ -44,8 +50,6 @@ extension Component {
     documentView.frame.size.height = collectionView.frame.size.height + headerHeight + footerHeight
 
     if let layout = model.layout {
-      collectionView.frame.size.height += CGFloat(layout.inset.top + layout.inset.bottom)
-      documentView.frame.size.height += CGFloat(layout.inset.top + layout.inset.bottom)
       documentView.frame.size.width += CGFloat(layout.inset.right)
     }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		BDB1F8B01E5D91BE0064F64B /* ComponentHorizontallyScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1F8AE1E5D91BE0064F64B /* ComponentHorizontallyScrollable.swift */; };
 		BDB1F8B31E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1F8B21E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift */; };
 		BDB1F8B41E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1F8B21E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift */; };
+		BDB1FCBA1ECEE6140042ED61 /* GridableLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB1FCB91ECEE6140042ED61 /* GridableLayoutTests.swift */; };
 		BDB8D5931E4DFADC00220BC3 /* TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* TestItem.swift */; };
 		BDB8D5941E4DFADC00220BC3 /* TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* TestItem.swift */; };
 		BDB8D5951E4DFADC00220BC3 /* TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* TestItem.swift */; };
@@ -514,6 +515,7 @@
 		BDAD85F51E3E703A008289AE /* Component+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+tvOS.swift"; sourceTree = "<group>"; };
 		BDB1F8AE1E5D91BE0064F64B /* ComponentHorizontallyScrollable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentHorizontallyScrollable.swift; sourceTree = "<group>"; };
 		BDB1F8B21E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreComponent+Extensions+iOS.swift"; sourceTree = "<group>"; };
+		BDB1FCB91ECEE6140042ED61 /* GridableLayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridableLayoutTests.swift; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDB8D5921E4DFADC00220BC3 /* TestItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestItem.swift; sourceTree = "<group>"; };
 		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
@@ -906,6 +908,7 @@
 		BDDF2CCE1DC7C4FC00B766BA /* macOS */ = {
 			isa = PBXGroup;
 			children = (
+				BDB1FCB91ECEE6140042ED61 /* GridableLayoutTests.swift */,
 				BDFC474C1E747B2B008700BF /* TestGridWrapper.swift */,
 				BDFC474D1E747B2B008700BF /* TestListWrapper.swift */,
 				BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */,
@@ -1841,6 +1844,7 @@
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* TestComponent.swift in Sources */,
+				BDB1FCBA1ECEE6140042ED61 /* GridableLayoutTests.swift in Sources */,
 				BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BDE44B171EA0F0E50021EAC8 /* TestComponentManager.swift in Sources */,

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -51,7 +51,7 @@ class TestGridableLayout: XCTestCase {
       return
     }
 
-    XCTAssertEqual(collectionView.contentSize, CGSize(width: 100, height: 150))
+    XCTAssertEqual(collectionView.contentSize, CGSize(width: 125, height: 150))
     XCTAssertEqual(carouselComponent.view.frame.size, CGSize(width: 100, height: 150))
   }
 

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -2,6 +2,15 @@
 import Foundation
 import XCTest
 
+class ItemsPerRowViewMock: View, ItemConfigurable {
+
+  func configure(with item: Item) {}
+
+  func computeSize(for item: Item) -> CGSize {
+    return CGSize(width: 100, height: 50)
+  }
+}
+
 class TestGridableLayout: XCTestCase {
 
   let parentSize = CGSize(width: 100, height: 100)
@@ -195,5 +204,43 @@ class TestGridableLayout: XCTestCase {
     )
 
     XCTAssertEqual(collectionViewLayout.collectionViewContentSize, expectedContentSize)
+  }
+
+  func testItemsPerRow() {
+    var component: Component
+    var model: ComponentModel
+    let items = [
+      Item(title: "Item 1"),
+      Item(title: "Item 2"),
+      Item(title: "Item 3"),
+      Item(title: "Item 4"),
+      Item(title: "Item 5"),
+      Item(title: "Item 6"),
+      Item(title: "Item 7"),
+      Item(title: "Item 8"),
+      Item(title: "Item 9"),
+      Item(title: "Item 10"),
+      Item(title: "Item 11"),
+      Item(title: "Item 12"),
+      Item(title: "Item 13"),
+      Item(title: "Item 14"),
+      Item(title: "Item 15"),
+    ]
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 1), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    XCTAssertEqual(component.view.contentSize, CGSize(width: 1500, height: 44))
+
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 2), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    XCTAssertEqual(component.view.contentSize, CGSize(width: 800, height: 88))
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 3), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    XCTAssertEqual(component.view.contentSize, CGSize(width: 500, height: 132))
   }
 }

--- a/SpotsTests/iOS/TestGridableLayout.swift
+++ b/SpotsTests/iOS/TestGridableLayout.swift
@@ -232,7 +232,6 @@ class TestGridableLayout: XCTestCase {
     component.setup(with: CGSize(width: 100, height: 100))
     XCTAssertEqual(component.view.contentSize, CGSize(width: 1500, height: 44))
 
-
     model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 2), items: items)
     component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))

--- a/SpotsTests/macOS/GridableLayoutTests.swift
+++ b/SpotsTests/macOS/GridableLayoutTests.swift
@@ -1,0 +1,64 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+class ItemsPerRowViewMock: View, ItemConfigurable {
+
+  func configure(with item: Item) {}
+
+  func computeSize(for item: Item) -> CGSize {
+    return CGSize(width: 100, height: 50)
+  }
+}
+
+class TestGridableLayout: XCTestCase {
+
+  override func setUp() {
+    Configuration.registerDefault(view: ItemsPerRowViewMock.self)
+    Configuration.views.purge()
+  }
+
+  func testItemsPerRow() {
+    var component: Component
+    var model: ComponentModel
+    let items = [
+      Item(title: "Item 1"),
+      Item(title: "Item 2"),
+      Item(title: "Item 3"),
+      Item(title: "Item 4"),
+      Item(title: "Item 5"),
+      Item(title: "Item 6"),
+      Item(title: "Item 7"),
+      Item(title: "Item 8"),
+      Item(title: "Item 9"),
+      Item(title: "Item 10"),
+      Item(title: "Item 11"),
+      Item(title: "Item 12"),
+      Item(title: "Item 13"),
+      Item(title: "Item 14"),
+      Item(title: "Item 15"),
+      ]
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 1), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    var gridableLayout = component.collectionView?.collectionViewLayout as? GridableLayout
+    XCTAssertEqual(gridableLayout?.contentSize, CGSize(width: 1500, height: 50))
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 2), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    gridableLayout = component.collectionView?.collectionViewLayout as? GridableLayout
+
+    XCTAssertEqual(gridableLayout?.contentSize, CGSize(width: 800, height: 100))
+
+    model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 3), items: items)
+    component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+    gridableLayout = component.collectionView?.collectionViewLayout as? GridableLayout
+
+    XCTAssertEqual(gridableLayout?.contentSize, CGSize(width: 500, height: 150))
+  }
+  
+}

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -110,7 +110,7 @@ class TestSpot: XCTestCase {
     let component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
 
-    XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 150))
-    XCTAssertEqual(component.view.contentSize, CGSize(width: 100, height: 150))
+    XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 200))
+    XCTAssertEqual(component.view.contentSize, CGSize(width: 100, height: 200))
   }
 }


### PR DESCRIPTION
This PR adds a new property on `Layout` called `itemsPerRow` that is used to configure how many items should be displayed per row, pretty self explanatory. To quote the documentation:

```
  /// Items per row is used in horizontal `Component`'s to configure how many items should be displayed
  /// in per row. It defaults two 1, which means that all items end up on the same row.
  /// 
  /// Example with `itemsPerRow` set to 1.
  /// |item 1|item 2|item 3|item 4|
  ///
  /// Example with `itemsPerRow` set to 2.
  /// |item 1|item 3|
  /// |item 2|item 4|
```

It is supported for both macOS/iOS and tvOS.

This is how it looks on macOS.

![items-per-row](https://cloud.githubusercontent.com/assets/57446/26250708/3449ca46-3cab-11e7-93e6-b2a449c47eac.gif)

