### PR TITLE
Refactor ComponentModel to make Layout non-optional

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -389,7 +389,7 @@ public class ComponentManager {
     Dispatch.interactive {
       let newComponentModel = ComponentModel(json)
 
-      guard component.model != newComponentModel else {
+      guard component.model !== newComponentModel else {
         Dispatch.main {
           completion?()
         }

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -16,12 +16,13 @@ public class ItemManager {
   /// - Returns: Returns the new `Item` width based of the `Component` width, if the `Component` does
   ///            not rely on `span`, it will return `nil`.
   func calculateSpanWidth(for component: Component) -> CGFloat? {
-    guard let layout = component.model.layout, layout.span > 0.0 else {
+    guard component.model.layout.span > 0.0 else {
       return nil
     }
 
-    let componentWidth: CGFloat = component.view.frame.size.width - CGFloat(layout.inset.left + layout.inset.right)
-    return (componentWidth / CGFloat(layout.span)) - CGFloat(layout.itemSpacing)
+    let inset = CGFloat(component.model.layout.inset.left + component.model.layout.inset.right)
+    let componentWidth: CGFloat = component.view.frame.size.width - inset
+    return (componentWidth / CGFloat(component.model.layout.span)) - CGFloat(component.model.layout.itemSpacing)
   }
 
   func prepareItems(component: Component, recreateComposites: Bool = true) {
@@ -31,8 +32,8 @@ public class ItemManager {
 
   func prepare(component: Component, items: [Item], recreateComposites: Bool) -> [Item] {
     var preparedItems = items
-    var spanWidth: CGFloat? = calculateSpanWidth(for: component)
-    var shouldAdjustHeight = component.model.kind == .carousel
+    let spanWidth: CGFloat? = calculateSpanWidth(for: component)
+    let shouldAdjustHeight = component.model.kind == .carousel
     var largestHeight: CGFloat = 0.0
 
     preparedItems.enumerated().forEach { (index: Int, item: Item) in

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -93,18 +93,7 @@ public class SpotsControllerManager {
 
       let oldComponents = controller.components
       let oldComponentModels = oldComponents.map { $0.model }
-      var newComponentModels = components
-
-      /// Prepare default layouts for new components based of previous Component kind.
-      for (index, _) in newComponentModels.enumerated() {
-        guard index < oldComponentModels.count else {
-          break
-        }
-
-        if newComponentModels[index].layout == nil {
-          newComponentModels[index].layout = type(of: oldComponents[index]).layout
-        }
-      }
+      let newComponentModels = components
 
       guard compare(newComponentModels, oldComponentModels) else {
         Dispatch.main {

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -14,7 +14,7 @@ public extension Component {
 
   /// A computed CGFloat of the total height of all items inside of a component
   public var computedHeight: CGFloat {
-    guard model.layout?.dynamicHeight == true else {
+    guard model.layout.dynamicHeight == true else {
       return self.view.frame.height
     }
 

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -44,7 +44,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   /// The footer identifier
   public var footer: Item?
   /// Layout properties
-  public var layout: Layout?
+  public var layout: Layout
   /// A collection of view models
   public var items: [Item] = [Item]()
   /// The width and height of the component, usually calculated and updated by the UI component
@@ -89,10 +89,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
       Key.items.string: JSONItems
       ]
 
-    if let layout = layout {
-      JSONComponentModels[Key.layout] = layout.dictionary
-    }
-
+    JSONComponentModels[Key.layout] = layout.dictionary
     JSONComponentModels[Key.interaction] = interaction.dictionary
     JSONComponentModels[Key.identifier.string] = identifier
 
@@ -121,6 +118,8 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
 
     if let layoutDictionary: [String : Any] = map.property(Layout.rootKey) {
       self.layout = Layout(layoutDictionary)
+    } else {
+      self.layout = Layout()
     }
 
     if let interactionDictionary: [String : Any] = map.property(Interaction.rootKey) {
@@ -149,7 +148,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
               header: Item? = nil,
               footer: Item? = nil,
               kind: ComponentKind = Configuration.defaultComponentKind,
-              layout: Layout? = nil,
+              layout: Layout = Layout(),
               interaction: Interaction = .init(),
               items: [Item] = [],
               meta: [String : Any] = [:]) {
@@ -161,7 +160,6 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
     self.footer = footer
     self.items = items.refreshIndexes()
     self.meta = meta
-    self.layout = layout
   }
 
   // MARK: - Helpers

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -98,7 +98,7 @@ public struct Registry {
       }
       #if os(OSX)
         var views: NSArray?
-        if nib.instantiate(withOwner: nil, topLevelObjects: &views!) {
+        if nib.instantiate(withOwner: nil, topLevelObjects: &views) {
           view = views?.filter({ $0 is NSTableRowView }).first as? View
         }
       #else

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -98,7 +98,7 @@ public struct Registry {
       }
       #if os(OSX)
         var views: NSArray?
-        if nib.instantiate(withOwner: nil, topLevelObjects: &views) {
+        if nib.instantiate(withOwner: nil, topLevelObjects: &views!) {
           view = views?.filter({ $0 is NSTableRowView }).first as? View
         }
       #else

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -3,9 +3,6 @@
 import UIKit
 
 public class Component: NSObject, ComponentHorizontallyScrollable {
-  /// The default layout that should be used for components.
-  /// It will default to this one if `Layout` is absent during init.
-  public static var layout: Layout = Layout(span: 0.0)
   /// A configuration closure that can be used to pinpoint configuration of
   /// views used inside of the component.
   open static var configure: ((Component) -> Void)?
@@ -104,20 +101,12 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     self.model = model
     self.view = view
     self.parentComponent = parentComponent
-
     super.init()
-
-    if model.layout == nil {
-      self.model.layout = Component.layout
-    }
-
     registerDefaultIfNeeded(view: DefaultItemView.self)
-
     userInterface?.register()
 
-    if let componentLayout = self.model.layout,
-      let collectionViewLayout = collectionView?.collectionViewLayout as? ComponentFlowLayout {
-      componentLayout.configure(collectionViewLayout: collectionViewLayout)
+    if let collectionViewLayout = collectionView?.collectionViewLayout as? ComponentFlowLayout {
+      model.layout.configure(collectionViewLayout: collectionViewLayout)
     }
 
     self.componentDataSource = DataSource(component: self)
@@ -171,9 +160,9 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     configurePageControl()
     Component.configure?(self)
 
-    if let layout = model.layout, layout.infiniteScrolling {
+    if model.layout.infiniteScrolling {
       let size = sizeForItem(at: IndexPath(item: 0, section: 0))
-      collectionView?.contentOffset.x = size.width + CGFloat(layout.itemSpacing)
+      collectionView?.contentOffset.x = size.width + CGFloat(model.layout.itemSpacing)
     }
   }
 
@@ -196,7 +185,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// It is used to invoke `handleInfiniteScrolling` when the users scrolls a horizontal
   /// `Component` with `infiniteScrolling` enabled.
   func layoutSubviews() {
-    guard model.kind == .carousel, model.layout?.infiniteScrolling == true else {
+    guard model.kind == .carousel, model.layout.infiniteScrolling == true else {
       return
     }
 
@@ -249,7 +238,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     switch model.interaction.scrollDirection {
     case .horizontal:
-      if let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement {
+      if let pageIndicatorPlacement = model.layout.pageIndicatorPlacement {
         switch pageIndicatorPlacement {
         case .below:
           pageControl.frame.origin.y = collectionView.frame.height - pageControl.frame.height
@@ -279,7 +268,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// Configure the page control for the component.
   /// Page control is only supported in horizontal collection views.
   func configurePageControl() {
-    guard let placement = model.layout?.pageIndicatorPlacement else {
+    guard let placement = model.layout.pageIndicatorPlacement else {
       pageControl.removeFromSuperview()
       return
     }

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -25,9 +25,7 @@ extension Component {
       }
     }
 
-    if let componentLayout = model.layout {
-      collectionView.frame.size.height += CGFloat(componentLayout.inset.top + componentLayout.inset.bottom)
-    }
+    collectionView.frame.size.height += CGFloat(model.layout.inset.top + model.layout.inset.bottom)
   }
 
   func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
@@ -50,7 +48,7 @@ extension Component {
   }
 
   private func configurePageControl(collectionView: UICollectionView, collectionViewLayout: UICollectionViewFlowLayout) {
-    guard let pageIndicatorPlacement = model.layout?.pageIndicatorPlacement else {
+    guard let pageIndicatorPlacement = model.layout.pageIndicatorPlacement else {
       return
     }
 

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -19,16 +19,14 @@ extension Component {
 
       headerView.layer.zPosition = 100
 
-      if let layout = model.layout {
-        switch layout.headerMode {
-        case .sticky:
-          if model.kind != .list {
-            view.addSubview(headerView)
-          }
-        case .default:
-          if model.kind != .list {
-            backgroundView.addSubview(headerView)
-          }
+      switch model.layout.headerMode {
+      case .sticky:
+        if model.kind != .list {
+          view.addSubview(headerView)
+        }
+      case .default:
+        if model.kind != .list {
+          backgroundView.addSubview(headerView)
         }
       }
 

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -10,11 +10,11 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let component = component, let layout = component.model.layout else {
-        return 0
+    guard let component = component else {
+      return 0
     }
 
-    if layout.infiniteScrolling {
+    if component.model.layout.infiniteScrolling {
       var additionalIndexes: Int = 0
       var remainingWidth: CGFloat = 0
       for item in component.model.items {
@@ -40,14 +40,13 @@ extension DataSource: UICollectionViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let component = component,
-      let layout = component.model.layout else {
-        return UICollectionViewCell()
+    guard let component = component else {
+      return UICollectionViewCell()
     }
 
     let currentIndexPath: IndexPath
 
-    if layout.infiniteScrolling {
+    if component.model.layout.infiniteScrolling {
       /// Compute the first and last item in the list, it should start with the last
       /// item instead of the first on the model. The last item in the list should
       /// also be resolved to the last on the model.

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -44,7 +44,7 @@ extension Delegate: UIScrollViewDelegate {
 
     performPaginatedScrolling { component, _, _ in
       component.carouselScrollDelegate?.componentCarouselDidScroll(component)
-      if component.model.layout?.pageIndicatorPlacement == .overlay {
+      if component.model.layout.pageIndicatorPlacement == .overlay {
         component.pageControl.frame.origin.x = scrollView.contentOffset.x
       }
     }

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -22,8 +22,7 @@ public class ComponentFlowLayout: FlowLayout {
 
   open override func prepare() {
     guard let delegate = collectionView?.delegate as? Delegate,
-      let component = delegate.component,
-      let layout = component.model.layout
+      let component = delegate.component
       else {
         return
     }
@@ -45,16 +44,16 @@ public class ComponentFlowLayout: FlowLayout {
       contentSize = .zero
 
       if let firstItem = component.model.items.first {
-        contentSize.height = firstItem.size.height * CGFloat(layout.itemsPerRow)
+        contentSize.height = firstItem.size.height * CGFloat(component.model.layout.itemsPerRow)
 
-        if component.model.items.count % layout.itemsPerRow == 1 {
+        if component.model.items.count % component.model.layout.itemsPerRow == 1 {
           contentSize.width += firstItem.size.width + minimumLineSpacing
-          contentSize.height += CGFloat(layout.lineSpacing)
+          contentSize.height += CGFloat(component.model.layout.lineSpacing)
         }
       }
 
       for (index, item) in component.model.items.enumerated() {
-        guard indexEligibleForItemsPerRow(index: index, itemsPerRow: layout.itemsPerRow) else {
+        guard indexEligibleForItemsPerRow(index: index, itemsPerRow: component.model.layout.itemsPerRow) else {
           continue
         }
 
@@ -64,7 +63,7 @@ public class ComponentFlowLayout: FlowLayout {
       contentSize.height += component.headerHeight
       contentSize.height += component.footerHeight
       contentSize.width -= minimumInteritemSpacing
-      contentSize.width += CGFloat(layout.inset.left + layout.inset.right)
+      contentSize.width += CGFloat(component.model.layout.inset.left + component.model.layout.inset.right)
     case .vertical:
       contentSize.width = component.view.frame.width
       contentSize.height = super.collectionViewContentSize.height
@@ -72,7 +71,7 @@ public class ComponentFlowLayout: FlowLayout {
       contentSize.height += component.footerHeight
     }
 
-    contentSize.height += CGFloat(layout.inset.top + layout.inset.bottom)
+    contentSize.height += CGFloat(component.model.layout.inset.top + component.model.layout.inset.bottom)
   }
 
   public override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {
@@ -80,8 +79,7 @@ public class ComponentFlowLayout: FlowLayout {
 
     guard let collectionView = collectionView,
       let dataSource = collectionView.dataSource as? DataSource,
-      let component = dataSource.component,
-      let layout = component.model.layout
+      let component = dataSource.component
       else {
         return attributes
     }
@@ -105,27 +103,27 @@ public class ComponentFlowLayout: FlowLayout {
       itemAttribute.size = component.sizeForItem(at: indexPath)
 
       if scrollDirection == .horizontal {
-        if layout.itemsPerRow > 1 {
-          if indexPath.item % Int(layout.itemsPerRow) == 0 {
+        if component.model.layout.itemsPerRow > 1 {
+          if indexPath.item % Int(component.model.layout.itemsPerRow) == 0 {
             itemAttribute.frame.origin.y += sectionInset.top + component.headerHeight
           } else {
             itemAttribute.frame.origin.y = nextY
           }
         } else {
           itemAttribute.frame.origin.y = component.headerView?.frame.maxY ?? component.headerHeight
-          itemAttribute.frame.origin.y += CGFloat(layout.inset.top)
+          itemAttribute.frame.origin.y += CGFloat(component.model.layout.inset.top)
         }
 
         itemAttribute.frame.origin.x = nextX
 
-        if indexEligibleForItemsPerRow(index: indexPath.item, itemsPerRow: layout.itemsPerRow) {
+        if indexEligibleForItemsPerRow(index: indexPath.item, itemsPerRow: component.model.layout.itemsPerRow) {
           nextX += itemAttribute.size.width + minimumInteritemSpacing
           nextY = 0
         } else {
-          nextY = itemAttribute.frame.maxY + CGFloat(layout.lineSpacing)
+          nextY = itemAttribute.frame.maxY + CGFloat(component.model.layout.lineSpacing)
         }
       } else {
-        itemAttribute.frame.origin.y += CGFloat(layout.inset.top)
+        itemAttribute.frame.origin.y += CGFloat(component.model.layout.inset.top)
       }
 
       attributes.append(itemAttribute)

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -250,7 +250,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
 
   fileprivate func layoutComponent(_ component: Component) {
     if component.userInterface is CollectionView {
-      guard let layout = component.model.layout, layout.span >= 1 else {
+      guard component.model.layout.span >= 1 else {
         return
       }
 

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -43,13 +43,11 @@ extension Component {
       $0.size.height > $1.size.height
     }).first?.size.height ?? 0.0
 
-    if let layout = model.layout {
-      newCollectionViewHeight *= CGFloat(layout.itemsPerRow)
-      newCollectionViewHeight += CGFloat(layout.inset.top + layout.inset.bottom)
+    newCollectionViewHeight *= CGFloat(model.layout.itemsPerRow)
+    newCollectionViewHeight += CGFloat(model.layout.inset.top + model.layout.inset.bottom)
 
-      if layout.itemsPerRow > 1 {
-        newCollectionViewHeight += CGFloat(layout.lineSpacing * Double(layout.itemsPerRow - 2))
-      }
+    if model.layout.itemsPerRow > 1 {
+      newCollectionViewHeight += CGFloat(model.layout.lineSpacing * Double(model.layout.itemsPerRow - 2))
     }
 
     return newCollectionViewHeight

--- a/Sources/macOS/Extensions/Component+macOS+Grid.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Grid.swift
@@ -15,11 +15,7 @@ extension Component {
     if let collectionViewContentSize = collectionView.collectionViewLayout?.collectionViewContentSize {
       var collectionViewContentSize = collectionViewContentSize
       collectionViewContentSize.height += headerHeight + footerHeight
-
-      if let layout = model.layout {
-        collectionViewContentSize.height += CGFloat(layout.inset.top + layout.inset.bottom)
-      }
-
+      collectionViewContentSize.height += CGFloat(model.layout.inset.top + model.layout.inset.bottom)
       collectionView.frame.size.height = collectionViewContentSize.height
       collectionView.frame.size.width = collectionViewContentSize.width
 

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -52,13 +52,10 @@ extension Component {
     }
 
     tableView.frame.size.width = size.width
-
-    if let layout = model.layout {
-      tableView.frame.origin.y += CGFloat(layout.inset.bottom)
-      tableView.frame.origin.x = CGFloat(layout.inset.left)
-      tableView.frame.size.width -= CGFloat(layout.inset.left + layout.inset.right)
-      tableView.frame.size.height += CGFloat(layout.inset.bottom)
-    }
+    tableView.frame.origin.y += CGFloat(model.layout.inset.bottom)
+    tableView.frame.origin.x = CGFloat(model.layout.inset.left)
+    tableView.frame.size.width -= CGFloat(model.layout.inset.left + model.layout.inset.right)
+    tableView.frame.size.height += CGFloat(model.layout.inset.bottom)
 
     scrollView.frame.size.height = tableView.frame.height + headerHeight + footerHeight
   }

--- a/SpotsTests/Shared/TestComponentModel.swift
+++ b/SpotsTests/Shared/TestComponentModel.swift
@@ -17,7 +17,7 @@ class ComponentModelTests: XCTestCase {
     // Test component created with JSON
     let jsonComponentModel = ComponentModel(json)
     XCTAssertEqual(jsonComponentModel.kind.string, json["kind"] as? String)
-    XCTAssertEqual(jsonComponentModel.layout?.span, (json["layout"] as? [String : Any])?["span"] as? Double)
+    XCTAssertEqual(jsonComponentModel.layout.span, (json["layout"] as? [String : Any])?["span"] as? Double)
 
     XCTAssert((jsonComponentModel.meta as NSDictionary).isEqual(json["meta"] as! NSDictionary))
     XCTAssert(jsonComponentModel.items.count == 1)
@@ -35,7 +35,7 @@ class ComponentModelTests: XCTestCase {
       meta: json["meta"] as! [String : String])
 
     XCTAssertEqual(codeComponentModel.kind.string, json["kind"] as? String)
-    XCTAssertEqual(codeComponentModel.layout?.span, (json["layout"] as? [String : Any])?["span"] as? Double)
+    XCTAssertEqual(codeComponentModel.layout.span, (json["layout"] as? [String : Any])?["span"] as? Double)
 
     XCTAssert((codeComponentModel.meta as NSDictionary).isEqual(json["meta"] as! NSDictionary))
     XCTAssert(codeComponentModel.items.count == 1)

--- a/SpotsTests/iOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/iOS/ComponentFlowLayoutTests.swift
@@ -88,16 +88,16 @@ class ComponentFlowLayoutTests: XCTestCase {
 
     let expectedFrameA = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left,
-        y: model.layout!.inset.top
+        x: model.layout.inset.left,
+        y: model.layout.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameB = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left + Double(itemSize.width),
-        y: model.layout!.inset.top
+        x: model.layout.inset.left + Double(itemSize.width),
+        y: model.layout.inset.top
       ),
       size: itemSize
     )
@@ -130,8 +130,8 @@ class ComponentFlowLayoutTests: XCTestCase {
     let layoutAttributes = collectionViewLayout.layoutAttributesForElements(in: CGRect(origin: CGPoint.zero, size: parentSize))
 
     XCTAssertEqual(layoutAttributes?.count, 2)
-    XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: model.layout!.inset.top), size: itemSize))
-    XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width) + model.layout!.itemSpacing, y: model.layout!.inset.top), size: itemSize))
+    XCTAssertEqual(layoutAttributes?[0].frame, CGRect(origin: CGPoint(x: 0.0, y: model.layout.inset.top), size: itemSize))
+    XCTAssertEqual(layoutAttributes?[1].frame, CGRect(origin: CGPoint(x: Double(itemSize.width) + model.layout.itemSpacing, y: model.layout.inset.top), size: itemSize))
   }
 
   func testLayoutAttributesForElementInVerticalLayoutWithInsets() {
@@ -162,32 +162,32 @@ class ComponentFlowLayoutTests: XCTestCase {
 
     let expectedFrameA = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left,
-        y: model.layout!.inset.top
+        x: model.layout.inset.left,
+        y: model.layout.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameB = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left + Double(itemSize.width),
-        y: model.layout!.inset.top
+        x: model.layout.inset.left + Double(itemSize.width),
+        y: model.layout.inset.top
       ),
       size: itemSize
     )
 
     let expectedFrameC = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left,
-        y: model.layout!.inset.top + Double(itemSize.height)
+        x: model.layout.inset.left,
+        y: model.layout.inset.top + Double(itemSize.height)
       ),
       size: itemSize
     )
 
     let expectedFrameD = CGRect(
       origin: CGPoint(
-        x: model.layout!.inset.left + Double(itemSize.width),
-        y: model.layout!.inset.top + Double(itemSize.height)
+        x: model.layout.inset.left + Double(itemSize.width),
+        y: model.layout.inset.top + Double(itemSize.height)
       ),
       size: itemSize
     )
@@ -199,8 +199,8 @@ class ComponentFlowLayoutTests: XCTestCase {
     XCTAssertEqual(layoutAttributes?[3].frame, expectedFrameD)
 
     let expectedContentSize = CGSize(
-      width: model.layout!.inset.left + model.layout!.inset.right + Double(itemSize.width) * 2,
-      height: model.layout!.inset.top + model.layout!.inset.bottom + Double(itemSize.height) * 2
+      width: model.layout.inset.left + model.layout.inset.right + Double(itemSize.width) * 2,
+      height: model.layout.inset.top + model.layout.inset.bottom + Double(itemSize.height) * 2
     )
 
     XCTAssertEqual(collectionViewLayout.collectionViewContentSize, expectedContentSize)

--- a/SpotsTests/iOS/ComponentiOSTests.swift
+++ b/SpotsTests/iOS/ComponentiOSTests.swift
@@ -139,7 +139,7 @@ class ComponentiOSTests: XCTestCase {
     let parentSize = CGSize(width: 667, height: 225)
 
     // Check `span` mapping
-    XCTAssertEqual(component.model.layout!.span, 4.0)
+    XCTAssertEqual(component.model.layout.span, 4.0)
 
     component.setup(with: parentSize)
     component.prepareItems()
@@ -202,7 +202,7 @@ class ComponentiOSTests: XCTestCase {
     component.view.layoutSubviews()
 
     // Sanity check, to make sure we have our page indicator in overlay mode
-    XCTAssertEqual(model.layout!.pageIndicatorPlacement, .overlay)
+    XCTAssertEqual(model.layout.pageIndicatorPlacement, .overlay)
 
     // Assert item layout (derived from preferred view size)
     XCTAssertEqual(component.model.items[0].size.height, 88)
@@ -302,8 +302,8 @@ class ComponentiOSTests: XCTestCase {
     XCTAssertEqual(targetContentOffset.pointee.y, 100000)
 
     // Make sure that minimum item spacing is taken into account when snapping to an item.
-    model.layout?.itemSpacing = 10
-    model.layout?.span = 2
+    model.layout.itemSpacing = 10
+    model.layout.span = 2
     collectionView.itemSize = CGSize(width: 140, height: 100)
     component = Component(model: model, view: collectionView)
     component.setup(with: parentSize)


### PR DESCRIPTION
`Layout` on `ComponentModel` is now a non-optional value. This helps to
reduce the amount of optional assignments that we had in the source
code.