### PR TITLE
Change "RxCocoa" version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - Carthage
 
 before_install:
-  - travis_wait 35; bin/bootstrap-if-needed
+  - carthage bootstrap --platform macOS
 
 script:
   - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode8.2
+osx_image: xcode8.3
 language: objective-c
 
 cache:

--- a/Spots.podspec
+++ b/Spots.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.subspec "RxSwift" do |ss|
     ss.source_files = "RxSpots/**/*"
     ss.dependency "Spots/Core"
-    ss.dependency "RxCocoa", "~> 3.2.0"
+    ss.dependency "RxCocoa", "~> 3.0"
   end
 
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }

--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,8 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-    - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
-    - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.3"
+    version: "8.3.3"
 
 dependencies:
   override:
@@ -11,6 +11,8 @@ dependencies:
 
 test:
   override:
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'

--- a/circle.yml
+++ b/circle.yml
@@ -13,10 +13,13 @@ test:
   override:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash) -cF osx -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
+    - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
-    - bash <(curl -s https://codecov.io/bash)
+


### PR DESCRIPTION
It should be safe to point to ~3.0, so we get versions with not breaking changes.