### PR TITLE
Add ComponentResolvable protocol

### DIFF
--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Each `Component` have their own `DataSource`, basically it supplies a default set of
 /// implementations to use the `ComponentModel` as its source of truth. Mutating the data
 /// source is handled by the `ComponentManager` also located on the `Component`.
-public class DataSource: NSObject {
+public class DataSource: NSObject, ComponentResolvable {
   /// The component that the data source belongs to.
   weak var component: Component?
   /// An object that ensures that all views displayed for this data source are properly

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Each `Component` has its own `Delegate`, its responsible for relying appropriate
 /// invocations to `ComponentDelegate`, `ComponentFocusDelegate` etc.
 /// `Delegate` is created in the init method for `Component`.
-public class Delegate: NSObject {
+public class Delegate: NSObject, ComponentResolvable {
   /// The component that the delegate belongs to.
   weak var component: Component?
   /// An object that ensures that all views displayed for this data source are properly

--- a/Sources/Shared/Extensions/ComponentResolvable+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentResolvable+Extensions.swift
@@ -31,7 +31,7 @@ extension ComponentResolvable {
   /// - Parameters:
   ///   - indexPath: The index path of the item that should be resolved.
   ///   - closure: The resolved component and item gets passed into the closure.
-  func resolveComponentItem(at indexPath: IndexPath, closure: (Component, Item) -> Void) {
+  func resolveComponentItem(at indexPath: IndexPath, _ closure: (Component, Item) -> Void) {
     guard let component = component else {
       return
     }

--- a/Sources/Shared/Extensions/ComponentResolvable+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentResolvable+Extensions.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+extension ComponentResolvable {
+  /// Resolve a component and return it in a generic closure, otherwise return the fallback.
+  ///
+  /// - Parameters:
+  ///   - closure: The resovled component gets passed into the closure if it manages to resolved it.
+  ///   - fallback: The fallback value that should be returned if the component cannot be resolved.
+  /// - Returns: If the component is resolved then the closure manages the result, other wise use the fallback.
+  @discardableResult func resolveComponent<T>(_ closure: (Component) -> T, fallback: @autoclosure () -> T) -> T {
+    guard let component = component else {
+      return fallback()
+    }
+
+    return closure(component)
+  }
+
+  /// Resolve component from instance.
+  ///
+  /// - Parameter closure: Passes the resolved component to the closure.
+  func resolveComponent(_ closure: (Component) -> Void) {
+    guard let component = component else {
+      return
+    }
+
+    closure(component)
+  }
+
+  /// Resolve component and item at a specific index path inside the component.
+  ///
+  /// - Parameters:
+  ///   - indexPath: The index path of the item that should be resolved.
+  ///   - closure: The resolved component and item gets passed into the closure.
+  func resolveComponentItem(at indexPath: IndexPath, closure: (Component, Item) -> Void) {
+    guard let component = component else {
+      return
+    }
+
+    guard let item = component.item(at: indexPath) else {
+      return
+    }
+
+    closure(component, item)
+  }
+}

--- a/Sources/Shared/Protocols/ComponentResolvable.swift
+++ b/Sources/Shared/Protocols/ComponentResolvable.swift
@@ -1,0 +1,8 @@
+/// ComponentResolvable is used to safely and easily resolve the component instance.
+/// This is used to reduce the amount of guard's when DataSource and Delegate needs access
+/// to the components data.
+/// For more information about what `ComponentResolvable` adds, see `ComponentResolvable+Extensions`.
+protocol ComponentResolvable {
+  /// An optional component instance.
+  var component: Component? { get }
+}

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -10,27 +10,27 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let component = component else {
-      return 0
-    }
+    let numberOfItemsInSection: Int = resolveComponent({ component in
+      if component.model.layout.infiniteScrolling {
+        var additionalIndexes: Int = 0
+        var remainingWidth: CGFloat = 0
+        for item in component.model.items {
+          remainingWidth += item.size.width
 
-    if component.model.layout.infiniteScrolling {
-      var additionalIndexes: Int = 0
-      var remainingWidth: CGFloat = 0
-      for item in component.model.items {
-        remainingWidth += item.size.width
+          if remainingWidth >= collectionView.frame.size.width {
+            break
+          }
 
-        if remainingWidth >= collectionView.frame.size.width {
-          break
+          additionalIndexes += 1
         }
 
-        additionalIndexes += 1
+        return component.model.items.count + additionalIndexes
       }
 
-      return component.model.items.count + additionalIndexes
-    }
+      return component.model.items.count
+    }, fallback: 0)
 
-    return component.model.items.count
+    return numberOfItemsInSection
   }
 
   /// Asks the data source for the number of items in the specified section. (required)
@@ -90,11 +90,8 @@ extension DataSource: UITableViewDataSource {
   ///
   /// - returns: The number of rows in section.
   public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    guard let component = component else {
-      return 0
-    }
-
-    return component.model.items.count
+    let numberOfRowsInSection = resolveComponent({ $0.model.items.count }, fallback: 0)
+    return numberOfRowsInSection
   }
 
   /// Asks the data source for a cell to insert in a particular location of the table view. (required)

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -13,7 +13,7 @@ extension Delegate: NSCollectionViewDelegate {
         return
       }
 
-      resolveComponentItem(at: indexPath, closure: { component, item in
+      self?.resolveComponentItem(at: indexPath, closure: { component, item in
         if component.model.interaction.mouseClick == .single {
           component.delegate?.component(component, itemSelected: item)
         }

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -9,17 +9,15 @@ extension Delegate: NSCollectionViewDelegate {
      This can probably be fixed in a more convenient way in the future without delays.
      */
     Dispatch.after(seconds: 0.1) { [weak self] in
-      guard let strongSelf = self,
-        let first = indexPaths.first,
-        let component = strongSelf.component,
-        let item = component.item(at: first.item), first.item < component.model.items.count
-        else {
-          return
+      guard let indexPath = indexPaths.first else {
+        return
       }
 
-      if component.model.interaction.mouseClick == .single {
-        component.delegate?.component(component, itemSelected: item)
-      }
+      resolveComponentItem(at: indexPath, closure: { component, item in
+        if component.model.interaction.mouseClick == .single {
+          component.delegate?.component(component, itemSelected: item)
+        }
+      })
     }
   }
 
@@ -29,19 +27,17 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item being added.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, willDisplay item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    guard
-      let component = component,
-      let view = (item as? Wrappable)?.wrappedView,
-      let item = component.item(at: indexPath)
-      else {
+    resolveComponentItem(at: indexPath) { component, resolvedItem in
+      guard let view = (item as? Wrappable)?.wrappedView else {
         return
-    }
+      }
 
-    if let itemConfigurable = view as? ItemConfigurable {
-      component.configure?(itemConfigurable)
-    }
+      if let itemConfigurable = view as? ItemConfigurable {
+        component.configure?(itemConfigurable)
+      }
 
-    component.delegate?.component(component, willDisplay: view, item: item)
+      component.delegate?.component(component, willDisplay: view, item: resolvedItem)
+    }
   }
 
   /// Notifies the delegate that the specified item was removed from the collection view.
@@ -50,48 +46,44 @@ extension Delegate: NSCollectionViewDelegate {
   /// - parameter item: The item that was removed.
   /// - parameter indexPath: The index path of the item.
   public func collectionView(_ collectionView: NSCollectionView, didEndDisplaying item: NSCollectionViewItem, forRepresentedObjectAt indexPath: IndexPath) {
-    guard
-      let component = component,
-      let view = (item as? Wrappable)?.wrappedView,
-      let item = component.item(at: indexPath)
-      else {
+    resolveComponentItem(at: indexPath) { component, resolvedItem in
+      guard let view = (item as? Wrappable)?.wrappedView else {
         return
-    }
+      }
 
-    component.delegate?.component(component, didEndDisplaying: view, item: item)
+      component.delegate?.component(component, didEndDisplaying: view, item: resolvedItem)
+    }
   }
 }
 
 extension Delegate: NSCollectionViewDelegateFlowLayout {
 
   public func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
-    guard let component = component else {
-      return CGSize.zero
-    }
-    return component.sizeForItem(at: indexPath)
+    let sizeForItem = resolveComponent({ $0.sizeForItem(at: indexPath) }, fallback: .zero)
+    return sizeForItem
   }
 }
 
 extension Delegate: NSTableViewDelegate {
 
   public func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-    guard let component = component else {
-      return 1.0
-    }
+    let heightOfRow: CGFloat = resolveComponent({ component in
+      component.model.size = CGSize(
+        width: tableView.frame.width,
+        height: tableView.frame.height)
 
-    component.model.size = CGSize(
-      width: tableView.frame.width,
-      height: tableView.frame.height)
+      let height = row < component.model.items.count
+        ? component.item(at: row)?.size.height ?? 0
+        : 1.0
 
-    let height = row < component.model.items.count
-      ? component.item(at: row)?.size.height ?? 0
-      : 1.0
+      if height == 0 {
+        return 1.0
+      }
 
-    if height == 0 {
-      return 1.0
-    }
+      return height
+    }, fallback: 1.0)
 
-    return height
+    return heightOfRow
   }
 
   public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
@@ -145,17 +137,15 @@ extension Delegate: NSTableViewDelegate {
   }
 
   public func tableView(_ tableView: NSTableView, willDisplayCell cell: Any, for tableColumn: NSTableColumn?, row: Int) {
-    guard
-      let component = component,
-      let item = component.item(at: row),
-      let cell = cell as? View
-      else {
-        return
+    resolveComponent { component in
+      guard let item = component.item(at: row),
+        let cell = cell as? View else {
+          return
+      }
+
+      let view = (cell as? Wrappable)?.wrappedView ?? cell
+      component.delegate?.component(component, willDisplay: view, item: item)
     }
-
-    let view = (cell as? Wrappable)?.wrappedView ?? cell
-
-    component.delegate?.component(component, willDisplay: view, item: item)
   }
 
   public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -13,11 +13,11 @@ extension Delegate: NSCollectionViewDelegate {
         return
       }
 
-      self?.resolveComponentItem(at: indexPath, closure: { component, item in
+      self?.resolveComponentItem(at: indexPath) { component, item in
         if component.model.interaction.mouseClick == .single {
           component.delegate?.component(component, itemSelected: item)
         }
-      })
+      }
     }
   }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -98,6 +98,12 @@
 		BD798EF81EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
 		BD798EF91EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
 		BD798EFA1EA2A1320069EFB7 /* TestSpotsControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */; };
+		BD91A94E1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */; };
+		BD91A94F1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */; };
+		BD91A9501F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */; };
+		BD91A9521F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */; };
+		BD91A9531F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */; };
+		BD91A9541F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */; };
 		BD99824C1EA93684000A6FD4 /* ViewPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD99824B1EA93684000A6FD4 /* ViewPreparer.swift */; };
 		BD99824D1EA93684000A6FD4 /* ViewPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD99824B1EA93684000A6FD4 /* ViewPreparer.swift */; };
 		BD99824E1EA93684000A6FD4 /* ViewPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD99824B1EA93684000A6FD4 /* ViewPreparer.swift */; };
