### PR TITLE
Include .relations when comparing two items

### DIFF
--- a/Sources/Shared/Classes/DiffManager.swift
+++ b/Sources/Shared/Classes/DiffManager.swift
@@ -180,6 +180,10 @@ class DiffManager {
       return .meta
     }
 
+    if !(newModel.relations as NSDictionary).isEqual(to: oldModel.relations) {
+      return .relations
+    }
+
     return .none
   }
 }

--- a/SpotsTests/Shared/DiffManagerTests.swift
+++ b/SpotsTests/Shared/DiffManagerTests.swift
@@ -116,4 +116,24 @@ class DiffManagerTests: XCTestCase {
     XCTAssertEqual(changes.moved[0], 2)
     XCTAssertEqual(changes.moved[2], 0)
   }
+
+  func testComparingRelations() {
+    var lhsItem = Item()
+    lhsItem.relations["a"] = [Item(title: "a")]
+
+    var rhsItem = Item()
+    rhsItem.relations["b"] = [Item(title: "b")]
+
+    // Comparing two equal items should not generate any changes.
+    XCTAssertNil(manager.compare(oldItems: [lhsItem], newItems: [lhsItem]))
+
+    let changes = manager.compare(oldItems: [lhsItem], newItems: [rhsItem])!
+    XCTAssertEqual(changes.insertions.count, 0)
+    XCTAssertEqual(changes.updates.count, 1)
+    XCTAssertTrue(changes.updates.contains(0))
+    XCTAssertEqual(changes.reloads.count, 0)
+    XCTAssertEqual(changes.deletions.count, 0)
+    XCTAssertEqual(changes.childUpdates.count, 0)
+    XCTAssertEqual(changes.moved.count, 0)
+  }
 }


### PR DESCRIPTION
Now the `DiffManager` will take `.relations` into account when diffing.
If relations has changed it will generate an update for the user interface.