### PR TITLE
Refactor Component+Core to be less dependent on the user interface

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -20,9 +20,10 @@ public extension Component {
 
     var height: CGFloat = 0
 
-    if tableView != nil {
+    switch model.kind {
+    case .list:
       #if !os(OSX)
-        let superViewHeight = self.view.superview?.frame.size.height ?? UIScreen.main.bounds.height
+        let superViewHeight = UIScreen.main.bounds.height
       #endif
 
       for item in model.items {
@@ -49,25 +50,19 @@ public extension Component {
           height += 28
         }
       #endif
-    } else if let collectionView = collectionView {
+    case .grid:
+      height = model.size?.height ?? 0
       #if os(macOS)
-        height = model.size?.height ?? 0
         height += headerView?.frame.size.height ?? 0
         height += footerView?.frame.size.height ?? 0
-      #else
-        if let collectionViewLayout = collectionView.collectionViewLayout as? FlowLayout {
-          switch collectionViewLayout.scrollDirection {
-          case .horizontal:
-            if let firstItem = item(at: 0), firstItem.size.height > collectionViewLayout.collectionViewContentSize.height {
-              height = firstItem.size.height + collectionViewLayout.sectionInset.top + collectionViewLayout.sectionInset.bottom
-            } else {
-              height = collectionViewLayout.collectionViewContentSize.height
-            }
-          case .vertical:
-            height = collectionView.collectionViewLayout.collectionViewContentSize.height
-          }
-        }
       #endif
+    case .carousel:
+        height = model.size?.height ?? 0
+        if let firstItem = item(at: 0), firstItem.size.height > height {
+          height = firstItem.size.height
+          height += CGFloat(model.layout.inset.top)
+          height += CGFloat(model.layout.inset.bottom)
+      }
     }
 
     return height

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -113,6 +113,8 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
       contentSize.height += component.headerHeight
       contentSize.height += component.footerHeight
     }
+
+    component.model.size = contentSize
   }
 
   /// Returns the layout attributes for all of the cells and views in the specified rectangle.


### PR DESCRIPTION
Because we cannot access UI elements in the main thread, the code is
now refactored to use the model instead of directly accessing
properties that are only allowed in the main thread.

The code should also be easier to read now that it has been refactored
into a switch case instead of nested if statements.