### PR TITLE
Apply animation after guard

### DIFF
--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -205,7 +205,6 @@ extension UICollectionView: UserInterface {
                       withAnimation animation: Animation = .automatic,
                       updateDataSource: () -> Void,
                       completion: ((()) -> Void)? = nil) {
-    applyAnimation(animation: animation)
     let insertions = changes.insertions.map { IndexPath(row: $0, section: 0) }
     let reloads = changes.reloads.map { IndexPath(row: $0, section: 0) }
     let deletions = changes.deletions.map { IndexPath(row: $0, section: 0) }
@@ -220,6 +219,8 @@ extension UICollectionView: UserInterface {
       completion?()
       return
     }
+
+    applyAnimation(animation: animation)
 
     if animation == .none {
       UIView.performWithoutAnimation {


### PR DESCRIPTION
Move the applyAnimation invocation so that the collection view never
ends up using the wrong animation. If the collection view were to stop
at the guard demeaning that there is nothing to update, the collection
view layout would stil store the animation which is not what we want.
Moving applying the animation fixes this issue.