### PR TITLE
Implement layoutSubviews() on SpotsContentView

### DIFF
--- a/Sources/macOS/Classes/SpotsContentView.swift
+++ b/Sources/macOS/Classes/SpotsContentView.swift
@@ -39,4 +39,20 @@ open class SpotsContentView: NSView {
     }
     containerScrollView.willRemoveSubview(subview)
   }
+
+  /// The default implementation of this method does nothing on iOS 5.1 and earlier.
+  /// Otherwise, the default implementation uses any constraints you have set to
+  /// determine the size and position of any subviews.
+  /// If `SpotsContentView` is added to a `SpotsScrollView` it will invoke `layoutViews`
+  /// to trigger a re-rendering of all components.
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+
+    guard let clipView = superview,
+      let containerScrollView = clipView.superview as? SpotsScrollView else {
+        return
+    }
+
+    containerScrollView.layoutViews()
+  }
 }


### PR DESCRIPTION
To always keep the Components in sync, we relay layoutSubviews to the
SpotsScrollView. This is the same kind of implementation that we have
for iOS and tvOS.