### PR TITLE
Prepare items before calling layout in carousel extension

### DIFF
--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -42,14 +42,8 @@ extension Component {
   }
 
   func resizeHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize, type: ComponentResize) {
-    switch type {
-    case .live:
-      layout(with: size)
-      prepareItems(recreateComposites: false)
-    case .end:
-      layout(with: size)
-      prepareItems(recreateComposites: false)
-    }
+    prepareItems(recreateComposites: false)
+    layout(with: size)
   }
 
   private func calculateCollectionViewHeight() -> CGFloat {


### PR DESCRIPTION
The items need to be prepared before calling layout, if they are not
prepared the collection view layout will show a warning that the item
is to big for the layout. This is because it is using the old size and
not the new one based of the new window size. This happens when you
resize the window that the component belongs too.