### PR TITLE
Refactor updating the data source using performUpdate method

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -246,10 +246,10 @@ public class ComponentManager {
           component.userInterface?.reload([index], withAnimation: animation, completion: nil)
         } else if newItem.size.height != oldItem.size.height {
           if let view: ItemConfigurable = component.userInterface?.view(at: index), animation != .none {
-            component.userInterface?.beginUpdates()
-            view.configure(with: component.model.items[index])
-            component.model.items[index].size.height = view.computeSize(for: component.model.items[index], containerSize: component.view.frame.size).height
-            component.userInterface?.endUpdates()
+            component.userInterface?.performUpdates({
+              view.configure(with: component.model.items[index])
+              component.model.items[index].size.height = view.computeSize(for: component.model.items[index], containerSize: component.view.frame.size).height
+            }, completion: nil)
           } else {
             component.userInterface?.reload([index], withAnimation: animation, completion: nil)
           }

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -81,10 +81,12 @@ public protocol UserInterface: class {
   /// - parameter completino: A completion closure that will run when the reload is done.
   func reloadSection(_ section: Int, withAnimation animation: Animation, completion: (() -> Void)?)
 
-  /// A method that is invoked before the update occures.
-  func beginUpdates()
-  /// A method that is invoked after the update occures.
-  func endUpdates()
+  /// Perform updates on the user interface.
+  ///
+  /// - Parameters:
+  ///   - updateClosure: An update closure that is invoked when the interface has began updating itself.
+  ///   - completion: An optional completion closure that is invoked when the update is done.
+  func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)?)
   /// A proxy method to call reloadData
   func reloadDataSource()
 

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -107,8 +107,6 @@ extension UICollectionView: UserInterface {
     }
   }
 
