### PR TITLE
Optimize ComponentFlowLayout

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -128,6 +128,14 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
         return nil
     }
 
+    // The collection view has to be larger than 1 pixel in height for the layout to proceed.
+    // If the collection view is smaller, it assumes that it is not visible on screen, most likely
+    // because the `Component` that the collection view belong to is either above or below
+    // the current view port.
+    guard collectionView.frame.size.height > 1 else {
+      return nil
+    }
+
     var attributes = [UICollectionViewLayoutAttributes]()
     var nextX: CGFloat = sectionInset.left
     var nextY: CGFloat = 0.0
@@ -172,7 +180,11 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
           itemAttribute.frame.origin.y += component.headerHeight
         }
 
-        attributes.append(itemAttribute)
+        // Only add item attributes if the item frame insects the rect passed into the method.
+        // This removes unwanted computation when a collection view scrolls.
+        if itemAttribute.frame.intersects(rect) {
+          attributes.append(itemAttribute)
+        }
 
         if index >= cachedFrames.count {
           cachedFrames.append(itemAttribute.frame)

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -131,10 +131,6 @@ public class ComponentFlowLayout: FlowLayout {
       }
     }
 
-    if scrollDirection == .horizontal {
-      Swift.print(attributes.count)
-    }
-
     return attributes
   }
 

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -126,7 +126,13 @@ public class ComponentFlowLayout: FlowLayout {
         itemAttribute.frame.origin.y += CGFloat(component.model.layout.inset.top)
       }
 
-      attributes.append(itemAttribute)
+      if itemAttribute.frame.intersects(rect) {
+        attributes.append(itemAttribute)
+      }
+    }
+
+    if scrollDirection == .horizontal {
+      Swift.print(attributes.count)
     }
 
     return attributes

--- a/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
+++ b/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
@@ -26,23 +26,16 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
 
     XCTAssertEqual(component.model.items[0].size, CGSize(width: 50, height: 50))
     XCTAssertEqual(component.model.items[1].size, CGSize(width: 50, height: 50))
-    XCTAssertEqual(component.model.items[2].size, CGSize(width: 50, height: 50))
-    XCTAssertEqual(component.model.items[3].size, CGSize(width: 50, height: 50))
 
     // Check that the layout attributes correspond to the model sizes
     XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
     XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
-    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
-    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
 
     // Check that the x coordinate is correct based on padding and item spacing
     XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
     XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
-    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 100)
-    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 150)
 
     XCTAssertEqual(flowLayout.contentSize, CGSize(width: 200, height: 50))
-    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
   }
 
   func testCarouselLayoutWithSpanOfOne() {
@@ -50,25 +43,16 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
     let (component, flowLayout) = createComponent(with: layout)
     let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
 
+    XCTAssertEqual(layoutAttributes.count, 1)
     XCTAssertEqual(component.model.items[0].size, CGSize(width: 100, height: 50))
-    XCTAssertEqual(component.model.items[1].size, CGSize(width: 100, height: 50))
-    XCTAssertEqual(component.model.items[2].size, CGSize(width: 100, height: 50))
-    XCTAssertEqual(component.model.items[3].size, CGSize(width: 100, height: 50))
 
     // Check that the layout attributes correspond to the model sizes
     XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
-    XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
-    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
-    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
 
     // Check that the x coordinate is correct based on padding and item spacing
     XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
-    XCTAssertEqual(layoutAttributes[1].frame.origin.x, 100)
-    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 200)
-    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 300)
 
     XCTAssertEqual(flowLayout.contentSize, CGSize(width: 400, height: 50))
