### PR TITLE
Fix crash related to queue jumping

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -342,29 +342,28 @@ public class ComponentManager {
   /// - parameter animation:  The animation that should be used (only works for Listable objects)
   /// - parameter completion: A completion closure that is performed when all mutations are performed
   public func reloadIfNeeded(items: [Item], component: Component, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
-    Dispatch.interactive { [weak self] in
+    Dispatch.main { [weak self] in
       guard let `self` = self else {
-        Dispatch.main {
-          completion?()
-        }
+        completion?()
         return
       }
 
-      let componentCopy = Component(model: component.model)
-      componentCopy.model.items = items
-      componentCopy.prepareItems(recreateComposites: true)
-      guard let changes = self.diffManager.compare(oldItems: component.model.items, newItems: componentCopy.model.items) else {
-        Dispatch.main {
-          completion?()
-        }
-        return
-      }
+      let duplicatedComponent = component.duplicate()
 
-      Dispatch.main {
-        component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-          component.model.items = componentCopy.model.items
-        }) {
-          self.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
+      Dispatch.interactive {
+        guard let changes = self.diffManager.compare(oldItems: component.model.items, newItems: duplicatedComponent.model.items) else {
+          Dispatch.main {
+            completion?()
+          }
+          return
+        }
+
+        Dispatch.main {
+          component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
+            component.model.items = duplicatedComponent.model.items
+          }) {
+            self.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
+          }
         }
       }
     }

--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -344,7 +344,9 @@ public class ComponentManager {
   public func reloadIfNeeded(items: [Item], component: Component, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     Dispatch.interactive { [weak self] in
       guard let `self` = self else {
-        completion?()
+        Dispatch.main {
+          completion?()
+        }
         return
       }
 

--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -348,23 +348,19 @@ public class ComponentManager {
         return
       }
 
-      let duplicatedComponent = component.duplicate()
+      let duplicatedComponent = Component(model: component.model)
+      duplicatedComponent.model.items = items
+      duplicatedComponent.setup(with: component.view.frame.size)
 
-      Dispatch.interactive {
-        guard let changes = self.diffManager.compare(oldItems: component.model.items, newItems: duplicatedComponent.model.items) else {
-          Dispatch.main {
-            completion?()
-          }
-          return
-        }
+      guard let changes = self.diffManager.compare(oldItems: component.model.items, newItems: duplicatedComponent.model.items) else {
+        completion?()
+        return
+      }
 
-        Dispatch.main {
-          component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
-            component.model.items = duplicatedComponent.model.items
-          }) {
-            self.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
-          }
-        }
+      component.reloadIfNeeded(changes, withAnimation: animation, updateDataSource: {
+        component.model.items = duplicatedComponent.model.items
+      }) {
+        self.finishComponentOperation(component, updateHeightAndIndexes: true, completion: completion)
       }
     }
   }

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -76,6 +76,16 @@ public extension Component {
     return height
   }
 
+  /// Creates a new instance of the `Component` using the same model information
+  /// and then invokes `setup(with:)` using `view.frame.size`.
+  ///
+  /// - Returns: A new `Component` instance with the same model information.
+  func duplicate() -> Component {
+    let component = Component(model: model)
+    component.setup(with: view.frame.size)
+    return component
+  }
+
   func configureClosureDidChange() {
     guard let configure = configure else {
       return

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -76,16 +76,6 @@ public extension Component {
     return height
   }
 
-  /// Creates a new instance of the `Component` using the same model information
-  /// and then invokes `setup(with:)` using `view.frame.size`.
-  ///
-  /// - Returns: A new `Component` instance with the same model information.
-  func duplicate() -> Component {
-    let component = Component(model: model)
-    component.setup(with: view.frame.size)
-    return component
-  }
-
   func configureClosureDidChange() {
     guard let configure = configure else {
       return


### PR DESCRIPTION
The previous attempts to improve the user experience resulted in a bug
when trying to update the data source. Because we set the items in a
different queue, the data source could not determine that the diff was
correct after updating the data source. Now we will create a temporary
component, prepare the new items and do the diffing based on what the
new items get as values. Previously the model data was always updated
even if there wasn't any changes which is not what we want. Now the
model data is updating inside the `updateDataSource` closure.