### PR TITLE
Implement proper Interaction.mouseClick behavior for NSCollectionView

### DIFF
--- a/Sources/macOS/Classes/GridWrapper.swift
+++ b/Sources/macOS/Classes/GridWrapper.swift
@@ -44,6 +44,28 @@ class GridWrapper: NSCollectionViewItem, Wrappable, Cell {
     }
   }
 
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+
+    guard let collectionView = collectionView,
+      let delegate = collectionView.delegate as? Delegate,
+      let component = delegate.component
+      else {
+        return
+    }
+
+    guard event.clickCount > 1 && component.model.interaction.mouseClick == .double else {
+      return
+    }
+
+    for index in collectionView.selectionIndexes {
+      guard let item = component.item(at: index) else {
+        continue
+      }
+      component.delegate?.component(component, itemSelected: item)
+    }
+  }
+
   override func mouseEntered(with event: NSEvent) {
     super.mouseEntered(with: event)
 

--- a/Sources/macOS/Classes/GridWrapper.swift
+++ b/Sources/macOS/Classes/GridWrapper.swift
@@ -47,8 +47,7 @@ class GridWrapper: NSCollectionViewItem, Wrappable, Cell {
   override func mouseDown(with event: NSEvent) {
     super.mouseDown(with: event)
 
-    guard let collectionView = collectionView,
-      let delegate = collectionView.delegate as? Delegate,
+    guard let delegate = collectionView.delegate as? Delegate,
       let component = delegate.component
       else {
         return

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -16,7 +16,10 @@ extension Delegate: NSCollectionViewDelegate {
         else {
           return
       }
-      component.delegate?.component(component, itemSelected: item)
+
+      if component.model.interaction.mouseClick == .single {
+        component.delegate?.component(component, itemSelected: item)
+      }
     }
   }
 


### PR DESCRIPTION
When `Interaction.mouseClick` is set to `double`, the delegate
invocation will be ignore and instead handled in `GridWrapper`.

`NSCollectionViewItem`'s have access to the `NSCollectionView` it
belongs to. It will resolve the `Component` from the `NSCollectionView`
delegate and trigger the `delegate` method `component(_ component:
Component, itemSelected: Item)` for all currently selected items in the
collection view.