### PR TITLE
Only allow other gestures that are attached to views that reside in componentsView

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -323,6 +323,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   }
 
   public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-    return true
+    return otherGestureRecognizer.view?.superview == componentsView
   }
 }


### PR DESCRIPTION
To avoid collision between other gestures and the scrolling in
SpotsScrollView, `shouldRecognizeSimultaneouslyWith` will now only
allow use if the view that the gesture is attached to resides inside
componentsView. Which in other words means that it belongs to a
component.