@@ -453,6 +459,8 @@
 		BD77D1FB1E85382D0075A3FC /* ComponentModel+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ComponentModel+Equatable.swift"; sourceTree = "<group>"; };
 		BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManager.swift; sourceTree = "<group>"; };
 		BD798EF71EA2A1320069EFB7 /* TestSpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsControllerManager.swift; sourceTree = "<group>"; };
+		BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentResolvable.swift; sourceTree = "<group>"; };
+		BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ComponentResolvable+Extensions.swift"; sourceTree = "<group>"; };
 		BD99824B1EA93684000A6FD4 /* ViewPreparer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPreparer.swift; sourceTree = "<group>"; };
 		BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+List.swift"; sourceTree = "<group>"; };
 		BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+macOS+Carousel.swift"; sourceTree = "<group>"; };
@@ -853,6 +861,7 @@
 				BDAD85411E3E7032008289AE /* SpotsController+SpotsControllerManager.swift */,
 				BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */,
 				BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */,
+				BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -874,6 +883,7 @@
 				BDAD85511E3E7032008289AE /* UserInterface.swift */,
 				D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */,
 				BDAD85531E3E7032008289AE /* Wrappable.swift */,
+				BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1553,6 +1563,7 @@
 				BDAD85771E3E7032008289AE /* RegistryType.swift in Sources */,
 				BDAD85DA1E3E7032008289AE /* Dispatch.swift in Sources */,
 				BDAD84C11E3E701C008289AE /* ListWrapper.swift in Sources */,
