### PR TITLE
Opt-out from using auto resizing cells

### DIFF
--- a/Sources/iOS/Extensions/Component+iOS+List.swift
+++ b/Sources/iOS/Extensions/Component+iOS+List.swift
@@ -33,6 +33,8 @@ extension Component {
 
     /// On iOS 8 and prior, the second cell always receives the same height as the first cell. Setting estimatedRowHeight magically fixes this issue. The value being set is not relevant.
     if #available(iOS 9, *) {
+      // Set `estimatedRowHeight` to `0` to opt-out of using self-sizing cells based on autolayout.
+      tableView.estimatedRowHeight = 0
       return
     } else {
       tableView.estimatedRowHeight = 10


### PR DESCRIPTION
Using this behavior had negative impact when scrolling in larger data sets.
Seeing as we calculate the height of each rows internally, it is safe to opt out of this behavior, not doing so would lead to undesired behavior as the `UITableView` would rely on sizing that happens during scrolling instead of `Spots` internal size caching.