### PR TITLE
Implement functionality to reload component header and footer

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ReactiveX/RxSwift" "3.5.0"
+github "ReactiveX/RxSwift" "3.6.1"
 github "hyperoslo/Cache" "3.3.0"
 github "onmyway133/SwiftHash" "1.4.0"
 github "zenangst/Tailor" "2.2.1"

--- a/Sources/Shared/Extensions/Component+HeaderFooter.swift
+++ b/Sources/Shared/Extensions/Component+HeaderFooter.swift
@@ -1,0 +1,35 @@
+import CoreGraphics
+
+extension Component {
+  func reloadHeader() {
+    guard let header = model.header, let headerView = headerView else {
+      return
+    }
+
+    if let itemConfigurable = headerView as? ItemConfigurable {
+      let size = CGSize(
+        width: view.frame.width,
+        height: itemConfigurable.computeSize(for: header, containerSize: view.frame.size).height
+      )
+      headerView.frame.size = size
+      itemConfigurable.configure(with: header)
+      model.header = header
+    }
+  }
+
+  func reloadFooter() {
+    guard let footer = model.footer, let footerView = footerView else {
+      return
+    }
+
+    if let itemConfigurable = footerView as? ItemConfigurable {
+      let size = CGSize(
+        width: view.frame.width,
+        height: itemConfigurable.computeSize(for: footer, containerSize: view.frame.size).height
+      )
+      footerView.frame.size = size
+      itemConfigurable.configure(with: footer)
+      model.footer = footer
+    }
+  }
+}

