### PR TITLE
Improve scrolling behavior when using multiple horizontal components

### DIFF
--- a/Sources/iOS/Classes/ComponentCollectionView.swift
+++ b/Sources/iOS/Classes/ComponentCollectionView.swift
@@ -3,7 +3,7 @@ import UIKit
 /// ComponentCollectionView is a very simple subclass of UICollectionView.
 /// The purpose of this class is to forward `layoutSubviews` to the `Component`.
 /// This is used to perform infinite scrolling for horizontal layouts.
-class ComponentCollectionView: UICollectionView {
+class ComponentCollectionView: UICollectionView, UIGestureRecognizerDelegate {
 
   /// The component that the collection view belongs too.
   weak var component: Component?

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -2,7 +2,7 @@ import UIKit
 import QuartzCore
 
 /// The core foundation scroll view inside of Spots that manages the linear layout of all components.
-open class SpotsScrollView: UIScrollView {
+open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
   /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
   /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
@@ -309,5 +309,9 @@ open class SpotsScrollView: UIScrollView {
   private func compare(rect lhs: CGRect, to rhs: CGRect?) -> Bool {
     guard let rhs = rhs else { return false }
     return lhs.integral.equalTo(rhs.integral)
+  }
+
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return true
   }
 }

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -52,4 +52,10 @@ extension SpotsController {
       }
     }
   }
+
+  public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    for case let componentView as ScrollView in self.scrollView.componentsView.subviews where !componentView.panGestureRecognizer.isEnabled {
+      componentView.panGestureRecognizer.isEnabled = true
+    }
+  }
 }


### PR DESCRIPTION
Implements `UIGestureRecognizerDelegate` on `ComponentCollectionView` and `SpotsScrollView`.
It will no hand out precedence to who ever should get the pan gesture based on how the user scrolls.

Also fixes issues when scrolling horizontal components that are not fully visible, the constraint code has been refactored to adjust the content offset accordingly.