### PR TITLE
Implement stretch last component feature on macOS

### DIFF
--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -14,12 +14,9 @@ struct PlatformDefaults {
 
 public struct Configuration {
 
-  #if !os(macOS)
   /// Default setting for stretching the last `Component` to occupy the full height of `SpotsScrollView`.
   /// See `SpotsScrollView.stretchLastComponent` for more details.
-  /// Note: Available on iOS and tvOS
   public static var stretchLastComponent: Bool = false
-  #endif
 
   public static var defaultComponentKind: ComponentKind = .grid
   public static var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -2,6 +2,23 @@ import Cocoa
 
 open class SpotsScrollView: NSScrollView {
 
+  /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
+  /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
+  ///
+  /// ```
+  ///  Enabled    Disabled
+  ///  --------   --------
+  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
+  /// ||      || ||      ||
+  /// ||______|| ||______||
+  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
+  /// ||      || ||      ||
+  /// ||      || ||______||
+  /// ||______|| |        |
+  ///  --------   --------
+  /// ```
+  public var stretchLastComponent = Configuration.stretchLastComponent
+
   /// A KVO context used to monitor changes in contentSize, frames and bounds
   let subviewContext: UnsafeMutableRawPointer? = UnsafeMutableRawPointer(mutating: nil)
 
@@ -91,6 +108,7 @@ open class SpotsScrollView: NSScrollView {
 
   func layoutViews() {
     var yOffsetOfCurrentSubview: CGFloat = CGFloat(self.inset?.top ?? 0.0)
+    let lastView = subviewsInLayoutOrder.last
 
     for subview in subviewsInLayoutOrder {
       if let scrollView = subview as? ScrollView {
@@ -106,6 +124,14 @@ open class SpotsScrollView: NSScrollView {
         if let inset = self.inset {
           frame.size.width -= CGFloat(inset.left + inset.right)
           frame.origin.x = CGFloat(inset.left)
+        }
+
+        if stretchLastComponent && scrollView.isEqual(lastView) {
+          let newHeight = self.frame.size.height - scrollView.frame.origin.y + self.contentOffset.y
+
+          if newHeight >= frame.size.height {
+            frame.size.height = newHeight
+          }
         }
 
         scrollView.frame = frame

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		BD677E8F1DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
 		BD677E901DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
 		BD677E911DC65D63006D1654 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD677E8E1DC65D63006D1654 /* Helpers.swift */; };
+		BD6CB2641ED71C4900FC78C8 /* SpotsScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6CB2631ED71C4900FC78C8 /* SpotsScrollViewTests.swift */; };
 		BD6FBEF01E12B5F000AA58BD /* TestComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */; };
 		BD6FBEF11E12B5F000AA58BD /* TestComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */; };
 		BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */; };
@@ -426,6 +427,7 @@
 		BD677E881DC61EFC006D1654 /* TestStateCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestStateCache.swift; sourceTree = "<group>"; };
 		BD677E8C1DC62575006D1654 /* TestUIViewControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIViewControllerExtensions.swift; sourceTree = "<group>"; };
 		BD677E8E1DC65D63006D1654 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Helpers.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		BD6CB2631ED71C4900FC78C8 /* SpotsScrollViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsScrollViewTests.swift; sourceTree = "<group>"; };
 		BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComposition.swift; sourceTree = "<group>"; };
 		BD73972F1D718CD2000AF2DE /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD7397461D718CDB000AF2DE /* Spots-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Spots-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -920,6 +922,7 @@
 				BD165A361E6EAAA60023AF82 /* TestSpot.swift */,
 				BD165A381E6EAD750023AF82 /* HelperViews.swift */,
 				BDEA327B1E86FC850044B056 /* TestClickInteraction.swift */,
+				BD6CB2631ED71C4900FC78C8 /* SpotsScrollViewTests.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -1845,6 +1848,7 @@
 				D58478E71C440645006EBA49 /* TestComponentModel.swift in Sources */,
 				BD677E901DC65D63006D1654 /* Helpers.swift in Sources */,
 				BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
+				BD6CB2641ED71C4900FC78C8 /* SpotsScrollViewTests.swift in Sources */,
 				BD650CF71ECAC2C100DFD220 /* ItemConfigurableComputeSizeTests.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,

--- a/SpotsTests/macOS/SpotsScrollViewTests.swift
+++ b/SpotsTests/macOS/SpotsScrollViewTests.swift
@@ -1,0 +1,31 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+class SpotsScrollViewTests: XCTestCase {
+
+  func testStetchLastComponent() {
+    let items = [Item(), Item()]
+    let model = ComponentModel(layout: Layout(span: 1), items: items)
+    let controller = SpotsController(components: [Component(model: model), Component(model: model), Component(model: model)])
+    controller.prepareController()
+    controller.view.frame.size = CGSize(width: 100, height: 600)
+    controller.scrollView.layoutViews()
+
+    /// The first and the last component should be equal in height
+    XCTAssertEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
+
+    controller.scrollView.stretchLastComponent = true
+    controller.scrollView.layoutViews()
+
+    /// The first and last component should not be equal as the last one should be stretched.
+    XCTAssertNotEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
+
+    var totalComponentHeight: CGFloat = 0.0
+    for component in controller.components {
+      totalComponentHeight += component.view.frame.size.height
+    }
+
+    XCTAssertEqual(controller.scrollView.frame.size.height, totalComponentHeight)
+  }
+}


### PR DESCRIPTION
With stretch last component, the last component in the collection will
receive the remaining height of the current window. This works the same
way as on iOS and tvOS.