### PR TITLE
Set masksToBounds to false on UITableView and UICollectionView

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -226,6 +226,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     collectionView.backgroundView = backgroundView
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
+    collectionView.layer.masksToBounds = false
 
     guard model.kind == .carousel else {
       return

--- a/Sources/iOS/Extensions/Component+iOS+List.swift
+++ b/Sources/iOS/Extensions/Component+iOS+List.swift
@@ -6,6 +6,7 @@ extension Component {
     tableView.dataSource = componentDataSource
     tableView.delegate = componentDelegate
     tableView.rowHeight = UITableViewAutomaticDimension
+    tableView.layer.masksToBounds = false
     tableView.frame.size = size
     tableView.frame.size.width = round(size.width - (tableView.contentInset.left))
     tableView.frame.origin.x = round(size.width / 2 - tableView.frame.width / 2)


### PR DESCRIPTION
If maskToBounds is not set to false, the animation for the first item in the row won't work for collection views. This also opens up for better animations as they won't be cut-off if the animation happens outside of the view.