### PR TITLE
Make computeSize open so that you can override it.

### DIFF
--- a/Sources/iOS/Classes/DefaultItemView.swift
+++ b/Sources/iOS/Classes/DefaultItemView.swift
@@ -47,7 +47,7 @@ open class DefaultItemView: UITableViewCell, ItemConfigurable {
     assignAccesibilityAttributes(from: item)
   }
 
-  public func computeSize(for item: Item) -> CGSize {
+  open func computeSize(for item: Item) -> CGSize {
     let itemHeight = item.size.height > 0.0 ? item.size.height : Configuration.defaultViewSize.height
 
     return .init(

--- a/Sources/macOS/Classes/DefaultItemView.swift
+++ b/Sources/macOS/Classes/DefaultItemView.swift
@@ -65,10 +65,6 @@ open class DefaultItemView: NSTableRowView, ItemConfigurable {
     fatalError("init(coder:) has not been implemented")
   }
 
-  open func computeSize(for item: Item) -> CGSize {
-    return Configuration.defaultViewSize
-  }
-
   open func configure(with item: Item) {
     titleLabel.stringValue = item.title
     titleLabel.frame.origin.x = 8
@@ -87,5 +83,9 @@ open class DefaultItemView: NSTableRowView, ItemConfigurable {
     subtitleLabel.frame.origin.y = titleLabel.frame.origin.y + subtitleLabel.frame.height
 
     lineView.frame.origin.y = item.size.height + 1
+  }
+
+  open func computeSize(for item: Item) -> CGSize {
+    return Configuration.defaultViewSize
   }
 }


### PR DESCRIPTION
This PR changes the `computeSize` from being `public` to `open` so that you can override it.