### PR TITLE
Scope SpotsRefreshControl to only be available on iOS

### DIFF
--- a/Sources/iOS/Classes/SpotsRefreshControl.swift
+++ b/Sources/iOS/Classes/SpotsRefreshControl.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import UIKit
 
 /// A custom refresh control that makes sure that endRefreshing is only called
@@ -13,3 +14,4 @@ class SpotsRefreshControl: UIRefreshControl {
     }
   }
 }
+#endif


### PR DESCRIPTION
This broke the tvOS build when trying to release on cocoa pods has
UIRefreshControl is marked as unavailable.