### PR TITLE
Invoke layoutViews on SpotsScrollView

### DIFF
--- a/Sources/iOS/Classes/SpotsContentView.swift
+++ b/Sources/iOS/Classes/SpotsContentView.swift
@@ -26,4 +26,14 @@ open class SpotsContentView: UIView {
     }
     containerScrollView.willRemoveSubview(subview)
   }
+
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+
+    guard let containerScrollView = superview as? SpotsScrollView else {
+      return
+    }
+
+    containerScrollView.layoutViews()
+  }
 }

--- a/Sources/iOS/Classes/SpotsContentView.swift
+++ b/Sources/iOS/Classes/SpotsContentView.swift
@@ -27,6 +27,11 @@ open class SpotsContentView: UIView {
     containerScrollView.willRemoveSubview(subview)
   }
 
+  /// The default implementation of this method does nothing on iOS 5.1 and earlier. 
+  /// Otherwise, the default implementation uses any constraints you have set to 
+  /// determine the size and position of any subviews.
+  /// If `SpotsContentView` is added to a `SpotsScrollView` it will invoke `layoutViews`
+  /// to trigger a re-rendering of all components.
   open override func layoutSubviews() {
     super.layoutSubviews()
 

--- a/Sources/iOS/Classes/SpotsContentView.swift
+++ b/Sources/iOS/Classes/SpotsContentView.swift
@@ -1,6 +1,16 @@
 import UIKit
 
-/// A container view for KVO inside SpotsScrollView
+/// SpotsContentView is a container view that lives on `SpotsScrollView`.
+/// All views that gets added to the view hierarchy using a `SpotsController`
+/// reside in `SpotsContentView`, in that scenario it is the parent of all `Component` views.
+/// When a view is added, it will invoke `didAddSubviewToContainer` on `SpotsScrollView` to
+/// start monitoring the view using KVO. When a view will be removed `willRemoveSubview` is
+/// invoked on `SpotsScrollView` to remove any KVO setup for the view on question.
+/// When a `Component` performs any mutating operation, it will end up calling `afterUpdate`
+/// which calls `layoutSubviews` on its parent. The parent being `SpotsContentView`. That
+/// method then relays the invocation to call `layoutViews` on `SpotsScrollView. This will
+/// cause the `SpotsScrollView` layout operation to be called, causing the layout to be
+/// invalidated and re-rendered.
 open class SpotsContentView: UIView {
 
   /// Tells the view that a subview was added.


### PR DESCRIPTION
When a Component finishes its operations in `afterUpdate`. It calls `layoutSubviews` on its parent. For this to reach the `SpotsScrollView`, it needs to be forwarded. This method on `SpotsContentView` tells the `SpotsScrollView` to layout the views again. This is typically called after mutation.