### PR TITLE
Opt-out from doing diffing if the controller is empty

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -79,6 +79,16 @@ public class SpotsControllerManager {
       return
     }
 
+    // Opt-out from performing any kind of diffing if the controller has no components.
+    if controller.components.isEmpty {
+      reload(models: components, controller: controller) {
+        controller.scrollView.layoutViews()
+        SpotsController.componentsDidReloadComponentModels?(controller)
+        completion?()
+      }
+      return
+    }
+
     Dispatch.interactive { [weak self] in
       guard let strongSelf = self else {
         completion?()


### PR DESCRIPTION
To increase performance, `reloadIfNeeded` now opts-out of doing any diffing if the controller has no components.