### PR TITLE
Add init(padding:) on Inset

### DIFF
--- a/Sources/Shared/Structs/Inset.swift
+++ b/Sources/Shared/Structs/Inset.swift
@@ -44,6 +44,19 @@ public struct Inset: Mappable, Equatable {
     self.right = right
   }
 
+  /// A convenience initializer with default values.
+  public init() {}
+
+  /// A convenience init for initializing a content inset with the same values for all properties.
+  ///
+  /// - Parameter padding: The amount of inset that should be set for all direction.
+  public init(padding: Double = 0.0) {
+    self.top = padding
+    self.left = padding
+    self.bottom = padding
+    self.right = padding
+  }
+
   /// A convenience init for initializing a content inset using block syntax.
   ///
   /// - Parameter block: A mutating closure.

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -54,9 +54,9 @@
 		BD45D98B1E30909700C2D6B2 /* TestLayoutExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D98A1E30909700C2D6B2 /* TestLayoutExtensions.swift */; };
 		BD45D98C1E30909700C2D6B2 /* TestLayoutExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D98A1E30909700C2D6B2 /* TestLayoutExtensions.swift */; };
 		BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D98E1E30935500C2D6B2 /* TestLayoutExtensions.swift */; };
-		BD45D9951E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
-		BD45D9961E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
-		BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* TestInset.swift */; };
+		BD45D9951E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
+		BD45D9961E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
+		BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
 		BD5CF7371E8B7C57006CC281 /* ComponentResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5CF7361E8B7C57006CC281 /* ComponentResize.swift */; };
 		BD5FC7DF1E857AD900D03038 /* FlippedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5FC7DE1E857AD900D03038 /* FlippedView.swift */; };
 		BD5FE3451EA6222C0008749C /* TestComponentDelegate+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */; };
@@ -416,7 +416,7 @@
 		BD45D9861E30906300C2D6B2 /* TestLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayout.swift; sourceTree = "<group>"; };
 		BD45D98A1E30909700C2D6B2 /* TestLayoutExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayoutExtensions.swift; sourceTree = "<group>"; };
 		BD45D98E1E30935500C2D6B2 /* TestLayoutExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLayoutExtensions.swift; sourceTree = "<group>"; };
-		BD45D9941E30A8A000C2D6B2 /* TestInset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInset.swift; sourceTree = "<group>"; };
+		BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetTests.swift; sourceTree = "<group>"; };
 		BD45D9981E30B0F700C2D6B2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BD45D9991E30B0F700C2D6B2 /* Spots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Spots.podspec; sourceTree = "<group>"; };
 		BD5CF7361E8B7C57006CC281 /* ComponentResize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentResize.swift; sourceTree = "<group>"; };
@@ -1034,7 +1034,7 @@
 				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
 				D584782B1C43FF34006EBA49 /* TestComponentModel.swift */,
 				BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */,
-				BD45D9941E30A8A000C2D6B2 /* TestInset.swift */,
+				BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */,
 				BDEA327E1E87A6FF0044B056 /* TestInteraction.swift */,
 				BDB8D5921E4DFADC00220BC3 /* TestItem.swift */,
 				BD45D9861E30906300C2D6B2 /* TestLayout.swift */,
@@ -1600,7 +1600,7 @@
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
-				BD45D9971E30A8A000C2D6B2 /* TestInset.swift in Sources */,
+				BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1745,7 +1745,7 @@
 				BD21C2541E4358CD00FE2B26 /* TestGridableLayout.swift in Sources */,
 				BDE44B161EA0F0E40021EAC8 /* TestComponentManager.swift in Sources */,
 				BDCA3CF31E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
-				BD45D9951E30A8A000C2D6B2 /* TestInset.swift in Sources */,
+				BD45D9951E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BDEA327F1E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1859,7 +1859,7 @@
 				BD01BD121DAEA523009C10FF /* TestParser.swift in Sources */,
 				BD45D98F1E30935500C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BD45D9881E30906300C2D6B2 /* TestLayout.swift in Sources */,
-				BD45D9961E30A8A000C2D6B2 /* TestInset.swift in Sources */,
+				BD45D9961E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BD6FBEF11E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BDFC47521E747B2B008700BF /* TestListWrapper.swift in Sources */,
 				BD798EF91EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,

--- a/SpotsTests/Shared/InsetTests.swift
+++ b/SpotsTests/Shared/InsetTests.swift
@@ -1,7 +1,7 @@
 @testable import Spots
 import XCTest
 
-class TestInset: XCTestCase {
+class InsetTests: XCTestCase {
 
   let json: [String : Any] = [
     "top": 1.0,
@@ -17,6 +17,15 @@ class TestInset: XCTestCase {
     XCTAssertEqual(contentInset.left, 0.0)
     XCTAssertEqual(contentInset.bottom, 0.0)
     XCTAssertEqual(contentInset.right, 0.0)
+  }
+
+  func testPaddingInit() {
+    let contentInset = Inset(padding: 10)
+
+    XCTAssertEqual(contentInset.top, 10.0)
+    XCTAssertEqual(contentInset.left, 10.0)
+    XCTAssertEqual(contentInset.bottom, 10.0)
+    XCTAssertEqual(contentInset.right, 10.0)
   }
 
   func testJSONMapping() {


### PR DESCRIPTION
Adds a new initializer to easily create an Inset with the same padding on each side.

You can use it like this:

```swift
let inset = Inset(padding: 20)
```

This would give you an `Inset` with all sides having a value of `20`.