### PR TITLE
Improve tvOS implementation

### DIFF
--- a/Sources/Shared/Protocols/ComponentFocusDelegate.swift
+++ b/Sources/Shared/Protocols/ComponentFocusDelegate.swift
@@ -1,4 +1,4 @@
 public protocol ComponentFocusDelegate: class {
-  var focusedSpot: Component? { get set }
+  var focusedComponent: Component? { get set }
   var focusedItemIndex: Int? { get set }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -223,7 +223,9 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
     collectionView.layer.masksToBounds = false
-    collectionView.remembersLastFocusedIndexPath = true
+    if #available(iOS 9.0, *) {
+      collectionView.remembersLastFocusedIndexPath = true
+    }
 
     guard model.kind == .carousel else {
       return

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -124,11 +124,12 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// - Parameter model: A component model that is used for constructing and configurating the component.
   public required convenience init(model: ComponentModel) {
     let view = model.kind == .list
-      ? TableView()
+      ? ComponentTableView()
       : ComponentCollectionView(frame: .zero, collectionViewLayout: CollectionLayout())
 
     self.init(model: model, view: view)
 
+    (tableView as? ComponentTableView)?.component = self
     (collectionView as? ComponentCollectionView)?.component = self
   }
 
@@ -222,6 +223,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
     collectionView.layer.masksToBounds = false
+    collectionView.remembersLastFocusedIndexPath = true
 
     guard model.kind == .carousel else {
       return

--- a/Sources/iOS/Classes/ComponentTableView.swift
+++ b/Sources/iOS/Classes/ComponentTableView.swift
@@ -1,15 +1,11 @@
 import UIKit
 
-/// ComponentCollectionView is a very simple subclass of UICollectionView.
-/// The purpose of this class is to forward `layoutSubviews` to the `Component`.
-/// This is used to perform infinite scrolling for horizontal layouts.
-class ComponentCollectionView: UICollectionView, UIGestureRecognizerDelegate {
-
+class ComponentTableView: UITableView {
   /// The component that the collection view belongs too.
   weak var component: Component?
 
   /// The default implementation of this method does nothing on iOS 5.1 and earlier.
-  /// Otherwise, the default implementation uses any constraints you have set to determine 
+  /// Otherwise, the default implementation uses any constraints you have set to determine
   /// the size and position of any subviews.
   /// It forwards the `layoutSubviews` to the `Component` it belongs too.
   override func layoutSubviews() {

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -8,7 +8,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     return view
   }
 
-  public weak var focusedSpot: Component?
+  public weak var focusedComponent: Component?
   public var focusedItemIndex: Int?
 
   /// A closure that is called when the controller is reloaded with components
@@ -240,6 +240,13 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     }
   }
 
+  open override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    scrollView.frame = view.bounds
+    scrollView.componentsView.frame = scrollView.bounds
+  }
+
   /// Notifies the container that the size of tis view is about to change.
   ///
   /// - parameter size:        The new size for the container’s view.
@@ -341,6 +348,10 @@ extension SpotsController {
         $0.component.delegate = delegate
         $0.component.focusDelegate = self
       }
+    }
+
+    if focusedComponent == nil {
+      focusedComponent = components.first
     }
   }
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -238,8 +238,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
         }
 
-        frame.size.width = ceil(componentsView.frame.size.width)
-
         // Using `.integral` can sometimes set the height back to 1.
         // To avoid this we check if the height is zero before we run `.integral`.
         // If it was, then we set it to zero again to not have frame heights jump between
@@ -259,7 +257,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
         var frame = subview.frame
         frame.origin.x = 0
         frame.origin.y = yOffsetOfCurrentSubview
-        frame.size.width = componentsView.bounds.size.width
         subview.frame = frame
 
         yOffsetOfCurrentSubview += frame.size.height
@@ -278,15 +275,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   /// It does this by iterating over subviewsInLayoutOrder and sets the current offset for each individual view within the container.
   open override func layoutSubviews() {
     super.layoutSubviews()
-
-    let initialContentOffset = contentOffset
     layoutViews()
-
-    guard !initialContentOffset.equalTo(contentOffset) else {
-      return
-    }
-    setNeedsLayout()
-    layoutIfNeeded()
   }
 
   /// Compare points

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -249,6 +249,14 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           frame.size.height = 0
         }
 
+        #if os(tvOS)
+          // To avoid "aggressive" scrolling on tvOS, we now give the component view extra
+          // height so that the focus engine will pick the correct perferred view.
+          if remainingContentHeight > frame.size.height {
+            frame.size.height += UIScreen.main.bounds.height / 2
+          }
+        #endif
+
         scrollView.frame = frame
         scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
 

