### PR TITLE
Add additional delegate methods for controlling scrolling on tvOS

### DIFF
--- a/Sources/Shared/Extensions/ScrollDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ScrollDelegate+Extensions.swift
@@ -7,4 +7,12 @@ public extension ScrollDelegate {
   func didReachBeginning(in scrollView: ScrollableView, completion: Completion) {
     completion?()
   }
+
+  func didReachEnd(in scrollView: ScrollableView, completion: Completion) {
+    completion?()
+  }
+
+  func didScroll(in scrollView: ScrollView) -> Bool {
+    return false
+  }
 }

--- a/Sources/Shared/Protocols/ScrollDelegate.swift
+++ b/Sources/Shared/Protocols/ScrollDelegate.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+
 /// A scroll delegate for handling didReachBeginning and didReachEnd
 public protocol ScrollDelegate: class {
 
@@ -10,4 +12,28 @@ public protocol ScrollDelegate: class {
   ///
   /// - parameter completion: A completion closure that gets triggered when the view did reach the end of the scroll view.
   func didReachEnd(in scrollView: ScrollableView, completion: Completion)
+
+  #if os(tvOS)
+  /// A delegate method that notifies when the `SpotsScrollView` scrolls. It has a return value
+  /// that can be used to opt out from the default implementation of standard `SpotsScrollView` behavior.
+  /// If the method is `true`, then `didReachBeginning` and `didReachEnd` will not be invoked.
+  ///
+  /// - Parameter scrollView: The scroll view that user interacted with.
+  /// - Returns: Return `true` if you want to override the default implementation.
+  func didScroll(in scrollView: ScrollView) -> Bool
+
+  /// A delegate method that is invoked when the user stops interacting with the scroll view.
+  /// This can be used to tailor the scroll view position depending on the content.
+  /// If the method returns `true`, it will opt-out of doing any default scroll view position
+  /// handling.
+  ///
+  /// - Parameters:
+  ///   - scrollView: The scroll view that user interacted with.
+  ///   - velocity: The velocity of the scroll gesture.
+  ///   - targetContentOffset: The `targetContentOffset` is the end position for the scroll operation,
+  ///                          you can modify the `.pointee` value to get fine-grained control over
+  ///                          where the scrolling should end up.
+  /// - Returns: Return `true` if you want to override the default implementation.
+  func didEndDragging(in scrollView: ScrollableView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) -> Bool
+  #endif
 }

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -10,6 +10,12 @@ extension SpotsController {
   /// - parameter scrollView: The scroll-view object in which the scrolling occurred.
 
   open func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    #if os(tvOS)
+      guard scrollDelegate?.didScroll(in: scrollView) == false else {
+        return
+      }
+    #endif
+
     let offset = scrollView.contentOffset
     let size = scrollView.contentSize
     let multiplier: CGFloat = !refreshPositions.isEmpty

--- a/Sources/tvOS/Extensions/SpotsController+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsController+tvOS.swift
@@ -38,6 +38,10 @@ extension SpotsController {
   }
 
   public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    guard scrollDelegate?.didEndDragging(in: scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset) == false else {
+      return
+    }
+
     guard let focusedComponent = focusedComponent else {
       return
     }


### PR DESCRIPTION
Working with the focus engine on tvOS is a lot different than iOS. By
adding additional customization points for controlling the scrolling
opens up for more fine-grained control when building your UI.

The `ScrollViewDelegate` now has two new methods that you can
implement, this reduces the amount of subclassing that you have to do
on `SpotsController`.

- func didScroll(in scrollView: ScrollView) -> Bool
- func didEndDragging(in scrollView: ScrollableView, withVelocity
velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>)
-> Bool