### PR TITLE
Implement showEmptyComponent on Layout

### DIFF
--- a/Sources/Shared/Structs/Layout.swift
+++ b/Sources/Shared/Structs/Layout.swift
@@ -27,6 +27,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     case dynamicHeight = "dynamic-height"
     case pageIndicator = "page-indicator"
     case headerMode = "header-mode"
+    case showEmptyComponent = "show-empty-component"
     case infiniteScrolling = "infinite-scrolling"
   }
 
@@ -50,7 +51,6 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// |item 1|item 3|
   /// |item 2|item 4|
   public var itemsPerRow: Int = 1
-
   /// Defines how many items to show per row for `Gridable` components.
   public var span: Double = 0.0
   /// If enabled and the item count is less than the span, the CarouselComponent will even out the space between the items to align them.
@@ -68,6 +68,8 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   /// See `Component.handleInfiniteScrolling()` for more information.
   /// Note: Only available iOS and tvOS. 
   public var infiniteScrolling: Bool = false
+  /// If the `ComponentModel` is empty, it should still be shown.
+  public var showEmptyComponent: Bool = false
 
   /// A dictionary representation of the struct.
   public var dictionary: [String : Any] {
@@ -80,6 +82,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
       Key.dynamicSpan.rawValue: dynamicSpan,
       Key.dynamicHeight.rawValue: dynamicHeight,
       Key.headerMode.rawValue: headerMode.rawValue,
+      Key.showEmptyComponent.rawValue: showEmptyComponent,
       Key.infiniteScrolling.rawValue: infiniteScrolling
     ]
 
@@ -103,7 +106,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
   ///   - itemSpacing: Sets minimum item spacing for the model.
   ///   - lineSpacing: Sets minimum lines spacing for items in model.
   ///   - inset: An inset struct used to insert margins for the model.
-  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemsPerRow: Int = 1, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init(), headerMode: HeaderMode = .default, infiniteScrolling: Bool = false) {
+  public init(span: Double = 0.0, dynamicSpan: Bool = false, dynamicHeight: Bool = true, pageIndicatorPlacement: PageIndicatorPlacement? = nil, itemsPerRow: Int = 1, itemSpacing: Double = 0.0, lineSpacing: Double = 0.0, inset: Inset = .init(), headerMode: HeaderMode = .default, showEmptyComponent: Bool = false, infiniteScrolling: Bool = false) {
     self.span = span
     self.dynamicSpan = dynamicSpan
     self.dynamicHeight = dynamicHeight
@@ -113,6 +116,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     self.inset = inset
     self.pageIndicatorPlacement = pageIndicatorPlacement
     self.headerMode = headerMode
+    self.showEmptyComponent = showEmptyComponent
     self.infiniteScrolling = infiniteScrolling
   }
 
@@ -141,6 +145,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     self.span <- map.double(Key.span.rawValue)
     self.pageIndicatorPlacement = map.enum(Key.pageIndicator.rawValue)
     self.headerMode <- map.enum(Key.headerMode.rawValue)
+    self.showEmptyComponent <- map.boolean(Key.showEmptyComponent.rawValue)
     self.infiniteScrolling <- map.boolean(Key.infiniteScrolling.rawValue)
   }
 
@@ -169,6 +174,7 @@ public struct Layout: Mappable, DictionaryConvertible, Equatable {
     lhs.dynamicSpan == rhs.dynamicSpan &&
     lhs.dynamicHeight == rhs.dynamicHeight &&
     lhs.pageIndicatorPlacement == rhs.pageIndicatorPlacement &&
+    lhs.showEmptyComponent == rhs.showEmptyComponent &&
     lhs.headerMode == rhs.headerMode &&
     lhs.infiniteScrolling == rhs.infiniteScrolling
   }

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -21,12 +21,13 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
   // Subclasses must override this method and use it to return the width and height of the collection view’s content. These values represent the width and height of all the content, not just the content that is currently visible. The collection view uses this information to configure its own content size to facilitate scrolling.
   open override var collectionViewContentSize: CGSize {
     guard let delegate = collectionView?.delegate as? Delegate,
-      let component = delegate.component
+      let component = delegate.component,
+      let layout = component.model.layout
       else {
         return .zero
     }
 
-    guard !component.model.items.isEmpty else {
+    guard !component.model.items.isEmpty, !layout.showEmptyComponent else {
       return .zero
     }
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -243,8 +243,11 @@ import Tailor
     }
 
     layoutHeaderFooterViews(size)
-
     view.layoutSubviews()
+
+    if let layout = model.layout, model.items.isEmpty, !layout.showEmptyComponent {
+      view.frame.size.height = 0
+    }
   }
 
   /// Setup a collection view with a specific size.

