### PR TITLE
Refactor user interface extensions to not wrap cells

### DIFF
--- a/Sources/Shared/Classes/ViewPreparer.swift
+++ b/Sources/Shared/Classes/ViewPreparer.swift
@@ -23,7 +23,7 @@ class ViewPreparer {
     case let view as Wrappable:
       prepareWrappableView(view, atIndex: index, in: component, parentFrame: parentFrame)
     case let view as ItemConfigurable:
-      prepareItemConfigurableView(view, atIndex: index, in: component, configureView: true)
+      prepareItemConfigurableView(view, atIndex: index, in: component)
     default:
       assertionFailure("Unable to prepare view.")
     }
@@ -49,7 +49,7 @@ class ViewPreparer {
     } else if let wrappedView = Configuration.views.make(identifier, parentFrame: parentFrame)?.view {
       view.configure(with: wrappedView)
       if let configurableView = wrappedView as? ItemConfigurable {
-        prepareItemConfigurableView(configurableView, atIndex: index, in: component, configureView: false)
+        prepareItemConfigurableView(configurableView, atIndex: index, in: component)
       } else {
         component.model.items[index].size.height = wrappedView.frame.size.height
       }
@@ -63,15 +63,11 @@ class ViewPreparer {
   ///   - view: The view that should be prepared.
   ///   - index: The index of the item on the model.
   ///   - component: The component that the item belongs to.
-  func prepareItemConfigurableView(_ view: ItemConfigurable, atIndex index: Int, in component: Component, configureView: Bool = false) {
+  func prepareItemConfigurableView(_ view: ItemConfigurable, atIndex index: Int, in component: Component) {
     view.configure(with: component.model.items[index])
 
     if component.model.items[index].size.height == 0.0 {
       component.model.items[index].size = view.computeSize(for: component.model.items[index], containerSize: component.view.frame.size)
-    }
-
-    if configureView {
-      component.configure?(view)
     }
   }
 }

--- a/Sources/Shared/Extensions/Wrappable+Extensions.swift
+++ b/Sources/Shared/Extensions/Wrappable+Extensions.swift
@@ -7,10 +7,7 @@ public extension Wrappable {
 
     view.frame = bounds
     self.wrappedView = view
-    configureWrappedView()
 
     contentView.addSubview(view)
   }
-
-  func configureWrappedView() {}
 }

--- a/Sources/Shared/Protocols/Wrappable.swift
+++ b/Sources/Shared/Protocols/Wrappable.swift
@@ -7,5 +7,4 @@ public protocol Wrappable: class {
   var wrappedView: View? { get set }
 
   func configure(with view: View)
-  func configureWrappedView()
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -78,7 +78,13 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   }
 
   /// The underlying view for this component, usually UITableView or UICollectionView
-  public var view: ScrollView
+  public var view: ScrollView {
+    didSet {
+      if let userInterface = view as? UserInterface {
+        userInterface.register()
+      }
+    }
+  }
 
   /// A computed variable that casts the current `userInterface` into a `UITableView`.
   /// It will return `nil` if the model kind is not `.list`.

--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -13,13 +13,6 @@ public class GridWrapper: UICollectionViewCell, Wrappable, Cell {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func configureWrappedView() {
-    if let cell = wrappedView as? UICollectionViewCell {
-      cell.contentView.frame = contentView.frame
-      cell.isUserInteractionEnabled = false
-    }
-  }
-
   override public func layoutSubviews() {
     super.layoutSubviews()
 

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -16,13 +16,6 @@ public class ListWrapper: UITableViewCell, Wrappable, Cell {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func configureWrappedView() {
-    if let cell = wrappedView as? UITableViewCell {
-      cell.contentView.frame = contentView.frame
-      cell.isUserInteractionEnabled = false
-    }
-  }
-
   override public func layoutSubviews() {
     super.layoutSubviews()
     wrappedView?.frame.size = contentView.bounds.size

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -11,6 +11,10 @@ extension UICollectionView: UserInterface {
     Configuration.register(view: GridWrapper.self, identifier: CollectionView.compositeIdentifier)
     register(GridWrapper.self, forCellWithReuseIdentifier: CollectionView.compositeIdentifier)
 
+    if Configuration.views.defaultItem == nil {
+      register(GridWrapper.self, forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
+    }
+
     for (identifier, item) in Configuration.views.storage {
       if identifier.contains(CompositeComponent.identifier) {
         continue
@@ -18,8 +22,6 @@ extension UICollectionView: UserInterface {
 
       switch item {
       case .classType(let classType):
-        register(GridWrapper.self, forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
-
         guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
           return
         }
@@ -45,9 +47,6 @@ extension UICollectionView: UserInterface {
                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
                    withReuseIdentifier: identifier)
         }
-
-
-
       case .nib(let nib):
         register(nib, forCellWithReuseIdentifier: identifier)
       }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -21,22 +21,22 @@ extension UICollectionView: UserInterface {
       }
 
       switch item {
-      case .classType(let classType):
+      case .classType(_):
         guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
           return
         }
 
         if view is UICollectionViewCell {
-          register(classType, forCellWithReuseIdentifier: identifier)
+          register(type(of: view), forCellWithReuseIdentifier: identifier)
         } else {
           register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
         }
 
         if view is UICollectionReusableView {
-          register(classType,
+          register(type(of: view),
                    forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
                    withReuseIdentifier: identifier)
-          register(classType,
+          register(type(of: view),
                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
                    withReuseIdentifier: identifier)
         } else {

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -17,17 +17,36 @@ extension UICollectionView: UserInterface {
       }
 
       switch item {
-      case .classType(_):
-        register(GridHeaderFooterWrapper.self,
-                 forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                 withReuseIdentifier: identifier)
-        register(GridHeaderFooterWrapper.self,
-                 forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
-                 withReuseIdentifier: identifier)
-        register(GridWrapper.self,
-                 forCellWithReuseIdentifier: identifier)
-        register(GridWrapper.self,
-                 forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
+      case .classType(let classType):
+        register(GridWrapper.self, forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
+        let view = Configuration.views.make(identifier, useCache: true)?.view
+        let isCell = view as? UICollectionViewCell != nil
+        let isHeader = view as? UICollectionReusableView != nil
+
+        if isCell {
+          register(classType, forCellWithReuseIdentifier: identifier)
+        } else {
+          register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
+        }
+
+        if isHeader {
+          register(classType,
+                   forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
+                   withReuseIdentifier: identifier)
+          register(classType,
+                   forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
+                   withReuseIdentifier: identifier)
+        } else {
+          register(GridHeaderFooterWrapper.self,
+                   forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
+                   withReuseIdentifier: identifier)
+          register(GridHeaderFooterWrapper.self,
+                   forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
+                   withReuseIdentifier: identifier)
+        }
+
+
+
       case .nib(let nib):
         register(nib, forCellWithReuseIdentifier: identifier)
       }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -19,17 +19,18 @@ extension UICollectionView: UserInterface {
       switch item {
       case .classType(let classType):
         register(GridWrapper.self, forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
-        let view = Configuration.views.make(identifier, useCache: true)?.view
-        let isCell = view as? UICollectionViewCell != nil
-        let isHeader = view as? UICollectionReusableView != nil
 
-        if isCell {
+        guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
+          return
+        }
+
+        if view is UICollectionViewCell {
           register(classType, forCellWithReuseIdentifier: identifier)
         } else {
           register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
         }
 
-        if isHeader {
+        if view is UICollectionReusableView {
           register(classType,
                    forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
                    withReuseIdentifier: identifier)

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -19,17 +19,17 @@ extension UITableView: UserInterface {
       switch item {
       case .classType(let classType):
         register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
-        let view = Configuration.views.make(identifier, useCache: true)?.view
-        let isCell = view as? UITableViewCell != nil
-        let isHeader = view as? UITableViewHeaderFooterView != nil
+        guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
+          return
+        }
 
-        if isCell {
+        if view is UITableViewCell {
           register(classType, forCellReuseIdentifier: identifier)
         } else {
           register(ListWrapper.self, forCellReuseIdentifier: identifier)
         }
 
-        if isHeader {
+        if view is UITableViewHeaderFooterView {
           register(classType, forHeaderFooterViewReuseIdentifier: identifier)
         } else {
           register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -17,10 +17,23 @@ extension UITableView: UserInterface {
       }
 
       switch item {
-      case .classType(_):
-        register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
+      case .classType(let classType):
         register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
-        register(ListWrapper.self, forCellReuseIdentifier: identifier)
+        let view = Configuration.views.make(identifier, useCache: true)?.view
+        let isCell = view as? UITableViewCell != nil
+        let isHeader = view as? UITableViewHeaderFooterView != nil
+
+        if isCell {
+          register(classType, forCellReuseIdentifier: identifier)
+        } else {
+          register(ListWrapper.self, forCellReuseIdentifier: identifier)
+        }
+
+        if isHeader {
+          register(classType, forHeaderFooterViewReuseIdentifier: identifier)
+        } else {
+          register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
+        }
       case .nib(let nib):
         register(nib, forCellReuseIdentifier: identifier)
       }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -11,6 +11,10 @@ extension UITableView: UserInterface {
     Configuration.register(view: ListWrapper.self, identifier: TableView.compositeIdentifier)
     register(ListWrapper.self, forCellReuseIdentifier: TableView.compositeIdentifier)
 
+    if Configuration.views.defaultItem == nil {
+      register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
+    }
+
     for (identifier, item) in Configuration.views.storage {
       if identifier.contains(CompositeComponent.identifier) {
         continue
@@ -18,7 +22,6 @@ extension UITableView: UserInterface {
 
       switch item {
       case .classType(let classType):
-        register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
         guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
           return
         }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -21,19 +21,19 @@ extension UITableView: UserInterface {
       }
 
       switch item {
-      case .classType(let classType):
-        guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
+      case .classType(_):
+        guard let view = Configuration.views.make(identifier, useCache: false)?.view else {
           return
         }
 
         if view is UITableViewCell {
-          register(classType, forCellReuseIdentifier: identifier)
+          register(type(of: view), forCellReuseIdentifier: identifier)
         } else {
           register(ListWrapper.self, forCellReuseIdentifier: identifier)
         }
 
         if view is UITableViewHeaderFooterView {
-          register(classType, forHeaderFooterViewReuseIdentifier: identifier)
+          register(type(of: view), forHeaderFooterViewReuseIdentifier: identifier)
         } else {
           register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
         }

--- a/SpotsTests/iOS/TestDataSource.swift
+++ b/SpotsTests/iOS/TestDataSource.swift
@@ -11,8 +11,8 @@ class DataSourceTests: XCTestCase {
   func testDataSourceForListableObject() {
     Configuration.register(view: CustomListCell.self, identifier: "custom")
     let component = Component(model: ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
-      Item(title: "title 1"),
-      Item(title: "title 2")
+      Item(title: "title 1", kind: "custom"),
+      Item(title: "title 2", kind: "custom")
       ]))
 
     component.setup(with: CGSize(width: 100, height: 100))
@@ -22,8 +22,8 @@ class DataSourceTests: XCTestCase {
       return
     }
 
-    var itemCell1: ListWrapper? = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? ListWrapper
-    let itemCell2: ListWrapper? = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 1, section: 0)) as? ListWrapper
+    var itemCell1: CustomListCell? = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? CustomListCell
+    let itemCell2: CustomListCell? = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 1, section: 0)) as? CustomListCell
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
@@ -37,21 +37,16 @@ class DataSourceTests: XCTestCase {
     /// Check that preferred view size is applied if height is 0.0
     component.model.items[0].kind = "custom"
     component.model.items[0].size.height = 0.0
-    itemCell1 = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? ListWrapper
+    itemCell1 = component.componentDataSource!.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? CustomListCell
 
-    guard let itemConfigurable = itemCell1?.wrappedView as? CustomListCell else {
-      XCTFail("Unable to resolve list wrapper.")
-      return
-    }
-
-    XCTAssertNotNil(itemConfigurable)
+    XCTAssertNotNil(itemCell1)
     XCTAssertEqual(component.model.items[0].size.height, 44)
   }
 
   func testDataSourceForGridableObject() {
     let component = Component(model: ComponentModel(kind: .grid, layout: Layout(span: 1.0), items: [
-      Item(title: "title 1"),
-      Item(title: "title 2")
+      Item(title: "title 1", kind: "custom"),
+      Item(title: "title 2", kind: "custom")
       ]))
 
     component.setup(with: CGSize(width: 100, height: 100))
@@ -67,8 +62,8 @@ class DataSourceTests: XCTestCase {
     }
 
 
-    var itemCell1: GridWrapper? = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 0, section: 0)) as? GridWrapper
-    let itemCell2: GridWrapper? = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 1, section: 0)) as? GridWrapper
+    var itemCell1: CustomGridCell? = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 0, section: 0)) as? CustomGridCell
+    let itemCell2: CustomGridCell? = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 1, section: 0)) as? CustomGridCell
 
     XCTAssertNotNil(itemCell1)
     XCTAssertNotNil(itemCell2)
@@ -80,9 +75,8 @@ class DataSourceTests: XCTestCase {
     /// Check that preferred view size is applied if height is 0.0
     component.model.items[0].kind = "custom"
     component.model.items[0].size.height = 0.0
-    itemCell1 = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 0, section: 0)) as? GridWrapper
-    let itemConfigurable = itemCell1?.wrappedView as! CustomGridCell
-    XCTAssertNotNil(itemConfigurable)
+    itemCell1 = dataSource.collectionView(collectionView, cellForItemAt: IndexPath(item: 0, section: 0)) as? CustomGridCell
+    XCTAssertNotNil(itemCell1)
     XCTAssertEqual(component.model.items[0].size.height, 44)
   }
 


### PR DESCRIPTION
When using UITableViewCell and UICollectionView cells, you don't want
those to be wrapped in other views as they can be used directly on the
interface.

The user interface implementation will now check if the view is a cell
or not. If it is the default cell for the interface then it will
register the view instead of wrapping it. Normal views will be wrapped
inside a wrapper cell.

This change is only for iOS/tvOS.