### PR TITLE
Refactor/spots scroll view and spots content view

### DIFF
--- a/Sources/macOS/Classes/SpotsContentView.swift
+++ b/Sources/macOS/Classes/SpotsContentView.swift
@@ -22,7 +22,7 @@ open class SpotsContentView: NSView {
   func insertSubview(_ view: View, at index: Int) {
     subviews.insert(view, at: index)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView { scrollView in
+    resolveSpotsScrollView { scrollView in
       scrollView.layoutViews(animated: true)
     }
   }
@@ -35,7 +35,7 @@ open class SpotsContentView: NSView {
   override open func didAddSubview(_ subview: View) {
     super.didAddSubview(subview)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView { scrollView in
+    resolveSpotsScrollView { scrollView in
       scrollView.didAddSubviewToContainer(subview)
     }
   }
@@ -48,7 +48,7 @@ open class SpotsContentView: NSView {
   override open func willRemoveSubview(_ subview: View) {
     super.willRemoveSubview(subview)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView { scrollView in
+    resolveSpotsScrollView { scrollView in
       scrollView.willRemoveSubview(subview)
     }
   }
@@ -60,7 +60,7 @@ open class SpotsContentView: NSView {
   /// to trigger a re-rendering of all components.
   open override func layoutSubviews() {
     super.layoutSubviews()
-    spotsScrollView { scrollView in
+    resolveSpotsScrollView { scrollView in
       scrollView.layoutViews(animated: false)
     }
   }
@@ -70,7 +70,7 @@ open class SpotsContentView: NSView {
   /// - Parameter closure: A closure that returns the resolved `SpotsScrollView`.
   ///                      Note: The closure will not execute if the `SpotsScrollView` cannot
   ///                      be resolved.
-  private func spotsScrollView(_ closure: (SpotsScrollView) -> Void) {
+  private func resolveSpotsScrollView(_ closure: (SpotsScrollView) -> Void) {
     guard let clipView = superview,
       let spotsScrollView = clipView.superview as? SpotsScrollView else {
         return

--- a/Sources/macOS/Classes/SpotsContentView.swift
+++ b/Sources/macOS/Classes/SpotsContentView.swift
@@ -22,8 +22,8 @@ open class SpotsContentView: NSView {
   func insertSubview(_ view: View, at index: Int) {
     subviews.insert(view, at: index)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView {
-      $0.layoutViews(animated: true)
+    spotsScrollView { scrollView in
+      scrollView.layoutViews(animated: true)
     }
   }
 
@@ -35,7 +35,9 @@ open class SpotsContentView: NSView {
   override open func didAddSubview(_ subview: View) {
     super.didAddSubview(subview)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView { $0.didAddSubviewToContainer(subview) }
+    spotsScrollView { scrollView in
+      scrollView.didAddSubviewToContainer(subview)
+    }
   }
 
   /**
@@ -46,7 +48,9 @@ open class SpotsContentView: NSView {
   override open func willRemoveSubview(_ subview: View) {
     super.willRemoveSubview(subview)
     rebuildSubviewsInLayoutOrder()
-    spotsScrollView { $0.willRemoveSubview(subview) }
+    spotsScrollView { scrollView in
+      scrollView.willRemoveSubview(subview)
+    }
   }
 
   /// The default implementation of this method does nothing on iOS 5.1 and earlier.
@@ -56,7 +60,9 @@ open class SpotsContentView: NSView {
   /// to trigger a re-rendering of all components.
   open override func layoutSubviews() {
     super.layoutSubviews()
-    spotsScrollView { $0.layoutViews(animated: false) }
+    spotsScrollView { scrollView in
+      scrollView.layoutViews(animated: false)
+    }
   }
 
   /// Resolve `SpotsScrollView` based of the `SpotsContentView`'s superview.

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -231,21 +231,21 @@ open class SpotsController: NSViewController, SpotsProtocol {
   open override func viewDidLayout() {
     super.viewDidLayout()
 
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   open func windowDidResize(_ notification: Notification) {
     for component in components {
       component.didResize(size: view.frame.size, type: .live)
     }
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   public func windowDidEndLiveResize(_ notification: Notification) {
     components.forEach { component in
       component.didResize(size: view.frame.size, type: .end)
     }
-    scrollView.layoutSubviews()
+    scrollView.layoutViews(animated: false)
   }
 
   fileprivate func layoutComponent(_ component: Component) {

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -107,7 +107,7 @@ open class SpotsScrollView: NSScrollView {
     layoutSubtreeIfNeeded()
   }
 
-  func layoutViews() {
+  func layoutViews(animated: Bool = true) {
     var yOffsetOfCurrentSubview: CGFloat = CGFloat(self.inset?.top ?? 0.0)
     let lastView = subviewsInLayoutOrder.last
 
@@ -135,7 +135,7 @@ open class SpotsScrollView: NSScrollView {
           }
         }
 
-        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == false
+        let shouldAnimate = isAnimationsEnabled && window?.inLiveResize == false && animated
         if shouldAnimate {
           scrollView.animator().frame = frame
         } else {
@@ -185,6 +185,6 @@ open class SpotsScrollView: NSScrollView {
   open override func layoutSubtreeIfNeeded() {
     super.layoutSubtreeIfNeeded()
 
-    layoutViews()
+    layoutViews(animated: false)
   }
 }


### PR DESCRIPTION
Refactor SpotsScrollView and SpotsContentView  …
The KVO implementation for observing views has been refactored to
resemble the implementation on iOS and tvOS.

`subviewsInLayoutOrder` has been moved to `SpotsContentView`. The main
reason behind this is that `NSView` does not support `func
insertSubview(UIView, at: Int)`. So when replacing `Component`, they
can end up in the wrong location. By moving the implementation over to
`SpotsContentView` we ensure that the layout order stays intact between
mutations.

Note: Build on top of #684, so that will be merged before this one.