### PR TITLE
Set numberOfPages on page control in `afterUpdate`

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -336,5 +336,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     if !compositeComponents.isEmpty {
       setup(with: view.frame.size)
     }
+
+    pageControl.numberOfPages = model.items.count
   }
 }


### PR DESCRIPTION
We had a bug that the `numberOfPages` did not represent the number of
items if you performed a mutation on the Component. In short, they
become out-of-sync. To fix this problem, we now set the `numberOfPages`
to `model.items.count` in `afterUpdate` which is invoked after all
mutations done on the `Component`.