### PR TITLE
Implement missing methods for the tvOS focus engine to work with custom views

### DIFF
--- a/Sources/iOS/Classes/GridWrapper.swift
+++ b/Sources/iOS/Classes/GridWrapper.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 public class GridWrapper: UICollectionViewCell, Wrappable, Cell {
-
   weak public var wrappedView: View?
 
   override init(frame: CGRect) {
@@ -36,4 +35,14 @@ public class GridWrapper: UICollectionViewCell, Wrappable, Cell {
       (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
     }
   }
+
+  #if os(tvOS)
+  public override var canBecomeFocused: Bool {
+    return wrappedView?.canBecomeFocused ?? false
+  }
+
+  public override var preferredFocusedView: UIView? {
+    return wrappedView
+  }
+  #endif
 }

--- a/Sources/iOS/Classes/ListWrapper.swift
+++ b/Sources/iOS/Classes/ListWrapper.swift
@@ -36,4 +36,14 @@ public class ListWrapper: UITableViewCell, Wrappable, Cell {
     super.setSelected(selected, animated: animated)
     (wrappedView as? ViewStateDelegate)?.viewStateDidChange(viewState)
   }
+
+  #if os(tvOS)
+  public override var canBecomeFocused: Bool {
+    return wrappedView?.canBecomeFocused ?? false
+  }
+
+  public override var preferredFocusedView: UIView? {
+    return wrappedView
+  }
+  #endif
 }


### PR DESCRIPTION
To get the focus engine to work properly, the wrapper needs to use the
wrapped view as the `preferredFocusedView`. It also proxies the
`canBecomeFocused` to the wrapped view.