### PR TITLE
Fix bug in ComponentManager.insert

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -120,7 +120,7 @@ public class ComponentManager {
       }
 
       if numberOfItems > 0 {
-        self?.itemManager.configureItem(at: numberOfItems, component: component, usesViewSize: true)
+        self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
         component.userInterface?.insert(indexes, withAnimation: animation) {
           self?.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
         }


### PR DESCRIPTION
Fixes bug where inserted item is not configured properly. The reason is that the item manager gets the wrong index, it needs to get the item index, not the number of items in the collection.