### PR TITLE
Remove making a copy of the attributes before caching them

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -168,12 +168,10 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
         attributes.append(itemAttribute)
 
-        if let itemAttributeCopy = itemAttribute.copy() as? UICollectionViewLayoutAttributes {
-          if index >= cachedFrames.count {
-            cachedFrames.append(itemAttribute.frame)
-          } else {
-            cachedFrames[index] = itemAttribute.frame
-          }
+        if index >= cachedFrames.count {
+          cachedFrames.append(itemAttribute.frame)
+        } else {
+          cachedFrames[index] = itemAttribute.frame
         }
       }
     }


### PR DESCRIPTION
`itemAttributeCopy` was never used so it was redundant to make a copy
of the object.