### PR TITLE
Remove stretchSingleComponent feature

### DIFF
--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -15,12 +15,8 @@ struct PlatformDefaults {
 public struct Configuration {
 
   #if !os(macOS)
-  /// Default setting for stretching a single `Component` to occupy the full height of `SpotsScrollView`.
-  /// See `SpotsScrollView.stretchSingleComponent` for more details.
-  /// Note: Available on iOS and tvOS
-  public static var stretchSingleComponent: Bool = false
   /// Default setting for stretching the last `Component` to occupy the full height of `SpotsScrollView`.
-  /// See `SpotsScrollView.stretchSingleComponent` for more details.
+  /// See `SpotsScrollView.stretchLastComponent` for more details.
   /// Note: Available on iOS and tvOS
   public static var stretchLastComponent: Bool = false
   #endif

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -4,22 +4,6 @@ import QuartzCore
 /// The core foundation scroll view inside of Spots that manages the linear layout of all components.
 open class SpotsScrollView: UIScrollView {
 
-  /// When enabled, single components will be stretched to get the current height of the parent view.
-  /// This can be enabled globally by setting `Configuration.strechSingleComponent` to `true`.
-  ///
-  /// ```
-  ///  Enabled    Disabled
-  ///  --------   --------
-  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
-  /// ||      || ||      ||
-  /// ||      || ||______||
-  /// ||      || |        |
-  /// ||      || |        |
-  /// ||______|| |        |
-  ///  --------   --------
-  /// ```
-  ///
-  public var stretchSingleComponent = Configuration.stretchSingleComponent
   /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
   /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
   ///
@@ -221,13 +205,6 @@ open class SpotsScrollView: UIScrollView {
   /// Layout views in linear order based of view index in `subviewsInLayoutOrder`
   func layoutViews() {
     guard let superview = superview else {
-      return
-    }
-
-    guard !stretchSingleComponent || subviewsInLayoutOrder.count > 1 else {
-      if let firstSubview = subviewsInLayoutOrder.first {
-        firstSubview.frame.size = self.frame.size
-      }
       return
     }
 

--- a/SpotsTests/iOS/TestSpotsScrollView.swift
+++ b/SpotsTests/iOS/TestSpotsScrollView.swift
@@ -173,23 +173,6 @@ class SpotsScrollViewTests: XCTestCase {
     XCTAssertEqual(controller.scrollView.componentsView.subviews[3].frame.height, 0)
   }
 
-  func testStretchSingleComponent() {
-    let items = [Item(), Item()]
-    let model = ComponentModel(items: items)
-    let component = Component(model: model)
-    let controller = SpotsController(components: [component])
-    controller.prepareController()
-
-    /// The single component should not be stretched to use the same height as the parent.
-    controller.scrollView.layoutSubviews()
-    XCTAssertNotEqual(controller.scrollView.frame.size.height, controller.components.first!.view.frame.size.height)
-
-    /// The single component should be stretched to use the same height as the parent.
-    controller.scrollView.stretchSingleComponent = true
-    controller.scrollView.layoutSubviews()
-    XCTAssertEqual(controller.scrollView.frame.size, controller.components.first!.view.frame.size)
-  }
-
   func testStetchLastComponent() {
     let items = [Item(), Item()]
     let model = ComponentModel(items: items)


### PR DESCRIPTION
`stretchSingleComponent` did not work as intended, it pretty much
ruined the underlaying scrolling. And if you enable
`stretchLastComponent` you accomplish the same effect.