### PR TITLE
Implement height adjustments for carousel items

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -14,6 +14,8 @@ public class ItemManager {
   func prepare(component: Component, items: [Item], recreateComposites: Bool) -> [Item] {
     var preparedItems = items
     var spanWidth: CGFloat?
+    var shouldAdjustHeight = component.model.kind == .carousel ? true : false
+    var largestHeight: CGFloat = 0.0
 
     if let layout = component.model.layout, layout.span > 0.0 {
       let componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
@@ -29,6 +31,16 @@ public class ItemManager {
       if let configuredItem = configure(component: component, item: item, at: index, usesViewSize: true, recreateComposites: recreateComposites) {
         preparedItems[index].index = index
         preparedItems[index] = configuredItem
+      }
+
+      if shouldAdjustHeight && preparedItems[index].size.height > largestHeight {
+        largestHeight = preparedItems[index].size.height
+      }
+    }
+
+    if shouldAdjustHeight {
+      for element in preparedItems.indices {
+        preparedItems[element].size.height = largestHeight
       }
     }
 
@@ -50,6 +62,16 @@ public class ItemManager {
       component.model.items[index] = configuredItem
     } else {
       component.model.items[index] = configuredItem
+    }
+
+    guard component.model.kind == .carousel ? true : false else {
+      return
+    }
+
+    if var largestHeight: CGFloat = component.model.items.sorted(by: { $0.size.height > $1.size.height }).first?.size.height {
+      for element in component.model.items.indices {
+        component.model.items[index].size.height = largestHeight
+      }
     }
   }
 

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -68,9 +68,9 @@ public class ItemManager {
       return
     }
 
-    if var largestHeight: CGFloat = component.model.items.sorted(by: { $0.size.height > $1.size.height }).first?.size.height {
-      for element in component.model.items.indices {
-        component.model.items[index].size.height = largestHeight
+    if let largestHeight: CGFloat = component.model.items.sorted(by: { $0.size.height > $1.size.height }).first?.size.height {
+      for element in component.model.items.indices.enumerated() {
+        component.model.items[element.offset].size.height = largestHeight
       }
     }
   }

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -14,7 +14,7 @@ public class ItemManager {
   func prepare(component: Component, items: [Item], recreateComposites: Bool) -> [Item] {
     var preparedItems = items
     var spanWidth: CGFloat?
-    var shouldAdjustHeight = component.model.kind == .carousel ? true : false
+    var shouldAdjustHeight = component.model.kind == .carousel
     var largestHeight: CGFloat = 0.0
 
     if let layout = component.model.layout, layout.span > 0.0 {
@@ -64,7 +64,7 @@ public class ItemManager {
       component.model.items[index] = configuredItem
     }
 
-    guard component.model.kind == .carousel ? true : false else {
+    guard component.model.kind == .carousel else {
       return
     }
 


### PR DESCRIPTION
If you have dynamic cells in a carousel, it will no use the largest
item in the collection and use that size for everything in the
collection.

## Before
<img width="560" alt="screen shot 2017-07-03 at 10 15 45" src="https://user-images.githubusercontent.com/57446/27783989-b078d1e8-5fd8-11e7-818d-5cb0b46cacc2.png">


## After
<img width="551" alt="screen shot 2017-07-03 at 10 16 04" src="https://user-images.githubusercontent.com/57446/27783998-b6c703da-5fd8-11e7-96d8-b8f18861f945.png">
