### PR TITLE
Store contentOffset before switching out components in controller

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -494,10 +494,10 @@ public class SpotsControllerManager {
 
       // Opt-out of doing component cleanup if the controller has no components.
       let performCleanup = !controller.components.isEmpty
+      let previousContentOffset = controller.scrollView.contentOffset
 
       controller.components = Parser.parse(models)
 
-      let previousContentOffset = controller.scrollView.contentOffset
       if performCleanup {
         if controller.scrollView.superview == nil {
           controller.view.addSubview(controller.scrollView)


### PR DESCRIPTION
This is a tiny change, it saves the current content offset of the `SpotsScrollView` before it switches out the current components. This way we are sure that we are getting the correct `contentOffset` when the operation is completed.