### PR TITLE
Improve ComponentFlowLayout use of layout attributes

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -16,9 +16,8 @@ public class ItemManager {
     var spanWidth: CGFloat?
 
     if let layout = component.model.layout, layout.span > 0.0 {
-      var componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
-      componentWidth -= CGFloat(layout.itemSpacing * Double(items.count - 1))
-      spanWidth = componentWidth / CGFloat(layout.span)
+      let componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
+      spanWidth = (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
     }
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -88,7 +88,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
       contentSize.height += component.headerHeight
       contentSize.height += component.footerHeight
       contentSize.width -= minimumInteritemSpacing
-      contentSize.width += CGFloat(layout.inset.right)
+      contentSize.width += CGFloat(layout.inset.left + layout.inset.right)
 
       if let componentLayout = component.model.layout {
         contentSize.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -58,7 +58,7 @@ public class ComponentFlowLayout: FlowLayout {
       contentSize.height += component.headerHeight
       contentSize.height += component.footerHeight
       contentSize.width -= minimumInteritemSpacing
-      contentSize.width += CGFloat(layout.inset.right)
+      contentSize.width += CGFloat(layout.inset.left + layout.inset.right)
     case .vertical:
       contentSize.width = component.view.frame.width
       contentSize.height = super.collectionViewContentSize.height

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -114,6 +114,9 @@
 		BDA3D96C1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
 		BDA3D96D1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
 		BDA3D96E1EC6F1A400141227 /* ItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA3D96B1EC6F1A400141227 /* ItemManager.swift */; };
+		BDA5EEC01EDD78BD00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */; };
+		BDA5EEC11EDD78BE00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */; };
+		BDA5EEC21EDD78BF00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */; };
 		BDAD84A81E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
 		BDAD84A91E3E701C008289AE /* CarouselSpotHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */; };
 		BDAD84AA1E3E701C008289AE /* SpotsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84841E3E701B008289AE /* SpotsController.swift */; };
@@ -447,6 +450,7 @@
 		BD9ECEC61E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+iOS+HeaderFooter.swift"; sourceTree = "<group>"; };
 		BDA25E8F1EB5070F002B21C0 /* Wrappable+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Wrappable+macOS.swift"; sourceTree = "<group>"; };
 		BDA3D96B1EC6F1A400141227 /* ItemManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemManager.swift; sourceTree = "<group>"; };
+		BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentFlowLayoutSharedTests.swift; sourceTree = "<group>"; };
 		BDAD84831E3E701B008289AE /* CarouselSpotHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselSpotHeader.swift; sourceTree = "<group>"; };
 		BDAD84841E3E701B008289AE /* SpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SpotsController.swift; sourceTree = "<group>"; };
 		BDAD84851E3E701B008289AE /* ComponentFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentFlowLayout.swift; sourceTree = "<group>"; };
@@ -1047,6 +1051,7 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
+				BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1602,6 +1607,7 @@
 				BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */,
 				BD677E911DC65D63006D1654 /* Helpers.swift in Sources */,
 				BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
+				BDA5EEC21EDD78BF00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
@@ -1730,6 +1736,7 @@
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BD677E851DC616B2006D1654 /* ComponentSharedTests.swift in Sources */,
+				BDA5EEC01EDD78BD00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BD45D9871E30906300C2D6B2 /* LayoutTests.swift in Sources */,
 				BDB8D5931E4DFADC00220BC3 /* TestItem.swift in Sources */,
 				BD6FBEF01E12B5F000AA58BD /* TestComposition.swift in Sources */,
@@ -1851,6 +1858,7 @@
 				BD6CB2661ED77F8200FC78C8 /* SpotsScrollViewTests.swift in Sources */,
 				BD650CF71ECAC2C100DFD220 /* ItemConfigurableComputeSizeTests.swift in Sources */,
 				BD10D5261D7955AC00DF8E9B /* TestViewModelExtensions.swift in Sources */,
+				BDA5EEC11EDD78BE00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* ComponentSharedTests.swift in Sources */,

