### PR TITLE
Add max to calculateSpanWidth

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -22,7 +22,7 @@ public class ItemManager {
 
     let inset = CGFloat(component.model.layout.inset.left + component.model.layout.inset.right)
     let componentWidth: CGFloat = component.view.frame.size.width - inset
-    return (componentWidth / CGFloat(component.model.layout.span)) - CGFloat(component.model.layout.itemSpacing)
+    return max((componentWidth / CGFloat(component.model.layout.span)) - CGFloat(component.model.layout.itemSpacing), 0)
   }
 
   func prepareItems(component: Component, recreateComposites: Bool = true) {


### PR DESCRIPTION
To make sure that we never return negative values, this adds max to the return
value of the method. This should ensure that the method is never less
than 0.