--- a/Sources/Shared/Extensions/Component+Mutation.swift
+++ b/Sources/Shared/Extensions/Component+Mutation.swift
@@ -97,6 +97,8 @@ public extension Component {
   /// - parameter completion: A completion closure that is performed when all mutations are performed
   func reload(_ indexes: [Int]? = nil, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     manager.reload(indexes: indexes, component: self, withAnimation: animation, completion: completion)
+    reloadHeader()
+    reloadFooter()
   }
 
   /// Reload component with ItemChanges.

--- a/Sources/Shared/Extensions/Component+Mutation.swift
+++ b/Sources/Shared/Extensions/Component+Mutation.swift
@@ -97,8 +97,6 @@ public extension Component {
   /// - parameter completion: A completion closure that is performed when all mutations are performed
   func reload(_ indexes: [Int]? = nil, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     manager.reload(indexes: indexes, component: self, withAnimation: animation, completion: completion)
-    reloadHeader()
-    reloadFooter()
   }
 
   /// Reload component with ItemChanges.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -153,8 +153,8 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func setup(with size: CGSize) {
     view.frame.size = size
 
-    setupFooter(with: &model)
-    setupHeader(with: &model)
+    setupFooter()
+    setupHeader()
 
     if let tableView = self.tableView {
       setupTableView(tableView, with: size)

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -4,6 +4,7 @@ extension Component {
 
   func setupHeader() {
     guard let header = model.header, headerView == nil else {
+      reloadHeader()
       return
     }
 
@@ -27,6 +28,7 @@ extension Component {
 
   func setupFooter() {
     guard let footer = model.footer, footerView == nil else {
+      reloadFooter()
       return
     }
 

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -2,21 +2,14 @@ import UIKit
 
 extension Component {
 
-  func setupHeader(with model: inout ComponentModel) {
+  func setupHeader() {
     guard let header = model.header, headerView == nil else {
       return
     }
 
     if let headerView = Configuration.views.make(header.kind)?.view {
-      if let itemConfigurable = headerView as? ItemConfigurable {
-        let size = CGSize(width: view.frame.width,
-                          height: itemConfigurable.computeSize(for: header, containerSize: view.frame.size).height)
-        headerView.frame.size = size
-        itemConfigurable.configure(with: header)
-
-      }
-      model.header = header
-
+      self.headerView = headerView
+      reloadHeader()
       headerView.layer.zPosition = 100
 
       switch model.layout.headerMode {
@@ -29,32 +22,22 @@ extension Component {
           backgroundView.addSubview(headerView)
         }
       }
-
-      self.headerView = headerView
     }
   }
 
-  func setupFooter(with model: inout ComponentModel) {
+  func setupFooter() {
     guard let footer = model.footer, footerView == nil else {
       return
     }
 
     if let footerView = Configuration.views.make(footer.kind)?.view {
-      if let itemConfigurable = footerView as? ItemConfigurable {
-        let size = CGSize(width: view.frame.width,
-                          height: itemConfigurable.computeSize(for: footer, containerSize: view.frame.size).height)
-        footerView.frame.size = size
-        itemConfigurable.configure(with: footer)
-      }
-      model.footer = footer
-
+      self.footerView = footerView
+      reloadFooter()
       footerView.layer.zPosition = 99
 
       if model.kind != .list {
         view.addSubview(footerView)
       }
-
-      self.footerView = footerView
     }
   }
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -366,6 +366,8 @@ import Tailor
       let size = CGSize(width: superview.frame.width,
                         height: view.frame.height)
       layout(with: size)
+      setupHeader()
+      setupFooter()
 
       guard model.kind == .carousel else {
         return

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -205,8 +205,8 @@ import Tailor
   public func setup(with size: CGSize) {
     scrollView.frame.size = size
 
-    setupHeader(with: &model)
-    setupFooter(with: &model)
+    setupHeader()
+    setupFooter()
 
     configureDataSourceAndDelegate()
 

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -2,39 +2,29 @@ import Cocoa
 
 extension Component {
 
-  func setupHeader(with model: inout ComponentModel) {
+  func setupHeader() {
     guard let header = model.header, headerView == nil else {
       return
     }
 
     if let (_, headerView) = Configuration.views.make(header.kind) {
-      if let headerView = headerView,
-        let itemConfigurable = headerView as? ItemConfigurable {
-        itemConfigurable.configure(with: header)
-        let size = CGSize(width: view.frame.width,
-                          height: itemConfigurable.computeSize(for: header, containerSize: view.frame.size).height)
-        headerView.frame.size = size
-        model.header = header
+      if let headerView = headerView {
         self.headerView = headerView
+        reloadHeader()
         scrollView.addSubview(headerView)
       }
     }
   }
 
-  func setupFooter(with model: inout ComponentModel) {
+  func setupFooter() {
     guard let footer = model.footer, footerView == nil else {
       return
     }
 
     if let (_, footerView) = Configuration.views.make(footer.kind) {
-      if let footerView = footerView,
-        let itemConfigurable = footerView as? ItemConfigurable {
-        itemConfigurable.configure(with: footer)
-        let size = CGSize(width: view.frame.width,
-                          height: itemConfigurable.computeSize(for: footer, containerSize: view.frame.size).height)
-        footerView.frame.size = size
-        model.footer = footer
+      if let footerView = footerView {
         self.footerView = footerView
+        reloadFooter()
         scrollView.addSubview(footerView)
       }
     }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -374,6 +374,9 @@
 		D58478E71C440645006EBA49 /* TestComponentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D584782B1C43FF34006EBA49 /* TestComponentModel.swift */; };
 		D58478ED1C440726006EBA49 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
 		D58478F91C44076B006EBA49 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478F71C44076B006EBA49 /* Tailor.framework */; };
+		D58A10F11F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
+		D58A10F21F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
+		D58A10F31F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
 		D5D282671E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282681E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282691E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
@@ -606,6 +609,7 @@
 		D58478E91C440726006EBA49 /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/iOS/Tailor.framework; sourceTree = "<group>"; };
 		D58478EC1C440726006EBA49 /* Cache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cache.framework; path = Carthage/Build/iOS/Cache.framework; sourceTree = "<group>"; };
 		D58478F71C44076B006EBA49 /* Tailor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Tailor.framework; path = Carthage/Build/Mac/Tailor.framework; sourceTree = "<group>"; };
+		D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Component+HeaderFooter.swift"; sourceTree = "<group>"; };
 		D5D282661E54710D004BF251 /* ViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewState.swift; sourceTree = "<group>"; };
 		D5D2826A1E547219004BF251 /* ViewStateDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewStateDelegate.swift; sourceTree = "<group>"; };
 		D5D2826E1E5474E0004BF251 /* Cell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
@@ -880,6 +884,7 @@
 				BD0AF3511E83CC53008795C3 /* UserInterface+Extensions.swift */,
 				BDAD85431E3E7032008289AE /* Wrappable+Extensions.swift */,
 				BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */,
+				D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1608,6 +1613,7 @@
 				BDAD85951E3E7032008289AE /* ComponentDelegate+Extensions.swift in Sources */,
 				BD798EF61EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
 				BD77D1FE1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */,
+				D58A10F31F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */,
 				BD9ECEC21E6EC8AF003E4388 /* Component+iOS+Grid.swift in Sources */,
 				BDAD85651E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD84E31E3E701C008289AE /* UIViewController+Extensions.swift in Sources */,
@@ -1766,6 +1772,7 @@
 				52CD427A1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,
 				BDAD85781E3E7032008289AE /* CarouselScrollDelegate+Extensions.swift in Sources */,
 				BDDCF6EF1E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
+				D58A10F11F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */,
 				BD44D1E31EADC48200F7205E /* HeaderMode.swift in Sources */,
 				BD20E6601F384672008C2B8B /* DiffManager.swift in Sources */,
 				BD9ECEBE1E6EC8A5003E4388 /* Component+iOS+Carousel.swift in Sources */,
@@ -1858,6 +1865,7 @@
 				BDAD85971E3E7032008289AE /* SpotsController+Extensions.swift in Sources */,
 				BDAD85E21E3E7032008289AE /* Interaction.swift in Sources */,
 				BDAD85D61E3E7032008289AE /* Configuration.swift in Sources */,
+				D58A10F21F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */,
 				BDAD85C41E3E7032008289AE /* ComponentFocusDelegate.swift in Sources */,
 				BD165A3B1E6EAF310023AF82 /* ComponentFlowLayout.swift in Sources */,
 				D5D282701E5474E0004BF251 /* Cell.swift in Sources */,

--- a/SpotsTests/iOS/TestComponentDelegate+iOS.swift
+++ b/SpotsTests/iOS/TestComponentDelegate+iOS.swift
@@ -114,21 +114,21 @@ class ComponentDelegateiOSTests: XCTestCase {
 
     component.model.header = Item(kind: "regular-header")
     component.headerView = nil
-    component.setupHeader(with: &component.model)
+    component.setupHeader()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 44)
 
     component.model.header = Item(kind: "")
     component.headerView = nil
-    component.setupHeader(with: &component.model)
+    component.setupHeader()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 0)
 
     component.model.header = Item(kind: "item-configurable-header")
     component.headerView = nil
-    component.setupHeader(with: &component.model)
+    component.setupHeader()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForHeaderInSection: 0), 75)
@@ -161,28 +161,28 @@ class ComponentDelegateiOSTests: XCTestCase {
 
     component.model.footer = nil
     component.footerView = nil
-    component.setupFooter(with: &component.model)
+    component.setupFooter()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
 
     component.model.footer = Item(kind: "regular-footer")
     component.footerView = nil
-    component.setupFooter(with: &component.model)
+    component.setupFooter()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 44)
 
     component.model.footer = Item(kind: "")
     component.footerView = nil
-    component.setupFooter(with: &component.model)
+    component.setupFooter()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 0)
 
     component.model.footer = Item(kind: "item-configurable-footer")
     component.footerView = nil
-    component.setupFooter(with: &component.model)
+    component.setupFooter()
     tableView.reloadDataSource()
 
     XCTAssertEqual(delegate.tableView(tableView, heightForFooterInSection: 0), 75)


### PR DESCRIPTION
- Remove `model` parameter from `setupFooter` and `setupHeader` functions because we mutate instance variable anyway.
- Add `reloadHeader` and `reloadFooter` internal functions which are used during setup process and on `reload` of component. Now it's possible to change header/footer title, size and all the `Item` fields after the setup.