### PR TITLE
Improve/tvos implementation part deux

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -220,6 +220,14 @@ public class ItemManager {
         }
       }
     #endif
+
+
+    #if os(tvOS)
+      if size.height > component.view.frame.size.height {
+        size.height = component.view.frame.size.height - CGFloat(component.model.layout.inset.bottom)
+      }
+    #endif
+
     return size
   }
 }

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -224,7 +224,7 @@ public class ItemManager {
 
     #if os(tvOS)
       // This ensures that the height of the item never exceeds the size of the component view.
-      if size.height > component.view.frame.size.height {
+      if size.height > component.view.frame.size.height, component.view.superview != nil {
         size.height = component.view.frame.size.height - CGFloat(component.model.layout.inset.bottom)
       }
     #endif

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -223,6 +223,7 @@ public class ItemManager {
 
 
     #if os(tvOS)
+      // This ensures that the height of the item never exceeds the size of the component view.
       if size.height > component.view.frame.size.height {
         size.height = component.view.frame.size.height - CGFloat(component.model.layout.inset.bottom)
       }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -221,7 +221,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       return
     }
 
-
     self.model.interaction.scrollDirection = .horizontal
     setupHorizontalCollectionView(collectionView, with: size)
   }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -212,6 +212,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
     collectionView.layer.masksToBounds = false
+
     if #available(iOS 9.0, *) {
       collectionView.remembersLastFocusedIndexPath = true
     }
@@ -220,7 +221,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       return
     }
 
-    collectionView.showsHorizontalScrollIndicator = false
+
     self.model.interaction.scrollDirection = .horizontal
     setupHorizontalCollectionView(collectionView, with: size)
   }

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -379,6 +379,14 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
   ///
   /// - returns: Always returns true
   open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    guard let collectionView = collectionView else {
+      return false
+    }
+
+    guard collectionView.frame.size.height > 0 else {
+      return false
+    }
+
     return newBounds.size.height >= contentSize.height
   }
 

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -70,7 +70,6 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
 
   #if os(tvOS)
   /// A default focus guide that is constrained to the controllers
-  ///
   public lazy var focusGuide: UIFocusGuide = {
     let focusGuide = UIFocusGuide()
     focusGuide.isEnabled = false

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -208,10 +208,10 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     scrollView.clipsToBounds = true
     scrollView.delegate = self
 
+
     #if os(tvOS)
       configure(focusGuide: focusGuide, for: scrollView, enabled: false)
     #endif
-
     setupComponents()
     SpotsController.configure?(scrollView)
   }
@@ -222,12 +222,12 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
-    if let tabBarController = self.tabBarController, tabBarController.tabBar.isTranslucent {
-      scrollView.contentInset.bottom = tabBarController.tabBar.frame.size.height
-      scrollView.scrollIndicatorInsets.bottom = scrollView.contentInset.bottom
-    }
-
     #if os(iOS)
