### PR TITLE
Improve Component animations

### DIFF
--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -231,21 +231,21 @@ open class SpotsController: NSViewController, SpotsProtocol {
   open override func viewDidLayout() {
     super.viewDidLayout()
 
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   open func windowDidResize(_ notification: Notification) {
     for component in components {
       component.didResize(size: view.frame.size, type: .live)
     }
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   public func windowDidEndLiveResize(_ notification: Notification) {
     components.forEach { component in
       component.didResize(size: view.frame.size, type: .end)
     }
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   fileprivate func layoutComponent(_ component: Component) {

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -107,7 +107,7 @@ open class SpotsScrollView: NSScrollView {
     layoutSubtreeIfNeeded()
   }
 
-  func layoutViews() {
+  func layoutViews(animated: Bool = true) {
     var yOffsetOfCurrentSubview: CGFloat = CGFloat(self.inset?.top ?? 0.0)
     let lastView = subviewsInLayoutOrder.last
 
@@ -135,7 +135,7 @@ open class SpotsScrollView: NSScrollView {
           }
         }
 
-        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == false
+        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == false && animated
         if shouldAnimate {
           scrollView.animator().frame = frame
         } else {
@@ -185,6 +185,6 @@ open class SpotsScrollView: NSScrollView {
   open override func layoutSubtreeIfNeeded() {
     super.layoutSubtreeIfNeeded()
 
-    layoutViews()
+    layoutViews(animated: false)
   }
 }


### PR DESCRIPTION
`layoutViews` on `SpotsScrollView` has a label to be able to trigger animation when needed. Animations are set to false for when the `SpotsController`'s window resizes.