### PR TITLE
Fix rendering issue related to .integral in SpotsScrollView

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -128,14 +128,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
         return nil
     }
 
-    // The collection view has to be larger than 1 pixel in height for the layout to proceed.
-    // If the collection view is smaller, it assumes that it is not visible on screen, most likely
-    // because the `Component` that the collection view belong to is either above or below
-    // the current view port.
-    guard collectionView.frame.size.height > 1 else {
-      return nil
-    }
-
     var attributes = [UICollectionViewLayoutAttributes]()
     var nextX: CGFloat = sectionInset.left
     var nextY: CGFloat = 0.0

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -240,7 +240,18 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
         frame.size.width = ceil(componentsView.frame.size.width)
 
-        scrollView.frame = frame.integral
+        // Using `.integral` can sometimes set the height back to 1.
+        // To avoid this we check if the height is zero before we run `.integral`.
+        // If it was, then we set it to zero again to not have frame heights jump between
+        // one and zero when scrolling. Jump frame heights can cause rendering issues and
+        // make `UICollectionView` not render corretly when you use multiple components.
+        let shouldResetFrameSizeToZero = frame.size.height == 0
+        frame = frame.integral
+        if shouldResetFrameSizeToZero {
+          frame.size.height = 0
+        }
+
+        scrollView.frame = frame
         scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
 
         yOffsetOfCurrentSubview += scrollView.contentSize.height

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -245,9 +245,9 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
         // If it was, then we set it to zero again to not have frame heights jump between
         // one and zero when scrolling. Jump frame heights can cause rendering issues and
         // make `UICollectionView` not render corretly when you use multiple components.
-        let shouldResetFrameSizeToZero = frame.size.height == 0
+        let shouldResetFrameHeightToZero = frame.size.height == 0
         frame = frame.integral
-        if shouldResetFrameSizeToZero {
+        if shouldResetFrameHeightToZero {
           frame.size.height = 0
         }
 


### PR DESCRIPTION
In SpotsScrollView we rely on `.integral` when setting the frame. That
can sometimes manipulate the height of the frame. To avoid jumping
frames, we now check the frame height before we call `.integral` to see
if it was originally zero before the transformation. If it was zero, we
set the frame size height to be zero.

This fixes rendering issues related to `UICollectionView` when using
multiple components in a `SpotsScrollView`.