--- a/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
+++ b/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
@@ -1,0 +1,188 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+#if os(macOS)
+  import Cocoa
+#else
+  import UIKit
+#endif
+
+class ComponentFlowLayoutSharedTests: XCTestCase {
+
+  override func setUp() {
+    Configuration.register(view: TestView.self, identifier: ComponentFlowLayoutSharedTests.identifier)
+    Configuration.views.purge()
+  }
+
+  static let identifier: String = "MockIdentifier"
+  var model = ComponentModel(kind: .carousel,
+                             items: (0..<4).flatMap { Item(title: "Test \($0)", kind: identifier) })
+
+  func testRegularCarouselLayout() {
+    let layout = Layout()
+    let (component, flowLayout) = createComponent(with: layout)
+    let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
+
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[2].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[3].size, CGSize(width: 50, height: 50))
+
+    // Check that the layout attributes correspond to the model sizes
+    XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
+    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
+    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
+    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
+
+    // Check that the x coordinate is correct based on padding and item spacing
+    XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
+    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
+    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 100)
+    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 150)
+
+    XCTAssertEqual(flowLayout.contentSize, CGSize(width: 200, height: 50))
+    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
+  }
+
+  func testCarouselLayoutWithSpanOfOne() {
+    let layout = Layout(span: 1)
+    let (component, flowLayout) = createComponent(with: layout)
+    let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
+
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 100, height: 50))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 100, height: 50))
+    XCTAssertEqual(component.model.items[2].size, CGSize(width: 100, height: 50))
+    XCTAssertEqual(component.model.items[3].size, CGSize(width: 100, height: 50))
+
+    // Check that the layout attributes correspond to the model sizes
+    XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
+    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
+    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
+    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
+
+    // Check that the x coordinate is correct based on padding and item spacing
+    XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
+    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 100)
+    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 200)
+    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 300)
+
+    XCTAssertEqual(flowLayout.contentSize, CGSize(width: 400, height: 50))
+    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
+  }
+
+  func testCarouselLayoutWithSpanOfTwo() {
+    let layout = Layout(span: 2)
+    let (component, flowLayout) = createComponent(with: layout)
+    let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
+
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[2].size, CGSize(width: 50, height: 50))
+    XCTAssertEqual(component.model.items[3].size, CGSize(width: 50, height: 50))
+
+    // Check that the layout attributes correspond to the model sizes
+    XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
+    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
+    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
+    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
+
+    // Check that the x coordinate is correct based on padding and item spacing
+    XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
+    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
+    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 100)
+    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 150)
+
+    XCTAssertEqual(flowLayout.contentSize, CGSize(width: 200, height: 50))
+
+    // Check that the content size is equal to the last layout attribute
+    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
+  }
+
+  func testCarouselLayoutWithSpanOfOneWithInsetOfTen() {
+    let layout = Layout(span: 1, inset: Inset(padding: 10))
+    let (component, flowLayout) = createComponent(with: layout)
+    let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
+
+    // The width should be 80 because the component size is 100 and it has 10 in padding on each side.
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 80, height: 50))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 80, height: 50))
+    XCTAssertEqual(component.model.items[2].size, CGSize(width: 80, height: 50))
+    XCTAssertEqual(component.model.items[3].size, CGSize(width: 80, height: 50))
+
+    // Check that the layout attributes correspond to the model sizes
+    XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
+    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
+    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
+    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
+
+    // Check that the x coordinate is correct based on padding and item spacing
+    XCTAssertEqual(layoutAttributes[0].frame.origin.x, 10)
+    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 90)
+    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 170)
+    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 250)
+
+    // The total content size should be the width of the items + padding on each side.
+    // In this case that should be the current formula:
+    // $totalItemWidth + $leftInset + $rightInset
+    //     80 * 4      +     10     +     10
+    XCTAssertEqual(flowLayout.contentSize, CGSize(width: 340, height: 70))
+
+    // Check that the content size is equal to the last layout attribute plus right padding
+    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX + 10)
+  }
+
+  func testCarouselLayoutWithSpanOfTwoWithPaddingAndItemSpacing() {
+    let layout = Layout(span: 2, itemSpacing: 10, inset: Inset(padding: 10))
+    let (component, flowLayout) = createComponent(with: layout)
+    let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
+
+    // The width should be the width of the component (100) divided by 2, then minus the padding which
+    // is 10 on each side. We also have an item spacing of 10.
+    XCTAssertEqual(component.model.items[0].size, CGSize(width: 30, height: 50))
+    XCTAssertEqual(component.model.items[1].size, CGSize(width: 30, height: 50))
+    XCTAssertEqual(component.model.items[2].size, CGSize(width: 30, height: 50))
+    XCTAssertEqual(component.model.items[3].size, CGSize(width: 30, height: 50))
+
+    // Check that the layout attributes correspond to the model sizes
+    XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
+    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
+    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
+    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
+
+    // Check that the x coordinate is correct based on padding and item spacing
+    XCTAssertEqual(layoutAttributes[0].frame.origin.x, 10)
+    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
+    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 90)
+    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 130)
+
+    // In this case that should be the current formula:
+    // $totalItemWidth + $leftInset + $rightInset + ($itemSpacing * $numberOfItems - $itemSpacing)
+    //     30 * 4      +     10     +     10      + (     10      *       4        - 10  )
+    XCTAssertEqual(flowLayout.contentSize, CGSize(width: 170, height: 70))
+    // Check that the content size is equal to the last layout attribute plus right padding
+    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX + 10)
+  }
+
+  private func createComponent(with layout: Layout) -> (Component, ComponentFlowLayout) {
+    var model = self.model
+    model.layout = layout
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    return (component, component.collectionView?.collectionViewLayout as! ComponentFlowLayout)
+  }
+}
+
+extension ComponentFlowLayout {
+
+  #if os(macOS)
+  fileprivate func sharedLayoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
+    return layoutAttributesForElements(in: rect)
+  }
+  #else
+  fileprivate func sharedLayoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes] {
+    return layoutAttributesForElements(in: rect)!
+  }
+  #endif
+}

--- a/SpotsTests/iOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/iOS/ComponentFlowLayoutTests.swift
@@ -60,7 +60,7 @@ class ComponentFlowLayoutTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(collectionView.contentSize, CGSize(width: 125, height: 150))
+    XCTAssertEqual(collectionView.contentSize, CGSize(width: 150, height: 150))
     XCTAssertEqual(carouselComponent.view.frame.size, CGSize(width: 100, height: 150))
   }
 


### PR DESCRIPTION
Adds a collection of shared tests to verify that both macOS and
iOS/tvOS share the same results when using layout attributes for
carousel components.

It reverts a previous change that caused the layout to not render
correctly. These changes are verified by the new shared
ComponentFlowLayoutSharedTests.