### PR TITLE
Update/cache version

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "ReactiveX/RxSwift" "3.5.0"
-github "hyperoslo/Cache" "199a19a445fe5c5db1f75b59d65a220fc96ed8ea"
-github "onmyway133/SwiftHash" "1.3.0"
+github "hyperoslo/Cache" "3.3.0"
+github "onmyway133/SwiftHash" "1.4.0"
 github "zenangst/Tailor" "2.2.1"

--- a/Sources/Shared/Structs/StateCache.swift
+++ b/Sources/Shared/Structs/StateCache.swift
@@ -76,7 +76,7 @@ public struct StateCache {
 
   /// Clear the current StateCache
   public func clear(completion: (() -> Void)? = nil) {
-    try? cache.clear()
+    try? cache.clear(keepingRootDirectory: true)
     completion?()
   }
 

--- a/SpotsTests/Shared/TestStateCache.swift
+++ b/SpotsTests/Shared/TestStateCache.swift
@@ -40,7 +40,7 @@ class StateCacheTests: XCTestCase {
 
   func testRemovingStateCacheFromController() {
     let expectation = self.expectation(description: "Clear state cache")
-    controller.stateCache?.clear {
+    controller.stateCache?.clear() {
       XCTAssertEqual(self.controller.stateCache!.load().count, 0)
       XCTAssertEqual(self.controller.stateCache!.cacheExists, false)
       expectation.fulfill()

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -48,10 +48,10 @@ class TestSpot: XCTestCase {
       let cachedSpot = Component(cacheKey: cacheKey)
       XCTAssertEqual(cachedSpot.model.items[0].title, "test")
       XCTAssertEqual(cachedSpot.model.items.count, 1)
-      cachedSpot.stateCache?.clear()
+      cachedSpot.stateCache?.clear(keepingRootDirectory: true)
       expectation.fulfill()
 
-      cachedSpot.stateCache?.clear()
+      cachedSpot.stateCache?.clear(keepingRootDirectory: true)
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }

--- a/SpotsTests/macOS/TestSpot.swift
+++ b/SpotsTests/macOS/TestSpot.swift
@@ -48,10 +48,10 @@ class TestSpot: XCTestCase {
       let cachedSpot = Component(cacheKey: cacheKey)
       XCTAssertEqual(cachedSpot.model.items[0].title, "test")
       XCTAssertEqual(cachedSpot.model.items.count, 1)
-      cachedSpot.stateCache?.clear(keepingRootDirectory: true)
+      cachedSpot.stateCache?.clear()
       expectation.fulfill()
 
-      cachedSpot.stateCache?.clear(keepingRootDirectory: true)
+      cachedSpot.stateCache?.clear()
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }


### PR DESCRIPTION
This updates Carthage to use the latest version of `Cache` (3.3.0).
`StateCache` will no use `keepingRootDirectory` set to `true`.