-  public func beginUpdates() {}
-  public func endUpdates() {}
   public func reloadDataSource() {
     reloadData()
     updateContentSize()
@@ -289,5 +287,18 @@ extension UICollectionView: UserInterface {
     }
 
     componentFlowLayout.animation = nil
+  }
+
+  /// Perform batch updates on the data source.
+  ///
+  /// - Parameters:
+  ///   - updateClosure: An update closure that contains everything that should be updated inside the `performBatchUpdates` method.
+  ///   - completion: An optional completion closure that is invoked inside the completion handler.
+  public func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)?) {
+    performBatchUpdates({
+      updateClosure()
+    }) { _ in
+      completion?()
+    }
   }
 }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -292,12 +292,11 @@ extension UICollectionView: UserInterface {
   /// Perform batch updates on the data source.
   ///
   /// - Parameters:
-  ///   - updateClosure: An update closure that contains everything that should be updated inside the `performBatchUpdates` method.
+  ///   - updateClosure: An update closure that contains everything that should be updated just before `performBatchUpdates` is called.
   ///   - completion: An optional completion closure that is invoked inside the completion handler.
   public func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)?) {
-    performBatchUpdates({
-      updateClosure()
-    }) { _ in
+    updateClosure()
+    performBatchUpdates({}) { _ in
       completion?()
     }
   }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -121,13 +121,13 @@ extension UITableView: UserInterface {
       UIView.setAnimationsEnabled(false)
     }
 
-    performUpdates {
+    performUpdates({
       insertRows(at: indexPaths, with: animation.tableViewAnimation)
       for (from, to) in movedItems {
         moveRow(at: IndexPath(row: from, section: 0),
                 to: IndexPath(row: to, section: 0))
       }
-    }
+    })
 
     if animation == .none {
       UIView.setAnimationsEnabled(true)
@@ -149,9 +149,9 @@ extension UITableView: UserInterface {
     }
 
     if !indexPaths.isEmpty {
-      performUpdates {
+      performUpdates({
         reloadRows(at: indexPaths, with: animation.tableViewAnimation)
-      }
+      })
     } else {
       reloadDataSource()
     }
@@ -179,13 +179,13 @@ extension UITableView: UserInterface {
       UIView.setAnimationsEnabled(false)
     }
 
-    performUpdates {
+    performUpdates({
       deleteRows(at: indexPaths, with: animation.tableViewAnimation)
       for (from, to) in movedItems {
         moveRow(at: IndexPath(item: from, section: 0),
                 to: IndexPath(item: to, section: 0))
       }
-    }
+    })
 
     if animation == .none {
       UIView.setAnimationsEnabled(true)
@@ -244,9 +244,9 @@ extension UITableView: UserInterface {
       UIView.setAnimationsEnabled(false)
     }
 
-    performUpdates {
+    performUpdates({
       reloadSections(IndexSet(integer: section), with: animation.tableViewAnimation)
-    }
+    })
 
     if animation == .none {
       UIView.setAnimationsEnabled(true)
@@ -255,12 +255,15 @@ extension UITableView: UserInterface {
     completion?()
   }
 
-  /// Perform updates with closure
+  /// Perform batch updates on the data source.
   ///
-  /// - parameter closure: A closure that contains the operations that should be performed within the context
-  fileprivate func performUpdates(_ closure: () -> Void) {
+  /// - Parameters:
+  ///   - updateClosure: An update closure that is invoked inbetween `beginUpdates` and `endUpdates`.
+  ///   - completion: An optional completion closure that is invoked after `endUpdates.
+  public func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)? = nil) {
     beginUpdates()
-    closure()
+    updateClosure()
     endUpdates()
+    completion?()
   }
 }

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -189,6 +189,19 @@ extension NSCollectionView: UserInterface {
     reloadData()
   }
 
+  /// Perform batch updates on the data source.
+  ///
+  /// - Parameters:
+  ///   - updateClosure: An update closure that contains everything that should be updated inside the `performBatchUpdates` method.
+  ///   - completion: An optional completion closure that is invoked inside the completion handler.
+  public func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)? = nil) {
+    performBatchUpdates({
+      updateClosure()
+    }, completionHandler: { _ in
+      completion?()
+    })
+  }
+
   /**
    A convenience method for reloading a section
    - parameter index: The section you want to update
@@ -204,9 +217,6 @@ extension NSCollectionView: UserInterface {
       completion?()
     }
   }
-
-  public func beginUpdates() {}
-  public func endUpdates() {}
 
   private func applyAnimation(_ animation: Animation) {
     guard let componentFlowLayout = collectionViewLayout as? ComponentFlowLayout else {

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -57,7 +57,7 @@ extension NSTableView: UserInterface {
       for (from, to) in movedItems {
         moveRow(at: from, to: to)
       }
-    }, endClosure: completion)
+    }, completion: completion)
 
   }
 
@@ -107,7 +107,7 @@ extension NSTableView: UserInterface {
         moveRow(at: from, to: to)
       }
       removeRows(at: indexSet, withAnimation: animation.tableViewAnimation)
-    }, endClosure: completion)
+    }, completion: completion)
   }
 
   public func process(_ changes: (insertions: [Int], moved: [Int : Int], reloads: [Int], deletions: [Int], childUpdates: [Int]),
@@ -170,11 +170,16 @@ extension NSTableView: UserInterface {
     reloadData()
   }
 
-  fileprivate func performUpdates( _ closure: () -> Void, endClosure: (() -> Void)? = nil) {
+  /// Perform batch updates on the data source.
+  ///
+  /// - Parameters:
+  ///   - updateClosure: An update closure that is invoked inbetween `beginUpdates` and `endUpdates`.
+  ///   - completion: An optional completion closure that is invoked after `endUpdates.
+  public func performUpdates( _ updateClosure: () -> Void, completion: (() -> Void)? = nil) {
     beginUpdates()
-    closure()
+    updateClosure()
     endUpdates()
-    endClosure?()
+    completion?()
   }
 
   fileprivate func configure(view: View, with item: inout Item) {

--- a/SpotsTests/Shared/TestComposition.swift
+++ b/SpotsTests/Shared/TestComposition.swift
@@ -24,7 +24,7 @@ class CompositionTests: XCTestCase {
   }
 
   func testCoreComponentCreation() {
-    let layout = Layout().mutate { $0.span = 2.0 }
+    let layout = Layout(span: 2.0)
     var model = ComponentModel(kind: .grid, layout: layout)
 
     model.add(children: [


### PR DESCRIPTION
Performing soft updates didn't work properly for collection views as
that update was not wrapped in a batch update. To unify the
implementation for table view and collection view, the `UserInterface`
now demands a different method `performUpdates( _ updateClosure: () ->
Void, completion: (() -> Void)?)`.

For table views the update closure is invoked in-between
`beginUpdates()` and `endUpdates`. For collection view the
`updateClosure` is called inside `performBatchUpdates`.

`beginUpdates` and `endUpdates` have been removed from `UserInterface`.