### PR TITLE
Fix scrolling being disabled when starting with an empty collection.

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -390,6 +390,12 @@ import Tailor
       let size = CGSize(width: superview.frame.width,
                         height: view.frame.height)
       layout(with: size)
+
+      guard model.kind == .carousel else {
+        return
+      }
+      scrollView.scrollingEnabled = (model.items.count > 1)
+      scrollView.hasHorizontalScroller = (model.items.count > 1)
     }
   }
 }

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -4,9 +4,6 @@ extension Component {
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
     let newCollectionViewHeight = calculateCollectionViewHeight()
 
-    scrollView.scrollingEnabled = (model.items.count > 1)
-    scrollView.hasHorizontalScroller = (model.items.count > 1)
-
     collectionView.frame.size.height = newCollectionViewHeight
   }
 


### PR DESCRIPTION
If a horizontal component was initialized without items then scrolling
would never be enabled as it was set in setup instead of `layout`.
However, now it will check if scrolling should be enabled inside
`afterUpdate`. This should handle the cases that we need to cover for
it to always be enabled when applicable.