### PR TITLE
Add support for Component stretching.

### DIFF
--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -14,6 +14,17 @@ struct PlatformDefaults {
 
 public struct Configuration {
 
+  #if !os(macOS)
+  /// Default setting for stretching a single `Component` to occupy the full height of `SpotsScrollView`.
+  /// See `SpotsScrollView.stretchSingleComponent` for more details.
+  /// Note: Available on iOS and tvOS
+  public static var stretchSingleComponent: Bool = false
+  /// Default setting for stretching the last `Component` to occupy the full height of `SpotsScrollView`.
+  /// See `SpotsScrollView.stretchSingleComponent` for more details.
+  /// Note: Available on iOS and tvOS
+  public static var stretchLastComponent: Bool = false
+  #endif
+
   public static var defaultComponentKind: ComponentKind = .grid
   public static var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
   public static var views: Registry = .init()

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -19,7 +19,7 @@ open class SpotsScrollView: UIScrollView {
   ///  --------   --------
   /// ```
   ///
-  var stretchSingleComponent = Configuration.stretchSingleComponent
+  public var stretchSingleComponent = Configuration.stretchSingleComponent
   /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
   /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
   ///
@@ -35,7 +35,7 @@ open class SpotsScrollView: UIScrollView {
   /// ||______|| |        |
   ///  --------   --------
   /// ```
-  var stretchLastComponent = Configuration.stretchLastComponent
+  public var stretchLastComponent = Configuration.stretchLastComponent
 
   /// A KVO context used to monitor changes in contentSize, frames and bounds
   let subviewContext: UnsafeMutableRawPointer? = UnsafeMutableRawPointer(mutating: nil)

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -21,7 +21,7 @@ open class SpotsScrollView: UIScrollView {
   ///
   var stretchSingleComponent = Configuration.stretchSingleComponent
   /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
-  /// This can be enabled globally by setting `Configuration.stretchSingleComponent` to `true`.
+  /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
   ///
   ///  Enabled    Disabled
   /// ```

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -7,8 +7,8 @@ open class SpotsScrollView: UIScrollView {
   /// When enabled, single components will be stretched to get the current height of the parent view.
   /// This can be enabled globally by setting `Configuration.strechSingleComponent` to `true`.
   ///
-  ///  Enabled    Disabled
   /// ```
+  ///  Enabled    Disabled
   ///  --------   --------
   /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
   /// ||      || ||      ||
@@ -23,8 +23,8 @@ open class SpotsScrollView: UIScrollView {
   /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
   /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
   ///
-  ///  Enabled    Disabled
   /// ```
+  ///  Enabled    Disabled
   ///  --------   --------
   /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
   /// ||      || ||      ||

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -172,4 +172,45 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual((controller.scrollView.componentsView.subviews[3] as? UIScrollView)!.contentSize.height, 320)
     XCTAssertEqual(controller.scrollView.componentsView.subviews[3].frame.height, 0)
   }
+
+  func testStretchSingleComponent() {
+    let items = [Item(), Item()]
+    let model = ComponentModel(items: items)
+    let component = Component(model: model)
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
+
+    /// The single component should not be stretched to use the same height as the parent.
+    controller.scrollView.layoutSubviews()
+    XCTAssertNotEqual(controller.scrollView.frame.size.height, controller.components.first!.view.frame.size.height)
+
+    /// The single component should be stretched to use the same height as the parent.
+    controller.scrollView.stretchSingleComponent = true
+    controller.scrollView.layoutSubviews()
+    XCTAssertEqual(controller.scrollView.frame.size, controller.components.first!.view.frame.size)
+  }
+
+  func testStetchLastComponent() {
+    let items = [Item(), Item()]
+    let model = ComponentModel(items: items)
+    let controller = SpotsController(components: [Component(model: model), Component(model: model), Component(model: model)])
+    controller.prepareController()
+    controller.scrollView.layoutSubviews()
+
+    /// The first and the last component should be equal in height
+    XCTAssertEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
+
+    controller.scrollView.stretchLastComponent = true
+    controller.scrollView.layoutSubviews()
+
+    /// The first and last component should not be equal as the last one should be stretched.
+    XCTAssertNotEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
+
+    var totalComponentHeight: CGFloat = 0.0
+    for component in controller.components {
+      totalComponentHeight += component.view.frame.size.height
+    }
+
+    XCTAssertEqual(controller.scrollView.frame.size.height, totalComponentHeight)
+  }
 }


### PR DESCRIPTION
## Feature stretching 💪

Adds support for stretching components. If you only have one `Component` in your collection you can enable stretching for that component, which means that it will use the parent frame as it size instead of computing the remaining size of the component based of contentOffset and contentSize. This should have a positive effect on performance as it would exist earlier and perform less computation on larger collections.

It also adds support for stretching the last component in the collection. When enabled the last component will use the remaining size of the screen.

This can be enabled globally for an application by setting either Configuration.stretchSingleComponent or Configuration.stretchLastComponent to true.

It can also be enabled per controller by setting `controller.scrollView.stretchSingleComponent`, `controller.scrollView.stretchLastComponent` to true.

The default values are both `false`. These features are available on iOS and tvOS.


### Documentation

```
  /// When enabled, single components will be stretched to get the current height of the parent view.
  /// This can be enabled globally by setting `Configuration.strechSingleComponent` to `true`.
  ///
  ///  Enabled    Disabled
  /// ```
  ///  --------   --------
  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
  /// ||      || ||      ||
  /// ||      || ||______||
  /// ||      || |        |
  /// ||      || |        |
  /// ||______|| |        |
  ///  --------   --------
  /// ```
  ///
  var stretchSingleComponent = Configuration.stretchSingleComponent
  /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
  /// This can be enabled globally by setting `Configuration.stretchSingleComponent` to `true`.
  ///
  ///  Enabled    Disabled
  /// ```
  ///  --------   --------
  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
  /// ||      || ||      ||
  /// ||______|| ||______||
  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
  /// ||      || ||      ||
  /// ||      || ||______||
  /// ||______|| |        |
  ///  --------   --------
  /// ```
  var stretchLastComponent = Configuration.stretchLastComponent
```