### PR TITLE
Return .zero height when there are now items

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -16,7 +16,11 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     guard let delegate = collectionView?.delegate as? Delegate,
       let component = delegate.component
       else {
-        return CGSize.zero
+        return .zero
+    }
+
+    guard !component.model.items.isEmpty else {
+      return .zero
     }
 
     if scrollDirection != .horizontal {


### PR DESCRIPTION
Adds a guard in `collectionViewContentSize` to return .zero if the component has no items.
We do this so that component with insets don't appear on screen if they are empty.