### PR TITLE
Refactor size calculations for carousel views.

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -17,14 +17,8 @@ public class ItemManager {
 
     if let layout = component.model.layout, layout.span > 0.0 {
       var componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
-
-      #if !os(OSX)
-        if component.view.frame.size.width == 0.0 {
-          componentWidth = UIScreen.main.bounds.width - CGFloat(layout.inset.left + layout.inset.right)
-        }
-      #endif
-
-      spanWidth = (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
+      componentWidth -= CGFloat(layout.itemSpacing * Double(items.count - 1))
+      spanWidth = (componentWidth / CGFloat(layout.span))
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -18,7 +18,7 @@ public class ItemManager {
     if let layout = component.model.layout, layout.span > 0.0 {
       var componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
       componentWidth -= CGFloat(layout.itemSpacing * Double(items.count - 1))
-      spanWidth = (componentWidth / CGFloat(layout.span))
+      spanWidth = componentWidth / CGFloat(layout.span)
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -69,12 +69,5 @@ extension Component {
     } else {
       footerView?.frame.origin.y = view.frame.size.height - footerHeight
     }
-
-    if let layout = model.layout {
-      headerView?.frame.origin.x = CGFloat(layout.inset.left)
-      footerView?.frame.origin.x = CGFloat(layout.inset.left)
-      headerView?.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
-      footerView?.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
-    }
   }
 }

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -11,11 +11,8 @@ extension Delegate: UIScrollViewDelegate {
         scrollView.contentOffset.y = constrainedYOffset
       }
 
-      let xOffset = CGFloat(component.model.layout?.inset.left ?? 0.0) + scrollView.contentOffset.x
-
       if let footerView = component.footerView {
         footerView.frame.origin.y = scrollView.contentSize.height - footerView.frame.size.height
-        footerView.frame.origin.x = xOffset
       }
 
       if let headerView = component.headerView {
@@ -37,7 +34,6 @@ extension Delegate: UIScrollViewDelegate {
         } else {
           headerView.frame.origin.y = -scrollView.contentOffset.y
         }
-        headerView.frame.origin.x = xOffset
       }
     }
 

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -106,7 +106,8 @@ public class ComponentFlowLayout: FlowLayout {
             itemAttribute.frame.origin.y = nextY
           }
         } else {
-          itemAttribute.frame.origin.y += component.headerHeight
+          itemAttribute.frame.origin.y = component.headerView?.frame.maxY ?? component.headerHeight
+          itemAttribute.frame.origin.y += CGFloat(layout.inset.top)
         }
 
         itemAttribute.frame.origin.x = nextX
@@ -118,7 +119,7 @@ public class ComponentFlowLayout: FlowLayout {
           nextY = itemAttribute.frame.maxY + CGFloat(layout.lineSpacing)
         }
       } else {
-        itemAttribute.frame.origin.y += component.headerHeight
+        itemAttribute.frame.origin.y += CGFloat(layout.inset.top)
       }
 
       attributes.append(itemAttribute)

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -59,7 +59,6 @@ extension Component {
 
     if let layout = model.layout {
       newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
-      newCollectionViewHeight += headerHeight
       newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
 
       if layout.itemsPerRow > 1 {

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -42,11 +42,6 @@ extension Component {
 
   func layoutHeaderFooterViews(_ size: CGSize) {
     headerView?.frame.size.width = size.width
-
-    if let layout = model.layout {
-      headerView?.frame.origin.y = CGFloat(layout.inset.top)
-    }
-
     footerView?.frame.size.width = size.width
     footerView?.frame.origin.y = scrollView.frame.height - footerHeight
   }

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -110,7 +110,9 @@ class TestSpot: XCTestCase {
     let component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
 
-    XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 200))
-    XCTAssertEqual(component.view.contentSize, CGSize(width: 100, height: 200))
+    // Items are 50 in height, headers and footer share the same height of 50
+    // hence the total height being 150.
+    XCTAssertEqual(component.view.frame.size, CGSize(width: 100, height: 150))
+    XCTAssertEqual(component.view.contentSize, CGSize(width: 100, height: 150))
   }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.2.1"
+    version: "8.3"
 
 dependencies:
   override:


### PR DESCRIPTION
When adding layout insets, they should only apply to the collection of
items. Headers and footer should not be affected by this.

Removes an unwanted pre-processor when preparing items. It will no
longer default to use the UIScreen for iOS and tvOS.

The componentWidth calculation has also been improved to properly size
the items when using itemSpacing.