### PR TITLE
Add workaround for contentInsets when using tabs

### DIFF
--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -133,6 +133,10 @@ open class SpotsScrollView: NSScrollView {
   /// - Parameter animated: Determines if animations should be used when updating the frames of the
   ///                       underlaying views.
   public func layoutViews(animated: Bool = true) {
+    guard superview != nil else {
+      return
+    }
+
     if #available(OSX 10.12, *) {
       // Workaround to fix the contentInset when using tabs.
       frame.size.width -= 1

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -132,7 +132,13 @@ open class SpotsScrollView: NSScrollView {
   ///
   /// - Parameter animated: Determines if animations should be used when updating the frames of the
   ///                       underlaying views.
-  func layoutViews(animated: Bool = true) {
+  public func layoutViews(animated: Bool = true) {
+    if #available(OSX 10.12, *) {
+      // Workaround to fix the contentInset when using tabs.
+      frame.size.width -= 1
+      frame.size.width += 1
+    }
+
     var yOffsetOfCurrentSubview: CGFloat = CGFloat(self.inset?.top ?? 0.0)
     let lastView = componentsView.subviewsInLayoutOrder.last
 


### PR DESCRIPTION
macOS 10.12 and later has support for tabs. As far as I know, there are
now good ways of checking if the window is using tabs or not and when
it does have tabs the `contentInset.top` is different. To make the
controller adapt to the new content insets we modify the width -1 and
then +1 to trigger a redrawing of the scrollview auto resizing mask so
that the new content inset is used. If we don't do this, the view will
be cut off at the top until the window is resized. This usually only
happens for the first window in the tab collection.

Not the best fix but it does the job for now, beats having rendering issues
when you use it windows and tabs.