### PR TITLE
Feature collection view extension to get layout as flow layout

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -111,7 +111,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     registerDefaultIfNeeded(view: DefaultItemView.self)
     userInterface?.register()
 
-    if let collectionViewLayout = collectionView?.collectionViewLayout as? ComponentFlowLayout {
+    if let collectionViewLayout = collectionView?.flowLayout {
       model.layout.configure(collectionViewLayout: collectionViewLayout)
     }
 

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -29,7 +29,7 @@ extension Component {
   }
 
   func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let collectionViewLayout = collectionView.flowLayout else {
+    guard let collectionViewLayout = collectionView.flowLayout as? ComponentFlowLayout else {
       return
     }
 

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -3,7 +3,7 @@ import UIKit
 extension Component {
 
   func setupHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let collectionViewLayout = collectionView.collectionViewLayout as? ComponentFlowLayout else {
+    guard let collectionViewLayout = collectionView.flowLayout else {
       return
     }
 
@@ -29,7 +29,7 @@ extension Component {
   }
 
   func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let collectionViewLayout = collectionView.collectionViewLayout as? ComponentFlowLayout else {
+    guard let collectionViewLayout = collectionView.flowLayout else {
       return
     }
 

--- a/Sources/iOS/Extensions/Component+iOS+Grid.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Grid.swift
@@ -3,7 +3,7 @@ import UIKit
 extension Component {
 
   func layoutVerticalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let collectionViewLayout = collectionView.collectionViewLayout as? ComponentFlowLayout else {
+    guard let collectionViewLayout = collectionView.flowLayout else {
       return
     }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -205,7 +205,7 @@ extension Delegate: UICollectionViewDelegateFlowLayout {
   /// - parameter section:              The index number of the section whose line spacing is needed.
   /// - returns: The minimum space (measured in points) to apply between successive lines in a section.
   public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-    if let layout = collectionView.collectionViewLayout as? ComponentFlowLayout {
+    if let layout = collectionView.flowLayout {
       return layout.minimumLineSpacing
     } else {
       return 0
@@ -220,7 +220,7 @@ extension Delegate: UICollectionViewDelegateFlowLayout {
   ///
   /// - returns: The margins to apply to items in the section.
   public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-    if let layout = collectionView.collectionViewLayout as? ComponentFlowLayout {
+    if let layout = collectionView.flowLayout {
       guard layout.scrollDirection == .horizontal else {
         return layout.sectionInset
       }

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -18,7 +18,7 @@ extension Layout {
     collectionViewLayout.minimumLineSpacing = CGFloat(lineSpacing)
   }
 
-  public func configure(collectionViewLayout: CollectionLayout) {
+  public func configure(collectionViewLayout: FlowLayout) {
     collectionViewLayout.sectionInset = UIEdgeInsets(
       top: CGFloat(inset.top),
       left: CGFloat(inset.left),

--- a/Sources/iOS/Extensions/Layout+iOS.swift
+++ b/Sources/iOS/Extensions/Layout+iOS.swift
@@ -3,7 +3,7 @@ import UIKit
 extension Layout {
 
   public func configure(component: Component) {
-    guard let collectionViewLayout = component.collectionView?.collectionViewLayout as? FlowLayout else {
+    guard let collectionViewLayout = component.collectionView?.flowLayout else {
       return
     }
 

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -289,7 +289,7 @@ extension UICollectionView: UserInterface {
   }
 
   private func applyAnimation(animation: Animation) {
-    guard let componentFlowLayout = flowLayout else {
+    guard let componentFlowLayout = flowLayout as? ComponentFlowLayout else {
       return
     }
 
@@ -297,7 +297,7 @@ extension UICollectionView: UserInterface {
   }
 
   private func removeAnimation() {
-    guard let componentFlowLayout = flowLayout else {
+    guard let componentFlowLayout = flowLayout as? ComponentFlowLayout else {
       return
     }
 

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -289,7 +289,7 @@ extension UICollectionView: UserInterface {
   }
 
   private func applyAnimation(animation: Animation) {
-    guard let componentFlowLayout = collectionViewLayout as? ComponentFlowLayout else {
+    guard let componentFlowLayout = flowLayout else {
       return
     }
 
@@ -297,7 +297,7 @@ extension UICollectionView: UserInterface {
   }
 
   private func removeAnimation() {
-    guard let componentFlowLayout = collectionViewLayout as? ComponentFlowLayout else {
+    guard let componentFlowLayout = flowLayout else {
       return
     }
 

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -169,7 +169,7 @@ import Tailor
 
     if model.kind == .carousel {
       self.model.interaction.scrollDirection = .horizontal
-      (collectionView?.collectionViewLayout as? FlowLayout)?.scrollDirection = .horizontal
+      collectionView?.flowLayout?.scrollDirection = .horizontal
     }
   }
 
@@ -258,7 +258,7 @@ import Tailor
   ///   - collectionView: The collection view that should be configured.
   ///   - size: The size that should be used for setting up the collection view.
   fileprivate func setupCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    if let collectionViewLayout = collectionView.collectionViewLayout as? FlowLayout {
+    if let collectionViewLayout = collectionView.flowLayout {
       model.layout.configure(collectionViewLayout: collectionViewLayout)
     }
 

--- a/Sources/macOS/Classes/ComponentScrollView.swift
+++ b/Sources/macOS/Classes/ComponentScrollView.swift
@@ -15,8 +15,7 @@ class ComponentClipView: NSClipView {
   /// - Parameter newOrigin: The new origin.
   override func scroll(to newOrigin: NSPoint) {
     if let collectionView = documentView as? CollectionView {
-      if (collectionView.collectionViewLayout as? FlowLayout)?.scrollDirection == .horizontal {
-
+      if collectionView.flowLayout?.scrollDirection == .horizontal {
         super.scroll(to: newOrigin)
         return
       }

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -113,7 +113,7 @@ open class SpotsScrollView: NSScrollView {
 
       switch documentView {
       case let collectionView as NSCollectionView:
-        if let flowLayout = (collectionView.collectionViewLayout as? ComponentFlowLayout) {
+        if let flowLayout = collectionView.flowLayout as? ComponentFlowLayout {
           shouldResize = flowLayout.scrollDirection == .vertical
           contentSize = flowLayout.contentSize
         }

--- a/Sources/macOS/Extensions/CollectionView+Extensions.swift
+++ b/Sources/macOS/Extensions/CollectionView+Extensions.swift
@@ -1,0 +1,6 @@
+extension CollectionView {
+  var flowLayout: FlowLayout? {
+    set { collectionViewLayout = newValue }
+    get { return collectionViewLayout as? FlowLayout }
+  }
+}

--- a/Sources/macOS/Extensions/CollectionView+Extensions.swift
+++ b/Sources/macOS/Extensions/CollectionView+Extensions.swift
@@ -1,6 +1,5 @@
 extension CollectionView {
   var flowLayout: FlowLayout? {
-    set { collectionViewLayout = newValue }
-    get { return collectionViewLayout as? FlowLayout }
+    return collectionViewLayout as? FlowLayout
   }
 }

--- a/Sources/macOS/Extensions/Component+macOS+Carousel.swift
+++ b/Sources/macOS/Extensions/Component+macOS+Carousel.swift
@@ -8,7 +8,7 @@ extension Component {
   }
 
   func layoutHorizontalCollectionView(_ collectionView: CollectionView, with size: CGSize) {
-    guard let collectionViewLayout = collectionView.collectionViewLayout as? FlowLayout else {
+    guard let collectionViewLayout = collectionView.flowLayout else {
       return
     }
 

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -11,7 +11,7 @@ extension Component {
       if let headerView = headerView {
         self.headerView = headerView
         reloadHeader()
-        (collectionView?.collectionViewLayout as? FlowLayout)?.headerReferenceSize = headerView.frame.size
+        (collectionView?.flowLayout)?.headerReferenceSize = headerView.frame.size
         scrollView.addSubview(headerView)
       }
     }
@@ -26,7 +26,7 @@ extension Component {
       if let footerView = footerView {
         self.footerView = footerView
         reloadFooter()
-        (collectionView?.collectionViewLayout as? FlowLayout)?.footerReferenceSize = footerView.frame.size
+        (collectionView?.flowLayout)?.footerReferenceSize = footerView.frame.size
         scrollView.addSubview(footerView)
       }
     }

--- a/Sources/macOS/Extensions/Layout+macOS.swift
+++ b/Sources/macOS/Extensions/Layout+macOS.swift
@@ -5,7 +5,7 @@ extension Layout {
   public func configure(component: Component) {
     inset.configure(scrollView: component.view)
 
-    if let layout = component.collectionView?.collectionViewLayout as? FlowLayout {
+    if let layout = component.collectionView?.flowLayout {
       layout.minimumInteritemSpacing = CGFloat(itemSpacing)
       layout.minimumLineSpacing = CGFloat(lineSpacing)
     }

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -219,7 +219,7 @@ extension NSCollectionView: UserInterface {
   }
 
   private func applyAnimation(_ animation: Animation) {
-    guard let componentFlowLayout = collectionViewLayout as? ComponentFlowLayout else {
+    guard let componentFlowLayout = flowLayout as? ComponentFlowLayout else {
       return
     }
 
@@ -227,7 +227,7 @@ extension NSCollectionView: UserInterface {
   }
 
   private func removeAnimation() {
-    guard let componentFlowLayout = collectionViewLayout as? ComponentFlowLayout else {
+    guard let componentFlowLayout = flowLayout as? ComponentFlowLayout else {
       return
     }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -315,6 +315,9 @@
 		BDC5F3791F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
 		BDC5F37A1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
 		BDC5F37B1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
+		BDC7FB371F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC7FB361F500DD900BF72E0 /* CollectionView+Extensions.swift */; };
+		BDC7FB381F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC7FB361F500DD900BF72E0 /* CollectionView+Extensions.swift */; };
+		BDC7FB391F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC7FB361F500DD900BF72E0 /* CollectionView+Extensions.swift */; };
 		BDCA3CF31E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
 		BDCA3CF41E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
 		BDCA3CF51E8295EB00A98A76 /* TestUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */; };
@@ -569,6 +572,7 @@
 		BDB8D5921E4DFADC00220BC3 /* TestItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestItem.swift; sourceTree = "<group>"; };
 		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
 		BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveAlgorithm.swift; sourceTree = "<group>"; };
+		BDC7FB361F500DD900BF72E0 /* CollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+Extensions.swift"; sourceTree = "<group>"; };
 		BDCA3CF21E8295EB00A98A76 /* TestUserInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUserInterface.swift; sourceTree = "<group>"; };
 		BDCBE3841EEEFF1E00BB2514 /* ScrollViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewManager.swift; sourceTree = "<group>"; };
 		BDCFCD401DCA7EFF0047E84C /* TestSpotsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSpotsController.swift; sourceTree = "<group>"; };
@@ -794,6 +798,11 @@
 		BDAD84F91E3E7025008289AE /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				BDC7FB361F500DD900BF72E0 /* CollectionView+Extensions.swift */,
+				BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */,
+				BD9ECEB91E6EC6D1003E4388 /* Component+macOS+Grid.swift */,
+				BD9ECEBB1E6EC82D003E4388 /* Component+macOS+HeaderFooter.swift */,
+				BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */,
 				BDAD84FB1E3E7025008289AE /* DataSource+macOS+Extensions.swift */,
 				BDAD84FC1E3E7025008289AE /* Delegate+macOS+Extensions.swift */,
 				BDAD84FE1E3E7025008289AE /* Inset+macOS.swift */,
@@ -801,10 +810,6 @@
 				BDAD85011E3E7025008289AE /* NSCollectionView+UserInterface.swift */,
 				BDAD85021E3E7025008289AE /* NSScrollView+Extensions.swift */,
 				BDAD85031E3E7025008289AE /* NSTableView+UserInterface.swift */,
-				BD9ECEB61E6EC6B4003E4388 /* Component+macOS+Carousel.swift */,
-				BD9ECEB91E6EC6D1003E4388 /* Component+macOS+Grid.swift */,
-				BD9ECEBB1E6EC82D003E4388 /* Component+macOS+HeaderFooter.swift */,
-				BD9ECEB41E6EC6A7003E4388 /* Component+macOS+List.swift */,
 				BDA25E8F1EB5070F002B21C0 /* Wrappable+macOS.swift */,
 			);
 			path = Extensions;
@@ -1605,6 +1610,7 @@
 				D5D2826D1E547219004BF251 /* ViewStateDelegate.swift in Sources */,
 				D5D282691E54710D004BF251 /* ViewState.swift in Sources */,
 				BDAD85CB1E3E7032008289AE /* UserInterface.swift in Sources */,
+				BDC7FB391F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */,
 				BDDCF6F11E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BDAD84E11E3E701C008289AE /* UITableView+UserInterface.swift in Sources */,
 				BDAD85711E3E7032008289AE /* Animation.swift in Sources */,
@@ -1728,6 +1734,7 @@
 				BDAD85B41E3E7032008289AE /* RefreshDelegate.swift in Sources */,
 				BDAD859C1E3E7032008289AE /* SpotsController+SpotsControllerManager.swift in Sources */,
 				BDAD85D21E3E7032008289AE /* ComponentModel.swift in Sources */,
+				BDC7FB371F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */,
 				BDAD85EA1E3E7032008289AE /* Registry.swift in Sources */,
 				BDAD85C61E3E7032008289AE /* SpotsProtocol.swift in Sources */,
 				BDAD85E41E3E7032008289AE /* Layout.swift in Sources */,
@@ -1850,6 +1857,7 @@
 				BD1F9E161EA39F02009C018B /* Array+Extensions.swift in Sources */,
 				BD91A9531F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */,
 				BDAD85C71E3E7032008289AE /* SpotsProtocol.swift in Sources */,
+				BDC7FB381F500DD900BF72E0 /* CollectionView+Extensions.swift in Sources */,
 				BDAD858E1E3E7032008289AE /* Component+Mutation.swift in Sources */,
 				BDAD85241E3E7025008289AE /* NSScrollView+Extensions.swift in Sources */,
 				BDAD85E51E3E7032008289AE /* Layout.swift in Sources */,

--- a/SpotsTests/iOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/iOS/ComponentFlowLayoutTests.swift
@@ -79,7 +79,7 @@ class ComponentFlowLayoutTests: XCTestCase {
     let carouselComponent = Component(model: model)
     carouselComponent.setup(with: parentSize)
 
-    guard let collectionViewLayout = carouselComponent.collectionView?.collectionViewLayout as? FlowLayout else {
+    guard let collectionViewLayout = carouselComponent.collectionView?.flowLayout else {
       XCTFail("Unable to resolve collection view layout.")
       return
     }
@@ -122,7 +122,7 @@ class ComponentFlowLayoutTests: XCTestCase {
     let carouselComponent = Component(model: model)
     carouselComponent.setup(with: parentSize)
 
-    guard let collectionViewLayout = carouselComponent.collectionView?.collectionViewLayout as? FlowLayout else {
+    guard let collectionViewLayout = carouselComponent.collectionView?.flowLayout else {
       XCTFail("Unable to resolve collection view layout.")
       return
     }
@@ -153,7 +153,7 @@ class ComponentFlowLayoutTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: parentSize)
 
-    guard let collectionViewLayout = component.collectionView?.collectionViewLayout as? FlowLayout else {
+    guard let collectionViewLayout = component.collectionView?.flowLayout else {
       XCTFail("Unable to resolve collection view layout.")
       return
     }

--- a/SpotsTests/macOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/macOS/ComponentFlowLayoutTests.swift
@@ -43,20 +43,20 @@ class ComponentFlowLayoutTests: XCTestCase {
     component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
 
-    var componentFlowLayout = component.collectionView?.collectionViewLayout as? ComponentFlowLayout
+    var componentFlowLayout = component.collectionView?.flowLayout as? ComponentFlowLayout
     XCTAssertEqual(componentFlowLayout?.contentSize, CGSize(width: 1500, height: 50))
 
     model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 2), items: items)
     component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
-    componentFlowLayout = component.collectionView?.collectionViewLayout as? ComponentFlowLayout
+    componentFlowLayout = component.collectionView?.flowLayout as? ComponentFlowLayout
 
     XCTAssertEqual(componentFlowLayout?.contentSize, CGSize(width: 800, height: 100))
 
     model = ComponentModel(kind: .carousel, layout: Layout(itemsPerRow: 3), items: items)
     component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
-    componentFlowLayout = component.collectionView?.collectionViewLayout as? ComponentFlowLayout
+    componentFlowLayout = component.collectionView?.flowLayout as? ComponentFlowLayout
 
     XCTAssertEqual(componentFlowLayout?.contentSize, CGSize(width: 500, height: 150))
   }

--- a/SpotsTests/macOS/TestLayoutExtensions.swift
+++ b/SpotsTests/macOS/TestLayoutExtensions.swift
@@ -16,7 +16,7 @@ class LayoutExtensionsTests: XCTestCase {
 
   func testConfigureGridableComponent() {
     let gridComponent = Component(model: ComponentModel(kind: .grid, layout: Layout(span: 1)))
-    let componentFlowLayout = gridComponent.collectionView?.collectionViewLayout as? FlowLayout
+    let componentFlowLayout = gridComponent.collectionView?.flowLayout
     let layout = Layout(json)
 
     layout.configure(component: gridComponent)


### PR DESCRIPTION
This adds an extension on CollectionView to return the collection view's layout as a flow layout. Seeing as we always rely on the flow layout for Spots to function properly we always cast the layout into a
collection view layout. This should reduce the amount of casting that we have to do.

The nifty thing is that the extension is on a type alias which makes it platform agnostic.