### PR TITLE
Reduce size of method to fix linter warning

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -307,7 +307,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     }
 
     let excludedAnimationTypes: [Animation] = [.top, .bottom]
-
     if !excludedAnimationTypes.contains(animation) {
       applyAnimationFix(type, attributes)
     }
@@ -331,27 +330,21 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     case .none:
       attributes.alpha = 1.0
     case .middle:
-      switch type {
-      case .insert:
+      if type == .insert {
         attributes.frame.origin = .init(x: collectionView.bounds.midX,
                                         y: collectionView.bounds.midY)
-      default:
-        break
       }
     case .automatic:
-      switch type {
-      case .insert:
+      if type == .insert {
         if component.model.items.count == 1 {
           attributes.alpha = 0.0
           return
         }
-      case .delete:
+      } else if type == .delete {
         if component.model.items.isEmpty {
           attributes.alpha = 0.0
           return
         }
-      default:
-        break
       }
 
       attributes.zIndex = -1

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -249,7 +249,6 @@ public class ComponentFlowLayout: FlowLayout {
     }
 
     let excludedAnimationTypes: [Animation] = [.top, .bottom]
-
     if !excludedAnimationTypes.contains(animation) {
       applyAnimationFix(type, attributes)
     }
@@ -273,32 +272,25 @@ public class ComponentFlowLayout: FlowLayout {
     case .none:
       attributes.alpha = 1.0
     case .middle:
-      switch type {
-      case .insert:
+      if type == .insert {
         attributes.size = .zero
         attributes.frame.origin = .init(x: attributes.frame.origin.x,
                                         y: attributes.frame.origin.y * 2)
-      case .delete:
+      } else if type == .delete {
         attributes.frame.origin = .init(x: attributes.frame.origin.x,
                                         y: attributes.frame.size.height / 2)
-        return
-      default:
-        break
       }
     case .automatic:
-      switch type {
-      case .insert:
+      if type == .insert {
         if component.model.items.count == 1 {
           attributes.alpha = 0.0
           return
         }
-      case .delete:
+      } else if type == .delete {
         if component.model.items.isEmpty {
           attributes.alpha = 0.0
           return
         }
-      default:
-        break
       }
 
       attributes.zIndex = -1


### PR DESCRIPTION
We don't exhaust the switches so we end up with a lot of `default:`
cases. Refactors `ComponentFlowLayout.applyAnimation` to use if/else if
statements to reduce the size of methods.