--- a/SpotsTests/Shared/LayoutTests.swift
+++ b/SpotsTests/Shared/LayoutTests.swift
@@ -16,7 +16,8 @@ class LayoutTests: XCTestCase {
       "right": 4.0
     ],
     "header-mode": "sticky",
-    "infinite-scrolling": true
+    "infinite-scrolling": true,
+    "show-empty-component": true
   ]
 
   func testDefaultValues() {
@@ -32,6 +33,7 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(layout.headerMode, .default)
     XCTAssertEqual(layout.pageIndicatorPlacement, nil)
     XCTAssertEqual(layout.infiniteScrolling, false)
+    XCTAssertEqual(layout.showEmptyComponent, false)
   }
 
   func testRegularInit() {
@@ -42,6 +44,7 @@ class LayoutTests: XCTestCase {
                         lineSpacing: 20.0,
                         inset: Inset(top: 10.0),
                         headerMode: .sticky,
+                        showEmptyComponent: true,
                         infiniteScrolling: true)
 
     XCTAssertEqual(layout.span, 2.0)
@@ -51,6 +54,7 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(layout.dynamicHeight, true)
     XCTAssertEqual(layout.headerMode, .sticky)
     XCTAssertEqual(layout.infiniteScrolling, true)
+    XCTAssertEqual(layout.showEmptyComponent, true)
   }
 
   func testJSONMapping() {
@@ -64,6 +68,7 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual(layout.inset, Inset(top: 1, left: 2, bottom: 3, right: 4))
     XCTAssertEqual(layout.headerMode, .sticky)
     XCTAssertEqual(layout.infiniteScrolling, true)
+    XCTAssertEqual(layout.showEmptyComponent, true)
   }
 
   func testDictionary() {
@@ -81,6 +86,7 @@ class LayoutTests: XCTestCase {
     XCTAssertEqual((layoutJSON["inset"] as? [String : Double])?["right"], layout.inset.right)
     XCTAssertEqual(layoutJSON["header-mode"] as? String, layout.headerMode.rawValue)
     XCTAssertEqual(layoutJSON["infinite-scrolling"] as? Bool, layout.infiniteScrolling)
+    XCTAssertEqual(layoutJSON["show-empty-component"] as? Bool, layout.showEmptyComponent)
   }
 
   func testConfigureWithJSON() {


### PR DESCRIPTION
By default, the Component will be hidden if it does not have any items.
With `showEmptyComponent` you can now configure if you want the
`Component` to still be visible even if the model has no items.
Sometimes you want the `Component` to always be visible even if its
collection is empty. Setting `showEmptyComponent` on `Layout` addresses
that need.

## Component with items
<img width="562" alt="screen shot 2017-07-03 at 10 57 09" src="https://user-images.githubusercontent.com/57446/27785832-1b9a7c32-5fdf-11e7-9226-7d136f4c84fa.png">

## Show empty Component enabled
<img width="576" alt="screen shot 2017-07-03 at 10 57 54" src="https://user-images.githubusercontent.com/57446/27785837-20b27698-5fdf-11e7-8cad-7e2795d04c8c.png">

## Show empty Component disabled (the default)
<img width="561" alt="screen shot 2017-07-03 at 10 57 22" src="https://user-images.githubusercontent.com/57446/27785844-2a1405bc-5fdf-11e7-99e4-56aced862c35.png">
