### PR TITLE
Move sizeForItem to ItemManager and improve safety

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -241,4 +241,27 @@ public class ItemManager {
       item.size.width = view.bounds.width
     }
   }
+
+
+  /// Resolve size property for an item at index path inside component.
+  ///
+  /// - Parameters:
+  ///   - indexPath: The index path of the item.
+  ///   - component: The component that item resides in.
+  /// - Returns: The size of the item, unless the size is negative, then it will return zero.
+  public func sizeForItem(at indexPath: IndexPath, in component: Component) -> CGSize {
+    var size = component.item(at: indexPath)?.size ?? .zero
+
+    // Never return a negative width.
+    if size.width < 0.0 {
+      size.width = 0.0
+    }
+
+    // Never return a negative height.
+    if size.height < 0.0 {
+      size.height = 0.0
+    }
+
+    return size
+  }
 }

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -242,8 +242,10 @@ public class ItemManager {
     }
   }
 
-
   /// Resolve size property for an item at index path inside component.
+  /// This method is used to ensure that user interface never receive negative
+  /// size values as that can lead to the user interface implementation throwing
+  /// an exception.
   ///
   /// - Parameters:
   ///   - indexPath: The index path of the item.

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -255,6 +255,22 @@ public class ItemManager {
     var size = component.item(at: indexPath)?.size ?? .zero
     size.width = max(size.width, 0)
     size.height = max(size.height, 0)
+
+    #if os(macOS)
+      // Make sure that the item width never exceeds the frame view width.
+      // If it does exceed the maximum width, the layout span will be used to reduce the size to make sure
+      // that all items fit on the same row.
+      if component.model.layout.span > 0 {
+        let inset = CGFloat(component.model.layout.inset.left + component.model.layout.inset.right)
+        let maxWidth = size.width * CGFloat(component.model.layout.span) + inset
+
+        if maxWidth > component.view.frame.size.width {
+          size.width -= CGFloat(component.model.layout.span)
+          size.width = round(size.width)
+        }
+      }
+    #endif
+
     return size
   }
 }

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -253,17 +253,8 @@ public class ItemManager {
   /// - Returns: The size of the item, unless the size is negative, then it will return zero.
   public func sizeForItem(at indexPath: IndexPath, in component: Component) -> CGSize {
     var size = component.item(at: indexPath)?.size ?? .zero
-
-    // Never return a negative width.
-    if size.width < 0.0 {
-      size.width = 0.0
-    }
-
-    // Never return a negative height.
-    if size.height < 0.0 {
-      size.height = 0.0
-    }
-
+    size.width = max(size.width, 0)
+    size.height = max(size.height, 0)
     return size
   }
 }

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -242,6 +242,13 @@ public extension Component {
     }
   }
 
+  /// Get the size of the item at index path.
+  ///
+  /// - Parameter indexPath: The index path of the item that should be resolved.
+  /// - Returns: A `CGSize` based of the `Item`'s width and height.
+  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
+    return manager.itemManager.sizeForItem(at: indexPath, in: self)
+  }
+
   func configure(with layout: Layout) {}
 }
-

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -297,14 +297,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
   }
 
-  /// Get the size of the item at index path.
-  ///
-  /// - Parameter indexPath: The index path of the item that should be resolved.
-  /// - Returns: A `CGSize` based of the `Item`'s width and height.
-  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    return manager.itemManager.sizeForItem(at: indexPath, in: self)
-  }
-
   /// Scroll to a specific item based on predicate.
   ///
   /// - parameter predicate: A predicate closure to determine which item to scroll to.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -302,10 +302,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// - Parameter indexPath: The index path of the item that should be resolved.
   /// - Returns: A `CGSize` based of the `Item`'s width and height.
   public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    return CGSize(
-      width:  item(at: indexPath)?.size.width  ?? 0.0,
-      height: item(at: indexPath)?.size.height ?? 0.0
-    )
+    return manager.itemManager.sizeForItem(at: indexPath, in: self)
   }
 
   /// Scroll to a specific item based on predicate.

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -348,32 +348,6 @@ import Tailor
     delegate?.component(self, itemSelected: item)
   }
 
-  /// Get the size of the item at index path.
-  ///
-  /// - Parameter indexPath: The index path of the item that should be resolved.
-  /// - Returns: A `CGSize` based of the `Item`'s width and height.
-  public func sizeForItem(at indexPath: IndexPath) -> CGSize {
-    var size = CGSize(
-      width:  round(item(at: indexPath)?.size.width ?? 0.0),
-      height: round(item(at: indexPath)?.size.height ?? 0.0)
-    )
-
-    // Make sure that the item width never exceeds the frame view width.
-    // If it does exceed the maximum width, the layout span will be used to reduce the size to make sure
-    // that all items fit on the same row.
-    if model.layout.span > 0 {
-      let inset = CGFloat(model.layout.inset.left + model.layout.inset.right)
-      let maxWidth = size.width * CGFloat(model.layout.span) + inset
-
-      if maxWidth > view.frame.size.width {
-        size.width -= CGFloat(model.layout.span)
-        size.width = round(size.width)
-      }
-    }
-
-    return size
-  }
-
   public func didResize(size: CGSize, type: ComponentResize) {
     if !compositeComponents.isEmpty && type == .end {
       reload(nil)

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		BD31BB9D1EA6209C00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
 		BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
 		BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */; };
+		BD357EAF1F46C940002B39AB /* ItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD357EAE1F46C940002B39AB /* ItemManagerTests.swift */; };
+		BD357EB01F46C940002B39AB /* ItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD357EAE1F46C940002B39AB /* ItemManagerTests.swift */; };
+		BD357EB11F46C940002B39AB /* ItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD357EAE1F46C940002B39AB /* ItemManagerTests.swift */; };
 		BD3B4A8D1EEFAB7B007ABD3B /* ScrollViewManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3B4A8C1EEFAB7B007ABD3B /* ScrollViewManagerTests.swift */; };
 		BD4295551D81D39700E07E1C /* ComponentiOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4295541D81D39700E07E1C /* ComponentiOSTests.swift */; };
 		BD42CA851E4C9B2600A86E3B /* ComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42CA841E4C9B2600A86E3B /* ComponentTests.swift */; };