--- a/Sources/iOS/Extensions/Component+iOS+List.swift
+++ b/Sources/iOS/Extensions/Component+iOS+List.swift
@@ -12,6 +12,7 @@ extension Component {
     tableView.frame.origin.x = round(size.width / 2 - tableView.frame.width / 2)
 
     #if os(tvOS)
+      tableView.remembersLastFocusedIndexPath = true
       tableView.layoutMargins = .zero
     #endif
 
@@ -44,7 +45,7 @@ extension Component {
   }
 
   func layoutTableView(_ tableView: TableView, with size: CGSize) {
-    tableView.frame.size.width = round(size.width - (tableView.contentInset.left))
-    tableView.frame.origin.x = round(size.width / 2 - tableView.frame.width / 2)
+    tableView.frame.size.width = round(size.width - CGFloat(model.layout.inset.left + model.layout.inset.right))
+    tableView.frame.origin.x = CGFloat(model.layout.inset.left)
   }
 }

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -87,20 +87,40 @@ extension Delegate: UICollectionViewDelegate {
       indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
-
-      #if os(tvOS)
-        // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
-        // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
-        if context.focusHeading == .up {
-          collectionView.scrollToItem(at: indexPath,
-                                      at: .centeredVertically,
-                                      animated: true)
-        }
-      #endif
     }
 
     return context.nextFocusedView?.canBecomeFocused ?? false
   }
+
+  #if os(tvOS)
+  public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
+    // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
+    guard context.focusHeading == .up else {
+      return
+    }
+
+    guard let component = component else {
+      return
+    }
+
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return
+    }
+
+    guard let spotsScrollView = collectionView.superview?.superview as? SpotsScrollView else {
+      return
+    }
+
+    if spotsScrollView.contentOffset.y > 0 {
+      spotsScrollView.isScrollEnabled = false
+      var currentOffset = spotsScrollView.contentOffset
+      currentOffset.y -= component.sizeForItem(at: indexPath).height
+      spotsScrollView.setContentOffset(currentOffset, animated: true)
+      spotsScrollView.isScrollEnabled = true
+    }
+  }
+  #endif
 }
 
 extension Delegate: UITableViewDelegate {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -85,7 +85,7 @@ extension Delegate: UICollectionViewDelegate {
     if let component = component,
       component.model.items[indexPath.item].kind != CompositeComponent.identifier,
       indexPath.item < component.model.items.count {
-      component.focusDelegate?.focusedSpot = component
+      component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
     }
 
@@ -170,7 +170,7 @@ extension Delegate: UITableViewDelegate {
     if let component = component,
       component.model.items[indexPath.item].kind != CompositeComponent.identifier,
       indexPath.item < component.model.items.count {
-      component.focusDelegate?.focusedSpot = component
+      component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
     }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -91,15 +91,15 @@ extension Delegate: UICollectionViewDelegate {
       #if os(tvOS)
         // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
         // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
-        if !indexPath.isEmpty && component.model.kind == .grid {
+        if context.focusHeading == .up {
           collectionView.scrollToItem(at: indexPath,
-                                      at: UICollectionViewScrollPosition.centeredVertically,
+                                      at: .centeredVertically,
                                       animated: true)
         }
       #endif
     }
 
-    return !indexPath.isEmpty
+    return context.nextFocusedView?.canBecomeFocused ?? false
   }
 }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -87,6 +87,16 @@ extension Delegate: UICollectionViewDelegate {
       indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
+
+      #if os(tvOS)
+        // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
+        // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
+        if !indexPath.isEmpty && component.model.kind == .grid {
+          collectionView.scrollToItem(at: indexPath,
+                                      at: UICollectionViewScrollPosition.centeredVertically,
+                                      animated: true)
+        }
+      #endif
     }
 
     return !indexPath.isEmpty

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		BDEFF54F1DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
 		BDEFF5501DD1C85300FC0537 /* TestDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */; };
 		BDF404D11F4EA2DE00F9E3B9 /* ComponentScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF404D01F4EA2DE00F9E3B9 /* ComponentScrollView.swift */; };
+		BDFBB76D1F75094600421BCF /* ComponentTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFBB76C1F75094600421BCF /* ComponentTableView.swift */; };
+		BDFBB76E1F75094600421BCF /* ComponentTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFBB76C1F75094600421BCF /* ComponentTableView.swift */; };
 		BDFC474F1E747B2B008700BF /* TestGridWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474C1E747B2B008700BF /* TestGridWrapper.swift */; };
 		BDFC47521E747B2B008700BF /* TestListWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474D1E747B2B008700BF /* TestListWrapper.swift */; };
 		D55B7AF91E423122000125C8 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
