### PR TITLE
Reload header and footer after update

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -326,6 +326,9 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       setup(with: view.frame.size)
     }
 
+    reloadHeader()
+    reloadFooter()
+
     pageControl.numberOfPages = model.items.count
     view.superview?.layoutIfNeeded()
   }

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -4,7 +4,6 @@ extension Component {
 
   func setupHeader() {
     guard let header = model.header, headerView == nil else {
-      reloadHeader()
       return
     }
 
@@ -28,7 +27,6 @@ extension Component {
 
   func setupFooter() {
     guard let footer = model.footer, footerView == nil else {
-      reloadFooter()
       return
     }
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -366,8 +366,8 @@ import Tailor
       let size = CGSize(width: superview.frame.width,
                         height: view.frame.height)
       layout(with: size)
-      setupHeader()
-      setupFooter()
+      reloadHeader()
+      reloadFooter()
 
       guard model.kind == .carousel else {
         return


### PR DESCRIPTION
I didn't notice `if !compositeComponents.isEmpty` condition, so actually `setup` is not called after update, we have to call it manually for iOS as well.