### PR TITLE
Fix bug in ComponentManager.insert

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -119,8 +119,9 @@ public class ComponentManager {
         indexes.append(index)
       }
 
+      self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
+
       if numberOfItems > 0 {
-        self?.itemManager.configureItem(at: index, component: component, usesViewSize: true)
         component.userInterface?.insert(indexes, withAnimation: animation) {
           self?.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
         }


### PR DESCRIPTION
The first item was never configured, now it will always configure the
item that is being inserted into the collection.