### PR TITLE
Implement makeView on Registry

### DIFF
--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -113,4 +113,17 @@ public struct Registry {
 
     return (type: registryType, view: view)
   }
+
+  /// Construct a view from an `Item`.
+  ///
+  /// - Parameters:
+  ///   - item: An `Item` struct used to create the view.
+  ///   - frame: The frame that should be applied to the view.
+  /// - Returns: An optional view created based of the `Item`.
+  public func makeView<T: View>(from item: Spots.Item, with frame: CGRect) -> T? {
+    let view = make(item.kind)?.view as? T
+    (view as? ItemConfigurable)?.configure(with: item)
+    view?.frame = frame
+    return view
+  }
 }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -319,6 +319,9 @@
 		BDDF2CCC1DC7C23500B766BA /* TestAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */; };
 		BDDF2CCD1DC7C23500B766BA /* TestAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */; };
 		BDDF2CD01DC7C50700B766BA /* TestAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */; };
+		BDE3864A1EFAEA5200320A6D /* RegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE386491EFAEA5200320A6D /* RegistryTests.swift */; };
+		BDE3864B1EFAEA5200320A6D /* RegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE386491EFAEA5200320A6D /* RegistryTests.swift */; };
+		BDE3864C1EFAEA5200320A6D /* RegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE386491EFAEA5200320A6D /* RegistryTests.swift */; };
 		BDE44B0F1EA0E5E80021EAC8 /* ComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE44B0E1EA0E5E80021EAC8 /* ComponentManager.swift */; };
 		BDE44B101EA0E5E80021EAC8 /* ComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE44B0E1EA0E5E80021EAC8 /* ComponentManager.swift */; };
 		BDE44B111EA0E5E80021EAC8 /* ComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE44B0E1EA0E5E80021EAC8 /* ComponentManager.swift */; };
@@ -543,6 +546,7 @@
 		BDDCF6EE1E4DF93D004B38C4 /* DictionaryConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryConvertible.swift; sourceTree = "<group>"; };
 		BDDF2CCB1DC7C23500B766BA /* TestAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnimations.swift; sourceTree = "<group>"; };
 		BDDF2CCF1DC7C50700B766BA /* TestAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAnimations.swift; sourceTree = "<group>"; };
+		BDE386491EFAEA5200320A6D /* RegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryTests.swift; sourceTree = "<group>"; };
 		BDE44B0E1EA0E5E80021EAC8 /* ComponentManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentManager.swift; sourceTree = "<group>"; };
 		BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestComponentManager.swift; sourceTree = "<group>"; };
 		BDEA327B1E86FC850044B056 /* TestClickInteraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestClickInteraction.swift; sourceTree = "<group>"; };
@@ -1033,15 +1037,17 @@
 		D584782A1C43FF34006EBA49 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */,
 				BD677E841DC616B2006D1654 /* ComponentSharedTests.swift */,
 				BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */,
 				BD677E8E1DC65D63006D1654 /* Helpers.swift */,
+				BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */,
 				BD650CF51ECAC2C100DFD220 /* ItemConfigurableComputeSizeTests.swift */,
 				BD45D9861E30906300C2D6B2 /* LayoutTests.swift */,
+				BDE386491EFAEA5200320A6D /* RegistryTests.swift */,
 				BDE44B121EA0F0C90021EAC8 /* TestComponentManager.swift */,
 				D584782B1C43FF34006EBA49 /* TestComponentModel.swift */,
 				BD6FBEEF1E12B5F000AA58BD /* TestComposition.swift */,
-				BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */,
 				BDEA327E1E87A6FF0044B056 /* TestInteraction.swift */,
 				BDB8D5921E4DFADC00220BC3 /* TestItem.swift */,
 				BD01BD0D1DAEA464009C10FF /* TestParser.swift */,
@@ -1050,7 +1056,6 @@
 				BD677E881DC61EFC006D1654 /* TestStateCache.swift */,
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD10D5211D79533C00DF8E9B /* TestViewModelExtensions.swift */,
-				BDA5EEBE1EDD77DD00B18214 /* ComponentFlowLayoutSharedTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1609,6 +1614,7 @@
 				BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */,
 				BDA5EEC21EDD78BF00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BD6FBEF21E12B5F000AA58BD /* TestComposition.swift in Sources */,
+				BDE3864C1EFAEA5200320A6D /* RegistryTests.swift in Sources */,
 				BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 			);
@@ -1737,6 +1743,7 @@
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BD677E851DC616B2006D1654 /* ComponentSharedTests.swift in Sources */,
+				BDE3864A1EFAEA5200320A6D /* RegistryTests.swift in Sources */,
 				BDA5EEC01EDD78BD00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BD45D9871E30906300C2D6B2 /* LayoutTests.swift in Sources */,
 				BDB8D5931E4DFADC00220BC3 /* TestItem.swift in Sources */,
@@ -1863,6 +1870,7 @@
 				BDA5EEC11EDD78BE00B18214 /* ComponentFlowLayoutSharedTests.swift in Sources */,
 				BDEA32801E87A6FF0044B056 /* TestInteraction.swift in Sources */,
 				BD165A391E6EAD750023AF82 /* HelperViews.swift in Sources */,
+				BDE3864B1EFAEA5200320A6D /* RegistryTests.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* ComponentSharedTests.swift in Sources */,
 				BDB1FCBA1ECEE6140042ED61 /* ComponentFlowLayoutTests.swift in Sources */,
 				BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,

--- a/SpotsTests/Shared/RegistryTests.swift
+++ b/SpotsTests/Shared/RegistryTests.swift
@@ -23,7 +23,7 @@ class RegistryTests: XCTestCase {
   func testCreatingView() {
     let frame = CGRect(origin: .zero, size: .init(width: 50, height: 50))
     let item = Item(title: "foo", kind: "registry-mock")
-    let view: RegistryViewMock? = Configuration.views.makeView(from: item, frame: frame)
+    let view: RegistryViewMock? = Configuration.views.makeView(from: item, with: frame)
 
     XCTAssertNotNil(view)
     XCTAssertEqual(view?.frame, frame)

--- a/SpotsTests/Shared/RegistryTests.swift
+++ b/SpotsTests/Shared/RegistryTests.swift
@@ -1,0 +1,33 @@
+@testable import Spots
+import XCTest
+
+class RegistryTests: XCTestCase {
+
+  class RegistryViewMock: View, ItemConfigurable {
+    var title: String = ""
+
+    func configure(with item: Item) {
+      title = item.title
+    }
+
+    func computeSize(for item: Item) -> CGSize {
+      return .zero
+    }
+  }
+
+  override func setUp() {
+    super.setUp()
+    Configuration.register(view: RegistryViewMock.self, identifier: "registry-mock")
+  }
+
+  func testCreatingView() {
+    let frame = CGRect(origin: .zero, size: .init(width: 50, height: 50))
+    let item = Item(title: "foo", kind: "registry-mock")
+    let view: RegistryViewMock? = Configuration.views.makeView(from: item, frame: frame)
+
+    XCTAssertNotNil(view)
+    XCTAssertEqual(view?.frame, frame)
+    XCTAssertEqual(view?.title, item.title)
+  }
+
+}


### PR DESCRIPTION
`makeView(from item: Item, with frame: CGRect)` can be used to create views based of an `Item`. This is useful when you need to make a copy of a view that should not be bound by the reusability boundaries of Spots internal mechanisms.