### PR TITLE
Improve rendering on macOS

### DIFF
--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -141,7 +141,24 @@ public extension Component {
 
       let componentHeight = self.computedHeight
       Dispatch.main {
-        self.view.frame.size.height = componentHeight
+        #if os(macOS)
+          if let enclosingScrollView = self.view.enclosingScrollView {
+            let maxHeight = enclosingScrollView.frame.size.height - enclosingScrollView.contentInsets.top
+            let newHeight: CGFloat
+            if componentHeight > maxHeight {
+              newHeight = maxHeight
+            } else {
+              newHeight = componentHeight
+            }
+
+            if self.view.frame.size.height != newHeight {
+              self.view.frame.size.height = newHeight
+            }
+          }
+        #else
+          self.view.frame.size.height = componentHeight
+        #endif
+
         completion?()
       }
     }

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -7,13 +7,11 @@ extension Component {
       return
     }
 
-    if let (_, headerView) = Configuration.views.make(header.kind) {
-      if let headerView = headerView {
-        self.headerView = headerView
-        reloadHeader()
-        (collectionView?.flowLayout)?.headerReferenceSize = headerView.frame.size
-        scrollView.addSubview(headerView)
-      }
+    if let headerView = Configuration.views.make(header.kind)?.view {
+      self.headerView = headerView
+      reloadHeader()
+      (collectionView?.flowLayout)?.headerReferenceSize = headerView.frame.size
+      scrollView.documentView?.addSubview(headerView)
     }
   }
 
@@ -22,13 +20,11 @@ extension Component {
       return
     }
 
-    if let (_, footerView) = Configuration.views.make(footer.kind) {
-      if let footerView = footerView {
-        self.footerView = footerView
-        reloadFooter()
-        (collectionView?.flowLayout)?.footerReferenceSize = footerView.frame.size
-        scrollView.addSubview(footerView)
-      }
+    if let footerView = Configuration.views.make(footer.kind)?.view {
+      self.footerView = footerView
+      reloadFooter()
+      (collectionView?.flowLayout)?.footerReferenceSize = footerView.frame.size
+      scrollView.documentView?.addSubview(footerView)
     }
   }
 


### PR DESCRIPTION
The `Component`'s view height should never exceed the size of the enclosing scroll view - content inset. If it is larger it will use the enclosing scroll views height as it cannot be bigger than that. See
`SpotsScrollView`'s implementation for more detail on how views are resized during scrolling.

Before this fix was implemented, the screen would flicker as it would set a larger size and the reduce itself to the appropriate size.

The `Component`'s view height should never exceed the size of the enclosing scroll view - content inset. If it is larger it will use the enclosing scroll views height as it cannot be bigger than that. See
`SpotsScrollView`'s implementation for more detail on how views are resized during scrolling.

Before this fix was implemented, the screen would flicker as it would set a larger size and the reduce itself to the appropriate size.