### PR TITLE
Improve automatic animation for component flow layout

### DIFF
--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -359,7 +359,11 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
       }
 
       attributes.zIndex = -1
-      attributes.alpha = 1.0
+
+      if type == .insert {
+        attributes.alpha = 0.0
+      }
+
       attributes.center = .init(x: attributes.center.x,
                                 y: attributes.center.y - attributes.frame.size.height)
     }


### PR DESCRIPTION
When inserting, the item should not display immediately, it should fade
from alpha 0 to 1.