+				BD91A9541F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */,
 				BD77D1FA1E8538080075A3FC /* ComponentKind.swift in Sources */,
 				BD9ECEC51E6EC8B8003E4388 /* Component+iOS+List.swift in Sources */,
 				BDAD84D11E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */,
@@ -1571,6 +1582,7 @@
 				BDAD84E11E3E701C008289AE /* UITableView+UserInterface.swift in Sources */,
 				BDAD85711E3E7032008289AE /* Animation.swift in Sources */,
 				BDAD85D71E3E7032008289AE /* Configuration.swift in Sources */,
+				BD91A9501F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */,
 				BDAD85951E3E7032008289AE /* ComponentDelegate+Extensions.swift in Sources */,
 				BD798EF61EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
 				BD77D1FE1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */,
@@ -1694,6 +1706,7 @@
 				BDAD85931E3E7032008289AE /* ComponentDelegate+Extensions.swift in Sources */,
 				BD9ECEC41E6EC8B8003E4388 /* Component+iOS+List.swift in Sources */,
 				BDCBE3851EEEFF1E00BB2514 /* ScrollViewManager.swift in Sources */,
+				BD91A94E1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */,
 				BD1F9E151EA39F02009C018B /* Array+Extensions.swift in Sources */,
 				BDAD85961E3E7032008289AE /* SpotsController+Extensions.swift in Sources */,
 				BDAD856F1E3E7032008289AE /* Animation.swift in Sources */,