@@ -442,6 +445,7 @@
 		BD2403101E4B9A02005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveAlgorithmTests.swift; sourceTree = "<group>"; };
 		BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateConfigurationClosureTests.swift; sourceTree = "<group>"; };
+		BD357EAE1F46C940002B39AB /* ItemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemManagerTests.swift; sourceTree = "<group>"; };
 		BD3B4A8C1EEFAB7B007ABD3B /* ScrollViewManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewManagerTests.swift; sourceTree = "<group>"; };
 		BD4295541D81D39700E07E1C /* ComponentiOSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentiOSTests.swift; sourceTree = "<group>"; };
 		BD42CA841E4C9B2600A86E3B /* ComponentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
@@ -1091,6 +1095,7 @@
 				BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */,
 				BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */,
 				BD5D69D71F398E740078AC19 /* DiffManagerTests.swift */,
+				BD357EAE1F46C940002B39AB /* ItemManagerTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1638,6 +1643,7 @@
 				BD650CF81ECAC2C100DFD220 /* ItemConfigurableComputeSizeTests.swift in Sources */,
 				BD45D9891E30906300C2D6B2 /* LayoutTests.swift in Sources */,
 				BDCFCD431DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
+				BD357EB11F46C940002B39AB /* ItemManagerTests.swift in Sources */,
 				BD677E8B1DC61EFC006D1654 /* TestStateCache.swift in Sources */,
 				BD7397381D718CDB000AF2DE /* TestComponentModel.swift in Sources */,
 				BD5FE3451EA6222C0008749C /* TestComponentDelegate+iOS.swift in Sources */,
@@ -1789,6 +1795,7 @@
 				BD45D98B1E30909700C2D6B2 /* TestLayoutExtensions.swift in Sources */,
 				BD30491D1F041C7E00D9EECB /* MoveAlgorithmTests.swift in Sources */,
 				BDDF2CCC1DC7C23500B766BA /* TestAnimations.swift in Sources */,
+				BD357EAF1F46C940002B39AB /* ItemManagerTests.swift in Sources */,
 				BDEED2E81D8446400030B475 /* TestSpotsScrollView.swift in Sources */,
 				BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */,
 				BD677E851DC616B2006D1654 /* ComponentSharedTests.swift in Sources */,
@@ -1928,6 +1935,7 @@
 				BDE3864B1EFAEA5200320A6D /* RegistryTests.swift in Sources */,
 				BD9AB9F61E44AD9700085677 /* ComponentSharedTests.swift in Sources */,
 				BDB1FCBA1ECEE6140042ED61 /* ComponentFlowLayoutTests.swift in Sources */,
+				BD357EB01F46C940002B39AB /* ItemManagerTests.swift in Sources */,
 				BD31BB9E1EA6209D00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
 				BDCFCD421DCA7EFF0047E84C /* TestSpotsController.swift in Sources */,
 				BDE44B171EA0F0E50021EAC8 /* TestComponentManager.swift in Sources */,

--- a/SpotsTests/Shared/ItemManagerTests.swift
+++ b/SpotsTests/Shared/ItemManagerTests.swift
@@ -1,0 +1,26 @@
+@testable import Spots
+import Foundation
+import XCTest
+
+class ItemManagerTests: XCTestCase {
+
+  func testSizeForItem() {
+    let items = [
+      Item(size: CGSize(width: 100, height: 100)),
+      Item(size: CGSize(width: 100, height: -100)),
+    ]
+    let model = ComponentModel(kind: .grid, items: items)
+    let component = Component(model: model)
+
+    // Should return the same size as the item.
+    XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 0, section: 0)),
+                   CGSize(width: 100, height: 100))
+    // Should never return a negative value.
+    XCTAssertEqual(component.sizeForItem(at: IndexPath(item: 1, section: 0)),
+                   CGSize(width: 100, height: 0))
+
+    component.setup(with: CGSize(width: 100, height: 100))
+    // When an item is prepared, the item should be larger than zero.
+    XCTAssertTrue(component.sizeForItem(at: IndexPath(item: 1, section: 0)).height > 0)
+  }
+}


### PR DESCRIPTION
Collection view flow layouts are sensitive to receiving negative
values, so this commit adds a safety feature in `sizeForItem` that
makes it so that it cannot return negative values when resolving an
items size.

The implementation has also been moved from the component extension
into the `ItemManager`, this makes it easier to test.