### PR TITLE
Improve registering views

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -338,5 +338,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     pageControl.numberOfPages = model.items.count
+    view.superview?.layoutIfNeeded()
   }
 }

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -21,22 +21,18 @@ extension UICollectionView: UserInterface {
       }
 
       switch item {
-      case .classType(_):
-        guard let view = Configuration.views.make(identifier, useCache: true)?.view else {
-          return
-        }
-
-        if view is UICollectionViewCell {
-          register(type(of: view), forCellWithReuseIdentifier: identifier)
+      case .classType(let classType):
+        if classType is UICollectionViewCell.Type {
+          register(classType, forCellWithReuseIdentifier: identifier)
         } else {
           register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
         }
 
-        if view is UICollectionReusableView {
-          register(type(of: view),
+        if classType is UICollectionReusableView.Type {
+          register(classType,
                    forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
                    withReuseIdentifier: identifier)
-          register(type(of: view),
+          register(classType,
                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
                    withReuseIdentifier: identifier)
         } else {

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -21,18 +21,18 @@ extension UICollectionView: UserInterface {
       }
 
       switch item {
-      case .classType(let classType):
-        if classType is UICollectionViewCell.Type {
-          register(classType, forCellWithReuseIdentifier: identifier)
+      case .classType(let type):
+        if type is UICollectionViewCell.Type {
+          register(type, forCellWithReuseIdentifier: identifier)
         } else {
           register(GridWrapper.self, forCellWithReuseIdentifier: identifier)
         }
 
-        if classType is UICollectionReusableView.Type {
-          register(classType,
+        if type is UICollectionReusableView.Type {
+          register(type,
                    forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
                    withReuseIdentifier: identifier)
-          register(classType,
+          register(type,
                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
                    withReuseIdentifier: identifier)
         } else {

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -21,15 +21,15 @@ extension UITableView: UserInterface {
       }
 
       switch item {
-      case .classType(let classType):
-        if classType is UITableViewCell.Type {
-          register(classType, forCellReuseIdentifier: identifier)
+      case .classType(let type):
+        if type is UITableViewCell.Type {
+          register(type, forCellReuseIdentifier: identifier)
         } else {
           register(ListWrapper.self, forCellReuseIdentifier: identifier)
         }
 
-        if classType is UITableViewHeaderFooterView.Type {
-          register(classType, forHeaderFooterViewReuseIdentifier: identifier)
+        if type is UITableViewHeaderFooterView.Type {
+          register(type, forHeaderFooterViewReuseIdentifier: identifier)
         } else {
           register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
         }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -21,19 +21,15 @@ extension UITableView: UserInterface {
       }
 
       switch item {
-      case .classType(_):
-        guard let view = Configuration.views.make(identifier, useCache: false)?.view else {
-          return
-        }
-
-        if view is UITableViewCell {
-          register(type(of: view), forCellReuseIdentifier: identifier)
+      case .classType(let classType):
+        if classType is UITableViewCell.Type {
+          register(classType, forCellReuseIdentifier: identifier)
         } else {
           register(ListWrapper.self, forCellReuseIdentifier: identifier)
         }
 
-        if view is UITableViewHeaderFooterView {
-          register(type(of: view), forHeaderFooterViewReuseIdentifier: identifier)
+        if classType is UITableViewHeaderFooterView.Type {
+          register(classType, forHeaderFooterViewReuseIdentifier: identifier)
         } else {
           register(ListHeaderFooterWrapper.self, forHeaderFooterViewReuseIdentifier: identifier)
         }


### PR DESCRIPTION
Refactors the register methods on `UICollectionView+UserInterface.swift` and `UITableView+UserInterface.swift` to not initialize a view for comparison. Instead it will compare the `classType` with the corresponding dequeuable views for the user interface.

Doing this caused a recursion if the view that is being registered has a nested component inside.

This should also increase performance as the view no longer have to be initialized before registering. It is just types... all the way down.

This also fixes a small UI glitch by invoking `layoutIfNeeded` on the components super view after it is done mutating.