@@ -1706,6 +1719,7 @@
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
 				BD1F9E191EA39F2E009C018B /* Dictionary+Extensions.swift in Sources */,
 				BDA3D96C1EC6F1A400141227 /* ItemManager.swift in Sources */,
+				BD91A9521F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */,
 				BDC5F3791F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */,
 				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
 				BD99824C1EA93684000A6FD4 /* ViewPreparer.swift in Sources */,
@@ -1799,6 +1813,7 @@
 				BDAD85F11E3E7032008289AE /* TypeAlias.swift in Sources */,
 				BDAD85201E3E7025008289AE /* Inset+macOS.swift in Sources */,
 				BD1F9E161EA39F02009C018B /* Array+Extensions.swift in Sources */,
+				BD91A9531F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */,
 				BDAD85C71E3E7032008289AE /* SpotsProtocol.swift in Sources */,
 				BDAD858E1E3E7032008289AE /* Component+Mutation.swift in Sources */,
 				BDAD85241E3E7025008289AE /* NSScrollView+Extensions.swift in Sources */,
@@ -1847,6 +1862,7 @@
 				BD9ECEB71E6EC6B4003E4388 /* Component+macOS+Carousel.swift in Sources */,
 				BDAD851A1E3E7025008289AE /* SpotsContentView.swift in Sources */,
 				BD9ECEB81E6EC6BC003E4388 /* Component+macOS+List.swift in Sources */,
+				BD91A94F1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */,
 				BD44D1E41EADC48200F7205E /* HeaderMode.swift in Sources */,
 				BDAD851E1E3E7025008289AE /* Delegate+macOS+Extensions.swift in Sources */,
 				BD9ECEBA1E6EC6D1003E4388 /* Component+macOS+Grid.swift in Sources */,


### PR DESCRIPTION
This adds a new protocol called `ComponentResolvable`. Its an internal
protocol that gets a set of helper methods using protocol extensions.
It is used in `DataSource` and `Delegate` to reduce the amount of guard
statements that we previously had when ever either of the two had to
access the component data.