### PR TITLE
Remove rect optimization for horizontal components.

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -51,10 +51,7 @@ public extension Component {
       #endif
     } else if let collectionView = collectionView {
       #if os(macOS)
-        if let collectionViewLayout = collectionView.collectionViewLayout {
-          height = collectionViewLayout.collectionViewContentSize.height
-        }
-
+        height = model.size?.height ?? 0
         height += headerView?.frame.size.height ?? 0
         height += footerView?.frame.size.height ?? 0
       #else

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -168,14 +168,16 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
           } else {
             nextY = itemAttribute.frame.maxY + minimumLineSpacing
           }
+
+          attributes.append(itemAttribute)
         } else {
           itemAttribute.frame.origin.y += component.headerHeight
-        }
-
-        // Only add item attributes if the item frame insects the rect passed into the method.
-        // This removes unwanted computation when a collection view scrolls.
-        if itemAttribute.frame.intersects(rect) {
-          attributes.append(itemAttribute)
+          // Only add item attributes if the item frame insects the rect passed into the method.
+          // This removes unwanted computation when a collection view scrolls.
+          // Note that this only applies to vertical components.
+          if itemAttribute.frame.intersects(rect) {
+            attributes.append(itemAttribute)
+          }
         }
 
         if index >= cachedFrames.count {

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -73,6 +73,7 @@ public class ComponentFlowLayout: FlowLayout {
     }
 
     contentSize.height += CGFloat(component.model.layout.inset.top + component.model.layout.inset.bottom)
+    component.model.size = contentSize
   }
 
   public override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {

--- a/Sources/macOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/macOS/Classes/ComponentFlowLayout.swift
@@ -123,12 +123,12 @@ public class ComponentFlowLayout: FlowLayout {
         } else {
           nextY = itemAttribute.frame.maxY + CGFloat(component.model.layout.lineSpacing)
         }
+        attributes.append(itemAttribute)
       } else {
         itemAttribute.frame.origin.y += CGFloat(component.model.layout.inset.top)
-      }
-
-      if itemAttribute.frame.intersects(rect) {
-        attributes.append(itemAttribute)
+        if itemAttribute.frame.intersects(rect) {
+          attributes.append(itemAttribute)
+        }
       }
     }
 

--- a/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
+++ b/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
@@ -43,7 +43,7 @@ class ComponentFlowLayoutSharedTests: XCTestCase {
     let (component, flowLayout) = createComponent(with: layout)
     let layoutAttributes = flowLayout.sharedLayoutAttributesForElements(in: component.view.frame)
 
-    XCTAssertEqual(layoutAttributes.count, 1)
+    XCTAssertEqual(layoutAttributes.count, 4)
     XCTAssertEqual(component.model.items[0].size, CGSize(width: 100, height: 50))
 
     // Check that the layout attributes correspond to the model sizes


### PR DESCRIPTION
Horizontal components needs a larger rect to work properly when scrolling. If we check if the attribute intersects the item we can end up with jumpy views meaning that the item will adjust itself within
milliseconds of it being displayed when scrolling fast. This does not happens now that we have removed the optimization.