@@ -595,6 +597,7 @@
 		BDEFF54E1DD1C85300FC0537 /* TestDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDataSource.swift; sourceTree = "<group>"; };
 		BDEFF5511DD1DA8000FC0537 /* TestComponentDelegate+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TestComponentDelegate+iOS.swift"; sourceTree = "<group>"; };
 		BDF404D01F4EA2DE00F9E3B9 /* ComponentScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentScrollView.swift; sourceTree = "<group>"; };
+		BDFBB76C1F75094600421BCF /* ComponentTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTableView.swift; sourceTree = "<group>"; };
 		BDFC474C1E747B2B008700BF /* TestGridWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestGridWrapper.swift; sourceTree = "<group>"; };
 		BDFC474D1E747B2B008700BF /* TestListWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestListWrapper.swift; sourceTree = "<group>"; };
 		D55B7B021E423122000125C8 /* RxSpots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSpots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -733,6 +736,7 @@
 				BD24030B1E4B981A005BAA19 /* Component.swift */,
 				BDB1FCBB1ED060FF0042ED61 /* ComponentCollectionView.swift */,
 				BDAD84851E3E701B008289AE /* ComponentFlowLayout.swift */,
+				BDFBB76C1F75094600421BCF /* ComponentTableView.swift */,
 				BDAD848E1E3E701C008289AE /* DefaultItemView.swift */,
 				BDAD84871E3E701C008289AE /* GridHeaderFooterWrapper.swift */,
 				BDAD848A1E3E701C008289AE /* GridWrapper.swift */,
@@ -1591,6 +1595,7 @@
 				BDAD84CF1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */,
 				BDDCF6DD1E4DF91F004B38C4 /* Indexable.swift in Sources */,
 				BDAD85E91E3E7032008289AE /* Parser.swift in Sources */,
+				BDFBB76E1F75094600421BCF /* ComponentTableView.swift in Sources */,
 				BDAD859E1E3E7032008289AE /* SpotsController+SpotsControllerManager.swift in Sources */,
 				BDAD84D71E3E701C008289AE /* Inset+iOS.swift in Sources */,
 				BD1F9E1B1EA39F2E009C018B /* Dictionary+Extensions.swift in Sources */,
@@ -1781,6 +1786,7 @@
 				BDAD85871E3E7032008289AE /* ScrollDelegate+Extensions.swift in Sources */,
 				BD77D1FC1E85382D0075A3FC /* ComponentModel+Equatable.swift in Sources */,
 				BD798EF41EA28F200069EFB7 /* SpotsControllerManager.swift in Sources */,
+				BDFBB76D1F75094600421BCF /* ComponentTableView.swift in Sources */,
 				BD9ECEC11E6EC8AF003E4388 /* Component+iOS+Grid.swift in Sources */,
 				BDAD85601E3E7032008289AE /* CompositeComponent.swift in Sources */,
 				52CD427A1E4477C800187E09 /* PageIndicatorPlacement.swift in Sources */,

--- a/SpotsTests/iOS/ScrollViewManagerTests.swift
+++ b/SpotsTests/iOS/ScrollViewManagerTests.swift
@@ -26,7 +26,7 @@ class ScrollViewManagerTests: XCTestCase {
     let frame = CGRect(origin: .zero, size: CGSize(width: 100, height: 800))
     let parentView = UIView(frame: frame)
     let spotsScrollView = SpotsScrollView(frame: frame)
-    let scrollView = ScrollViewMock(frame: .zero)
+    let scrollView = ScrollViewMock(frame: .init(origin: .zero, size: .init(width: 100, height: 0)))
 
     parentView.addSubview(spotsScrollView)
     scrollView.contentSize = CGSize(width: 300, height: 200)


### PR DESCRIPTION
To make friends with the tvOS focus engine, we now have a `UITableView`
subclass called `ComponentTableVIew`. We need a subclass to set
`canBecomeFocused` to `false`.

By default, both `UITableView` and `UICollectionView` now both have
`remembersLastFocusedIndexPath` set to `true`.

`focusedSpot` has been renamed to `focusedComponent`.

`SpotsScrollView` will no longer modify the width of the subviews when
scrolling, this open up for having views that don't occupy the full
width when using them inside a `SpotsScrollView`. The `scrollView` will
now resize to the view `view.bounds` in `viewWillLayoutSubviews`.

When all the components are setup, the property `focusedComponent` will
default to the first component in `components` on `SpotsController`.

Removed some redundant code in `layoutSubviews` in `SpotsScrollView`.

`layoutTableView` has been refactored to support `inset` from `Layout`.