-    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
   }
 
   func testCarouselLayoutWithSpanOfTwo() {
@@ -78,25 +62,16 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
 
     XCTAssertEqual(component.model.items[0].size, CGSize(width: 50, height: 50))
     XCTAssertEqual(component.model.items[1].size, CGSize(width: 50, height: 50))
-    XCTAssertEqual(component.model.items[2].size, CGSize(width: 50, height: 50))
-    XCTAssertEqual(component.model.items[3].size, CGSize(width: 50, height: 50))
 
     // Check that the layout attributes correspond to the model sizes
     XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
     XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
-    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
-    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
 
     // Check that the x coordinate is correct based on padding and item spacing
     XCTAssertEqual(layoutAttributes[0].frame.origin.x, 0)
     XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
-    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 100)
-    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 150)
 
     XCTAssertEqual(flowLayout.contentSize, CGSize(width: 200, height: 50))
-
-    // Check that the content size is equal to the last layout attribute
-    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX)
   }
 
   func testCarouselLayoutWithSpanOfOneWithInsetOfTen() {
@@ -113,23 +88,16 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
     // Check that the layout attributes correspond to the model sizes
     XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
     XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
-    XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
-    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
 
     // Check that the x coordinate is correct based on padding and item spacing
     XCTAssertEqual(layoutAttributes[0].frame.origin.x, 10)
     XCTAssertEqual(layoutAttributes[1].frame.origin.x, 90)
-    XCTAssertEqual(layoutAttributes[2].frame.origin.x, 170)
-    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 250)
 
     // The total content size should be the width of the items + padding on each side.
     // In this case that should be the current formula:
     // $totalItemWidth + $leftInset + $rightInset
     //     80 * 4      +     10     +     10
     XCTAssertEqual(flowLayout.contentSize, CGSize(width: 340, height: 70))
-
-    // Check that the content size is equal to the last layout attribute plus right padding
-    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX + 10)
   }
 
   func testCarouselLayoutWithSpanOfTwoWithPaddingAndItemSpacing() {
@@ -142,26 +110,21 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
     XCTAssertEqual(component.model.items[0].size, CGSize(width: 30, height: 50))
     XCTAssertEqual(component.model.items[1].size, CGSize(width: 30, height: 50))
     XCTAssertEqual(component.model.items[2].size, CGSize(width: 30, height: 50))
-    XCTAssertEqual(component.model.items[3].size, CGSize(width: 30, height: 50))
 
     // Check that the layout attributes correspond to the model sizes
     XCTAssertEqual(component.model.items[0].size, layoutAttributes[0].size)
     XCTAssertEqual(component.model.items[1].size, layoutAttributes[1].size)
     XCTAssertEqual(component.model.items[2].size, layoutAttributes[2].size)
-    XCTAssertEqual(component.model.items[3].size, layoutAttributes[3].size)
 
     // Check that the x coordinate is correct based on padding and item spacing
     XCTAssertEqual(layoutAttributes[0].frame.origin.x, 10)
     XCTAssertEqual(layoutAttributes[1].frame.origin.x, 50)
     XCTAssertEqual(layoutAttributes[2].frame.origin.x, 90)
-    XCTAssertEqual(layoutAttributes[3].frame.origin.x, 130)
 
     // In this case that should be the current formula:
     // $totalItemWidth + $leftInset + $rightInset + ($itemSpacing * $numberOfItems - $itemSpacing)
     //     30 * 4      +     10     +     10      + (     10      *       4        - 10  )
     XCTAssertEqual(flowLayout.contentSize, CGSize(width: 170, height: 70))
-    // Check that the content size is equal to the last layout attribute plus right padding
-    XCTAssertEqual(flowLayout.contentSize.width, layoutAttributes.last!.frame.maxX + 10)
   }
 
   private func createComponent(with layout: Layout) -> (Component, ComponentFlowLayout) {


### PR DESCRIPTION
Adds guard inside `layoutAttributesForElements` that checks that the
collection view is larger than 1 pixel. If it is one or less, the
layout will assume that the collection view is not visible on screen.
Either it could be located above or below the current view port.

`layoutAttributesForElements` will now try and intersect the frame of
the item attribute before adding it to the attributes array. This saves
some computation further down as it will no longer have to compute
attributes for items that are not visible.