### PR TITLE
Implement Component animations

### DIFF
--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -228,25 +228,38 @@ import Tailor
       setupCollectionView(collectionView, with: size)
     }
 
-    layout(with: size)
+    layout(with: size, animated: false)
     Component.configure?(self)
   }
 
   /// Configure the view frame with a given size.
   ///
   /// - Parameter size: A `CGSize` used to set a new size to the user interface.
-  public func layout(with size: CGSize) {
+  /// - Parameter animated: Determines if the `Component` should perform animation when
+  ///                       applying its new size.
+  public func layout(with size: CGSize, animated: Bool = true) {
     if let tableView = self.tableView {
-      layoutTableView(tableView, with: size)
+      let instance = animated ? tableView.animator() : tableView
+      layoutTableView(instance, with: size)
     } else if let collectionView = self.collectionView {
-      layoutCollectionView(collectionView, with: size)
+      let instance = animated ? collectionView.animator() : collectionView
+      layoutCollectionView(instance, with: size)
     }
 
     layoutHeaderFooterViews(size)
     view.layoutSubviews()
 
     if let layout = model.layout, model.items.isEmpty, !layout.showEmptyComponent {
-      view.frame.size.height = 0
+      if animated {
+        let viewAnimator = view.animator()
+        viewAnimator.frame.size.height = 0
+        DispatchQueue.main.asyncAfter(deadline: .now() + NSAnimationContext.current().duration) {
+          viewAnimator.superview?.animator().layoutSubviews()
+        }
+      } else {
+        view.frame.size.height = 0
+        view.superview?.layoutSubviews()
+      }
     }
   }
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -251,10 +251,9 @@ import Tailor
 
     if let layout = model.layout, model.items.isEmpty, !layout.showEmptyComponent {
       if animated {
-        let viewAnimator = view.animator()
-        viewAnimator.frame.size.height = 0
-        DispatchQueue.main.asyncAfter(deadline: .now() + NSAnimationContext.current().duration) {
-          viewAnimator.superview?.animator().layoutSubviews()
+        view.animator().frame.size.height = 0
+        DispatchQueue.main.asyncAfter(deadline: .now() + NSAnimationContext.current().duration) { [weak self] in
+          self?.view.superview?.animator().layoutSubviews()
         }
       } else {
         view.frame.size.height = 0

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -135,7 +135,7 @@ open class SpotsScrollView: NSScrollView {
           }
         }
 
-        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == Optional(false)
+        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == false
         if shouldAnimate {
           scrollView.animator().frame = frame
         } else {

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -22,6 +22,7 @@ open class SpotsScrollView: NSScrollView {
   /// A KVO context used to monitor changes in contentSize, frames and bounds
   let subviewContext: UnsafeMutableRawPointer? = UnsafeMutableRawPointer(mutating: nil)
 
+  public var isAnimationsEnabled: Bool = false
   public var inset: Inset?
 
   /// A collection of NSView's that resemble the order of the views in the scroll view.
@@ -134,7 +135,13 @@ open class SpotsScrollView: NSScrollView {
           }
         }
 
-        scrollView.frame = frame
+        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == Optional(false)
+        if shouldAnimate {
+          scrollView.animator().frame = frame
+        } else {
+          scrollView.frame = frame
+        }
+
         scrollView.contentOffset = contentOffset
 
         yOffsetOfCurrentSubview += scrollView.frame.height

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -35,7 +35,7 @@ extension Component {
 
   func resizeHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize, type: ComponentResize) {
     prepareItems(recreateComposites: false)
-    layout(with: size)
+    layout(with: size, animated: false)
   }
 
   private func calculateCollectionViewHeight() -> CGFloat {

--- a/Sources/macOS/Extensions/Component+macOS+Grid.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Grid.swift
@@ -36,9 +36,9 @@ extension Component {
     switch type {
     case .live:
       prepareItems(recreateComposites: false)
-      layout(with: size)
+      layout(with: size, animated: false)
     case .end:
-      layout(with: size)
+      layout(with: size, animated: false)
     }
   }
 }

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -70,7 +70,7 @@ extension Component {
       tableView.beginUpdates()
       tableView.reloadSection(0, withAnimation: .none, completion: nil)
       tableView.endUpdates()
-      layout(with: size)
+      layout(with: size, animated: false)
     case .end:
       layoutTableView(tableView, with: size)
     }


### PR DESCRIPTION
When a Component changes size, they will now animate into its new size.
Animation is disabled when the window that the `Component` belongs to
resizes.

It looks like this when all items inside of a component are removed and then inserted again:

![component-animations](https://user-images.githubusercontent.com/57446/27804396-fe8a15ee-602e-11e7-9046-1eb8064c8ffd.gif)
