### PR TITLE
Improve GridableLayout by including line spacing

### DIFF
--- a/Sources/macOS/Classes/GridableLayout.swift
+++ b/Sources/macOS/Classes/GridableLayout.swift
@@ -43,6 +43,7 @@ public class GridableLayout: FlowLayout {
 
         if component.model.items.count % layout.itemsPerRow == 1 {
           contentSize.width += firstItem.size.width + minimumLineSpacing
+          contentSize.height += CGFloat(layout.lineSpacing)
         }
       }
 
@@ -114,7 +115,7 @@ public class GridableLayout: FlowLayout {
           nextX += itemAttribute.size.width + minimumInteritemSpacing
           nextY = 0
         } else {
-          nextY = itemAttribute.frame.maxY
+          nextY = itemAttribute.frame.maxY + CGFloat(layout.lineSpacing)
         }
       } else {
         itemAttribute.frame.origin.y += component.headerHeight

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -3,16 +3,7 @@ import Tailor
 
 extension Component {
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    var newCollectionViewHeight: CGFloat = 0.0
-    newCollectionViewHeight <- model.items.sorted(by: {
-      $0.size.height > $1.size.height
-    }).first?.size.height
-
-    if let layout = model.layout {
-      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
-      newCollectionViewHeight += headerHeight
-      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
-    }
+    let newCollectionViewHeight = calculateCollectionViewHeight()
 
     scrollView.scrollingEnabled = (model.items.count > 1)
     scrollView.hasHorizontalScroller = (model.items.count > 1)
@@ -32,16 +23,7 @@ extension Component {
       return
     }
 
-    var newCollectionViewHeight: CGFloat = 0.0
-    newCollectionViewHeight <- model.items.sorted(by: {
-      $0.size.height > $1.size.height
-    }).first?.size.height
-
-    if let layout = model.layout {
-      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
-      newCollectionViewHeight += headerHeight
-      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
-    }
+    let newCollectionViewHeight = calculateCollectionViewHeight()
 
     collectionView.frame.size.width = collectionViewContentSize.width
     collectionView.frame.size.height = newCollectionViewHeight
@@ -69,5 +51,24 @@ extension Component {
       layout(with: size)
       prepareItems(recreateComposites: false)
     }
+  }
+
+  private func calculateCollectionViewHeight() -> CGFloat {
+    var newCollectionViewHeight: CGFloat = 0.0
+    newCollectionViewHeight <- model.items.sorted(by: {
+      $0.size.height > $1.size.height
+    }).first?.size.height
+
+    if let layout = model.layout {
+      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
+      newCollectionViewHeight += headerHeight
+      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
+
+      if layout.itemsPerRow > 1 {
+        newCollectionViewHeight += CGFloat(layout.lineSpacing * Double(layout.itemsPerRow - 2))
+      }
+    }
+
+    return newCollectionViewHeight
   }
 }

--- a/Sources/macOS/Extensions/Component+macOS+Grid.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Grid.swift
@@ -15,6 +15,11 @@ extension Component {
     if let collectionViewContentSize = collectionView.collectionViewLayout?.collectionViewContentSize {
       var collectionViewContentSize = collectionViewContentSize
       collectionViewContentSize.height += headerHeight + footerHeight
+
+      if let layout = model.layout {
+        collectionViewContentSize.height += CGFloat(layout.inset.top + layout.inset.bottom)
+      }
+
       collectionView.frame.size.height = collectionViewContentSize.height
       collectionView.frame.size.width = collectionViewContentSize.width
 


### PR DESCRIPTION
This brings the GridableLayout for macOS up to par with iOS/tvOS.
It now takes `lineSpacing` into account when rendering collection views.