+      if let tabBarController = self.tabBarController, tabBarController.tabBar.isTranslucent {
+        scrollView.contentInset.bottom = tabBarController.tabBar.frame.size.height
+        scrollView.scrollIndicatorInsets.bottom = scrollView.contentInset.bottom
+      }
+
       refreshControl.addTarget(self, action: #selector(refreshComponent(_:)), for: .valueChanged)
 
       guard refreshDelegate != nil, refreshControl.superview == nil else {
@@ -251,7 +251,6 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
 
   open override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
-
     scrollView.frame = view.bounds
     scrollView.componentsView.frame = scrollView.bounds
   }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -3,7 +3,6 @@ import Cache
 
 /// A controller powered by components.
 open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDelegate, UIScrollViewDelegate {
-
   open var contentView: View {
     return view
   }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -123,7 +123,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   ///
   /// - Parameter subview: The subview that should no longer be observed.
   private func observeView(view: UIView) {
-    guard observedViews.contains(where: { $0 == view }) else {
+    guard !observedViews.contains(where: { $0 == view }) else {
       return
     }
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -123,7 +123,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   ///
   /// - Parameter subview: The subview that should no longer be observed.
   private func observeView(view: UIView) {
-    guard !observedViews.contains(where: { $0 == view }) else {
+    guard observedViews.contains(where: { $0 == view }) else {
       return
     }
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -249,14 +249,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           frame.size.height = 0
         }
 
-        #if os(tvOS)
-          // To avoid "aggressive" scrolling on tvOS, we now give the component view extra
-          // height so that the focus engine will pick the correct perferred view.
-          if remainingContentHeight > frame.size.height {
-            frame.size.height += UIScreen.main.bounds.height / 2
-          }
-        #endif
-
         scrollView.frame = frame
         scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -237,6 +237,12 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           frame.size.height = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
         }
 
+        #if os(tvOS)
+          if (scrollView as? CollectionView)?.flowLayout?.scrollDirection == .horizontal, frame.size.height < scrollView.contentSize.height {
+            frame.size.height = scrollView.contentSize.height
+          }
+        #endif
+
         // Using `.integral` can sometimes set the height back to 1.
         // To avoid this we check if the height is zero before we run `.integral`.
         // If it was, then we set it to zero again to not have frame heights jump between

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -212,7 +212,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
     componentsView.bounds = CGRect(origin: contentOffset, size: bounds.size)
 
     var yOffsetOfCurrentSubview: CGFloat = 0.0
-
     let lastView = subviewsInLayoutOrder.last
 
     for subview in subviewsInLayoutOrder {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -9,7 +9,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter indexPath: The index path of the item.
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
- public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
     let sizeForItem = resolveComponent({ component in
       component.sizeForItem(at: indexPath)
     }, fallback: .zero)
@@ -56,6 +56,19 @@ extension Delegate: UICollectionViewDelegate {
     }
   }
 
+  /// Asks the delegate whether the item at the specified index path can be focused.
+  ///
+  /// - parameter collectionView: The collection view object requesting this information.
+  /// - parameter indexPath:      The index path of an item in the collection view.
+  ///
+  /// - returns: YES if the item can receive be focused or NO if it can not.
+  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
+    let canFocusItem = resolveComponent({ component in
+      return component.item(at: indexPath) != nil
+    }, fallback: false)
+    return canFocusItem
+  }
+
   ///Asks the delegate whether a change in focus should occur.
   ///
   /// - parameter collectionView: The collection view object requesting this information.
@@ -63,27 +76,49 @@ extension Delegate: UICollectionViewDelegate {
   /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
   ///
   /// - returns: YES if the focus change should occur or NO if it should not.
+  @available(iOS 9.0, *)
   public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
-    guard let indexPaths = collectionView.indexPathsForSelectedItems else {
+    guard let indexPath = context.nextFocusedIndexPath else {
       return true
     }
 
-    if let component = component, let nextIndexPath = context.nextFocusedIndexPath {
+    if let component = component, indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
-      component.focusDelegate?.focusedItemIndex = nextIndexPath.item
+      component.focusDelegate?.focusedItemIndex = indexPath.item
     }
 
-    return indexPaths.isEmpty
+    return context.nextFocusedView?.canBecomeFocused ?? false
   }
 
-  public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-    if let indexPath = collectionView.indexPathsForSelectedItems?.first {
-      collectionView.deselectItem(at: indexPath, animated: true)
-      return false
-    } else {
-      return true
+  #if os(tvOS)
+  public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
+    // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
+    guard context.focusHeading == .up else {
+      return
+    }
+
+    guard let component = component else {
+      return
+    }
+
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return
+    }
+
+    guard let spotsScrollView = collectionView.superview?.superview as? SpotsScrollView else {
+      return
+    }
+
+    if spotsScrollView.contentOffset.y > 0 {
+      spotsScrollView.isScrollEnabled = false
+      var currentOffset = spotsScrollView.contentOffset
+      currentOffset.y -= component.sizeForItem(at: indexPath).height
+      spotsScrollView.setContentOffset(currentOffset, animated: true)
+      spotsScrollView.isScrollEnabled = true
     }
   }
+  #endif
 }
 
 extension Delegate: UITableViewDelegate {

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -9,7 +9,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter indexPath: The index path of the item.
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
-  @objc(collectionView:layout:sizeForItemAtIndexPath:) public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
     let sizeForItem = resolveComponent({ component in
       component.sizeForItem(at: indexPath)
     }, fallback: .zero)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -89,36 +89,6 @@ extension Delegate: UICollectionViewDelegate {
 
     return context.nextFocusedView?.canBecomeFocused ?? false
   }
-
-  #if os(tvOS)
-  public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-    // When scrolling on tvOS, the collection can lose its focus when scrolling fast in either direction,
-    // to help fight this issue, we now tell the collection view to scroll to the item that gained focus.
-    guard context.focusHeading == .up else {
-      return
-    }
-
-    guard let component = component else {
-      return
-    }
-
-    guard let indexPath = context.nextFocusedIndexPath else {
-      return
-    }
-
-    guard let spotsScrollView = collectionView.superview?.superview as? SpotsScrollView else {
-      return
-    }
-
-    if spotsScrollView.contentOffset.y > 0 {
-      spotsScrollView.isScrollEnabled = false
-      var currentOffset = spotsScrollView.contentOffset
-      currentOffset.y -= component.sizeForItem(at: indexPath).height
-      spotsScrollView.setContentOffset(currentOffset, animated: true)
-      spotsScrollView.isScrollEnabled = true
-    }
-  }
-  #endif
 }
 
 extension Delegate: UITableViewDelegate {

--- a/Sources/macOS/Classes/GridWrapper.swift
+++ b/Sources/macOS/Classes/GridWrapper.swift
@@ -47,6 +47,10 @@ class GridWrapper: NSCollectionViewItem, Wrappable, Cell {
   override func mouseDown(with event: NSEvent) {
     super.mouseDown(with: event)
 
+    guard let collectionView = collectionView else {
+      return
+    }
+
     guard let delegate = collectionView.delegate as? Delegate,
       let component = delegate.component
       else {

--- a/Sources/tvOS/Extensions/SpotsController+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsController+tvOS.swift
@@ -36,4 +36,45 @@ extension SpotsController {
     focusGuide.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
     focusGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
   }
+
+  public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+
+    guard let focusedComponent = focusedComponent else {
+      return
+    }
+
+    if focusedComponent == components.first {
+      if #available(tvOS 11.0, *) {
+        targetContentOffset.pointee.y = -scrollView.adjustedContentInset.top
+      } else {
+        targetContentOffset.pointee.y = -scrollView.contentInset.top
+      }
+      return
+    }
+
+    guard focusedComponent != components.last
+      else {
+      return
+    }
+
+    var offset: CGFloat = 0.0
+    if components.count > 3, focusedComponent === components[1] {
+      offset = scrollView.contentInset.top / 2
+    }
+
+    let directionUp = velocity.y < 0
+    let directionDown = velocity.y > 0
+
+    guard scrollView.contentOffset != targetContentOffset.pointee else {
+      return
+    }
+
+    if directionUp {
+      targetContentOffset.pointee.y = scrollView.contentOffset.y - focusedComponent.view.contentSize.height
+    } else if directionDown {
+      targetContentOffset.pointee.y = scrollView.contentOffset.y + focusedComponent.view.contentSize.height + offset
+    } else {
+      targetContentOffset.pointee.y = scrollView.contentOffset.y
+    }
+  }
 }

--- a/Sources/tvOS/Extensions/SpotsController+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsController+tvOS.swift
@@ -54,6 +54,11 @@ extension SpotsController {
 
     guard focusedComponent != components.last
       else {
+        if #available(tvOS 11.0, *) {
+          targetContentOffset.pointee.y += scrollView.adjustedContentInset.bottom / 2
+        } else {
+          targetContentOffset.pointee.y += scrollView.contentInset.bottom / 2
+        }
       return
     }
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,5 +21,5 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' -enableCodeCoverage YES test
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.3.3"
+    version: "9.0"
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "9.0"
+    version: "8.3.3"
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,15 +11,15 @@ dependencies:
 
 test:
   override:
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx clean
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF osx -J 'Spots'
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' clean
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' -enableCodeCoverage YES test
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,8 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.3.1' clean build
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.3.1' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.3.3"
+    version: "9.0"
 
 dependencies:
   override:
@@ -15,7 +15,7 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-macOS" -sdk macosx -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF osx -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3.1' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2' -enableCodeCoverage YES test

--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,8 @@ test:
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF ios -J 'Spots'
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' clean build
-    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1' -enableCodeCoverage YES test
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.3.1' clean build
+    - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "Spots-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV 1080p,OS=10.3.1' -enableCodeCoverage YES test
     - bash <(curl -s https://codecov.io/bash) -cF tvos -J 'Spots'
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator clean build
     - set -o pipefail && xcodebuild -project Spots.xcodeproj -scheme "RxSpots-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' -enableCodeCoverage YES test


### PR DESCRIPTION
Improve the tvOS implementation by removing some hacks to work with the focus engine. Now we tame the focus engine using the `scrollViewWillEndDragging` methods on the `UIScrollView`. This gives use much better fine-grained control over how scrolling should occur. I found this thread https://forums.developer.apple.com/thread/19638 that inspired the implementation. We could also implement a customization point here so that each controller can have their own scrolling behavior but that is something that we can add later on.