### PR TITLE
Refactor for-loop to use better naming

### DIFF
--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -130,9 +130,9 @@ extension UICollectionView: UserInterface {
     performBatchUpdates({
       self.insertItems(at: indexPaths)
 
-      for move in movedItems {
-        self.moveItem(at: IndexPath(item: move.key, section: 0),
-                      to: IndexPath(item: move.value, section: 0))
+      for (from, to) in movedItems {
+        self.moveItem(at: IndexPath(item: from, section: 0),
+                      to: IndexPath(item: to, section: 0))
       }
 
     }, completion: nil)
@@ -181,9 +181,9 @@ extension UICollectionView: UserInterface {
       guard let strongSelf = self else {
         return
       }
-      for move in movedItems {
-        strongSelf.moveItem(at: IndexPath(item: move.key, section: 0),
-                            to: IndexPath(item: move.value, section: 0))
+      for (from, to) in movedItems {
+        strongSelf.moveItem(at: IndexPath(item: from, section: 0),
+                            to: IndexPath(item: to, section: 0))
       }
       strongSelf.deleteItems(at: indexPaths)
 

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -123,9 +123,9 @@ extension UITableView: UserInterface {
 
     performUpdates {
       insertRows(at: indexPaths, with: animation.tableViewAnimation)
-      for move in movedItems {
-        moveRow(at: IndexPath(row: move.key, section: 0),
-                to: IndexPath(row: move.value, section: 0))
+      for (from, to) in movedItems {
+        moveRow(at: IndexPath(row: from, section: 0),
+                to: IndexPath(row: to, section: 0))
       }
     }
 
@@ -181,9 +181,9 @@ extension UITableView: UserInterface {
 
     performUpdates {
       deleteRows(at: indexPaths, with: animation.tableViewAnimation)
-      for move in movedItems {
-        moveRow(at: IndexPath(item: move.key, section: 0),
-                to: IndexPath(item: move.value, section: 0))
+      for (from, to) in movedItems {
+        moveRow(at: IndexPath(item: from, section: 0),
+                to: IndexPath(item: to, section: 0))
       }
     }
 

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -78,9 +78,9 @@ extension NSCollectionView: UserInterface {
         return
       }
       strongSelf.insertItems(at: set as Set<IndexPath>)
-      for move in movedItems {
-        strongSelf.moveItem(at: IndexPath(item: move.key, section: 0),
-                            to: IndexPath(item: move.value, section: 0))
+      for (from, to) in movedItems {
+        strongSelf.moveItem(at: IndexPath(item: from, section: 0),
+                            to: IndexPath(item: to, section: 0))
       }
     }) { _ in
       completion?()
@@ -125,9 +125,9 @@ extension NSCollectionView: UserInterface {
         return
       }
       strongSelf.deleteItems(at: set as Set<IndexPath>)
-      for move in movedItems {
-        strongSelf.moveItem(at: IndexPath(item: move.key, section: 0),
-                            to: IndexPath(item: move.value, section: 0))
+      for (from, to) in movedItems {
+        strongSelf.moveItem(at: IndexPath(item: from, section: 0),
+                            to: IndexPath(item: to, section: 0))
       }
     }) { _ in
       completion?()

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -54,8 +54,8 @@ extension NSTableView: UserInterface {
 
     performUpdates({
       insertRows(at: indexSet, withAnimation: animation.tableViewAnimation)
-      for move in movedItems {
-        moveRow(at: move.key, to: move.value)
+      for (from, to) in movedItems {
+        moveRow(at: from, to: to)
       }
     }, endClosure: completion)
 
@@ -103,9 +103,8 @@ extension NSTableView: UserInterface {
     indexes.forEach { indexSet.insert($0) }
 
     performUpdates({
-      for move in movedItems {
-        moveRow(at: move.key,
-                to: move.value)
+      for (from, to) in movedItems {
+        moveRow(at: from, to: to)
       }
       removeRows(at: indexSet, withAnimation: animation.tableViewAnimation)
     }, endClosure: completion)


### PR DESCRIPTION
Instead of saying `move.key` and `move.value`, we assign key and value
to `from` and `to` which makes it a lot more clear what the values are
without going to the algorithm to look up what the values represent.