### PR TITLE
Remove the use of <- operator in carousel extension

### DIFF
--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Tailor
 
 extension Component {
 
@@ -18,12 +17,7 @@ extension Component {
     if collectionView.contentSize.height > 0 {
       collectionView.frame.size.height = collectionView.contentSize.height
     } else {
-      var newCollectionViewHeight: CGFloat = 0.0
-
-      newCollectionViewHeight <- model.items.sorted(by: {
-        $0.size.height > $1.size.height
-      }).first?.size.height
-
+      let newCollectionViewHeight: CGFloat = model.items.sorted(by: { $0.size.height > $1.size.height }).first?.size.height ?? 0.0
       collectionView.frame.size.height = newCollectionViewHeight
 
       if collectionView.frame.size.height > 0 {

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -1,5 +1,4 @@
 import Cocoa
-import Tailor
 
 extension Component {
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
@@ -54,10 +53,9 @@ extension Component {
   }
 
   private func calculateCollectionViewHeight() -> CGFloat {
-    var newCollectionViewHeight: CGFloat = 0.0
-    newCollectionViewHeight <- model.items.sorted(by: {
+    var newCollectionViewHeight: CGFloat = model.items.sorted(by: {
       $0.size.height > $1.size.height
-    }).first?.size.height
+    }).first?.size.height ?? 0.0
 
     if let layout = model.layout {
       newCollectionViewHeight *= CGFloat(layout.itemsPerRow)


### PR DESCRIPTION
Removes the use of the `<-` operator when mapping the height of a carousel.
Importing a framework for one tiny operator was a bit overkill. Thanks @vadymmarkov for pointing
it out in https://github.com/hyperoslo/Spots/pull/626/files/c7ad4b25a37f18d43684caec1a99cacb9f5f1569#diff-f26a40b01819b8d192ca9ae6b9ccfac9 ❤️ 