### PR TITLE
Improve updateIfNeeded on SpotsControllerManager

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -644,18 +644,10 @@ public class SpotsControllerManager {
       return
     }
 
-    guard !(component.model.items == items) else {
+    component.reloadIfNeeded(items, withAnimation: animation) { 
       controller.scrollView.layoutSubviews()
       completion?()
-      return
     }
-
-    update(componentAtIndex: index, controller: controller, withAnimation: animation, withCompletion: {
-      controller.scrollView.layoutSubviews()
-      completion?()
-    }, { component in
-      component.model.items = items
-    })
   }
 
   /**


### PR DESCRIPTION
Relay update method to use `reloadIfNeeded` instead of
`update(componentAtIndex:)`. The outcome is the same, `reloadIfNeeded`
is just more optimized for this usecase.