### PR TITLE
Refactor Configuration to be injected

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -15,8 +15,15 @@ import Foundation
 /// ```
 public class ComponentManager {
 
-  let itemManager = ItemManager()
-  let diffManager = DiffManager()
+  let itemManager: ItemManager
+  let diffManager: DiffManager
+  let configuration: Configuration
+
+  init(configuration: Configuration) {
+    self.configuration = configuration
+    self.itemManager = .init(configuration: configuration)
+    self.diffManager = .init()
+  }
 
   /// Append item to collection with animation
   ///
@@ -264,7 +271,7 @@ public class ComponentManager {
             component.model.items[index].size.height = view.computeSize(for: component.model.items[index], containerSize: component.view.frame.size).height
           }, completion: nil)
         default:
-          if let model = newItem.model, let configurator = Configuration.presenters[item.kind] {
+          if let model = newItem.model, let configurator = self.configuration.presenters[item.kind] {
             component.userInterface?.performUpdates({
               component.model.items[index].size.height = configurator(view, model, component.view.frame.size).height
             }, completion: nil)
@@ -286,7 +293,7 @@ public class ComponentManager {
         } else {
           if let view: View = component.userInterface?.view(at: index),
             let model = newItem.model,
-            let configurator = Configuration.presenters[newItem.kind] {
+            let configurator = self.configuration.presenters[newItem.kind] {
             component.model.items[index].size.height = configurator(view, model, component.view.frame.size).height
           }
         }
@@ -376,7 +383,7 @@ public class ComponentManager {
         return
       }
 
-      let duplicatedComponent = Component(model: component.model)
+      let duplicatedComponent = Component(model: component.model, configuration: self.configuration)
       duplicatedComponent.model.items = items
       duplicatedComponent.setup(with: component.view.frame.size)
 

--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -14,15 +14,14 @@ import Foundation
 /// }
 /// ```
 public class ComponentManager {
-
   let itemManager: ItemManager
   let diffManager: DiffManager
   let configuration: Configuration
 
-  init(configuration: Configuration) {
+  init(itemManager: ItemManager = .init(), diffManager: DiffManager = .init(),  configuration: Configuration) {
     self.configuration = configuration
-    self.itemManager = .init(configuration: configuration)
-    self.diffManager = .init()
+    self.itemManager = itemManager
+    self.diffManager = diffManager
   }
 
   /// Append item to collection with animation

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -12,8 +12,8 @@ public class DataSource: NSObject, ComponentResolvable {
   /// An object that ensures that all views displayed for this data source are properly
   /// configured with the model data. See `ItemConfigurable` for more information
   /// about how to configure your views.
-  var viewPreparer: ViewPreparer
-  var configuration: Configuration
+  let viewPreparer: ViewPreparer
+  let configuration: Configuration
 
   /// A computed value that holds the amount of items that the component model holds.
   var numberOfItems: Int {

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -12,7 +12,8 @@ public class DataSource: NSObject, ComponentResolvable {
   /// An object that ensures that all views displayed for this data source are properly
   /// configured with the model data. See `ItemConfigurable` for more information
   /// about how to configure your views.
-  var viewPreparer = ViewPreparer()
+  var viewPreparer: ViewPreparer
+  var configuration: Configuration
 
   /// A computed value that holds the amount of items that the component model holds.
   var numberOfItems: Int {
@@ -26,7 +27,9 @@ public class DataSource: NSObject, ComponentResolvable {
   /// Initialize a new instance of a data source with a component.
   ///
   /// - Parameter component: The component that the data source belongs to.
-  init(component: Component) {
+  init(component: Component, with configuration: Configuration = .shared) {
     self.component = component
+    self.configuration = configuration
+    self.viewPreparer = ViewPreparer(configuration: configuration)
   }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -12,7 +12,8 @@ public class Delegate: NSObject, ComponentResolvable {
   /// An object that ensures that all views displayed for this data source are properly
   /// configured with the model data. See `ItemConfigurable` for more information
   /// about how to configure your views.
-  var viewPreparer = ViewPreparer()
+  var viewPreparer: ViewPreparer
+  var configuration: Configuration
 
   #if !os(macOS)
   /// The scroll view manager handles constraining horizontal components.
@@ -25,7 +26,9 @@ public class Delegate: NSObject, ComponentResolvable {
   /// Initialize a new instance of a delegate with a component.
   ///
   /// - Parameter component: The component that the delegate belongs to.
-  init(component: Component) {
+  init(component: Component, with configuration: Configuration) {
     self.component = component
+    self.configuration = configuration
+    self.viewPreparer = ViewPreparer(configuration: configuration)
   }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -12,8 +12,8 @@ public class Delegate: NSObject, ComponentResolvable {
   /// An object that ensures that all views displayed for this data source are properly
   /// configured with the model data. See `ItemConfigurable` for more information
   /// about how to configure your views.
-  var viewPreparer: ViewPreparer
-  var configuration: Configuration
+  let viewPreparer: ViewPreparer
+  let configuration: Configuration
 
   #if !os(macOS)
   /// The scroll view manager handles constraining horizontal components.
@@ -26,7 +26,7 @@ public class Delegate: NSObject, ComponentResolvable {
   /// Initialize a new instance of a delegate with a component.
   ///
   /// - Parameter component: The component that the delegate belongs to.
-  init(component: Component, with configuration: Configuration) {
+  init(component: Component, with configuration: Configuration = .shared) {
     self.component = component
     self.configuration = configuration
     self.viewPreparer = ViewPreparer(configuration: configuration)

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -5,6 +5,11 @@
 #endif
 
 public class ItemManager {
+  var configuration: Configuration
+
+  init(configuration: Configuration = .shared) {
+    self.configuration = configuration
+  }
 
   /// Calculate the span width for an item inside of a `Component`.
   /// Span width is the amount of spaces that an `Item` will get inside of a `Component`
@@ -27,7 +32,7 @@ public class ItemManager {
 
   func prepareItems(component: Component) {
     component.model.items = prepare(component: component, items: component.model.items)
-    Configuration.views.purge()
+    configuration.views.purge()
   }
 
   func prepare(component: Component, items: [Item]) -> [Item] {
@@ -105,7 +110,7 @@ public class ItemManager {
 
       let view: View?
 
-      if let resolvedView = Configuration.views.make(kind, parentFrame: component.view.bounds, useCache: true)?.view {
+      if let resolvedView = configuration.views.make(kind, parentFrame: component.view.bounds, useCache: true)?.view {
         view = resolvedView
       } else {
         return nil
@@ -122,7 +127,7 @@ public class ItemManager {
         fullWidth = component.view.superview?.frame.size.width ?? component.view.frame.size.width
       }
 
-      if let resolvedView = Configuration.views.make(kind, parentFrame: component.view.frame, useCache: true)?.view {
+      if let resolvedView = configuration.views.make(kind, parentFrame: component.view.frame, useCache: true)?.view {
         prepare(component: component, kind: kind, view: resolvedView as Any, item: &item)
       } else {
         return nil
@@ -147,7 +152,7 @@ public class ItemManager {
         return
       }
 
-      guard let configurator = Configuration.presenters[item.kind] else {
+      guard let configurator = configuration.presenters[item.kind] else {
         return
       }
 

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -5,7 +5,7 @@
 #endif
 
 public class ItemManager {
-  var configuration: Configuration
+  let configuration: Configuration
 
   init(configuration: Configuration = .shared) {
     self.configuration = configuration

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -151,7 +151,7 @@ public class SpotsControllerManager {
   ///   - newComponentModels: The new component model that should replace the existing component.
   ///   - yOffset: The y offset of the component.
   fileprivate func replaceComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let component = Component(model: newComponentModels[index])
+    let component = Component(model: newComponentModels[index], configuration: controller.configuration)
     let oldComponent = controller.components[index]
 
     component.view.frame = oldComponent.view.frame
@@ -172,7 +172,7 @@ public class SpotsControllerManager {
   ///   - newComponentModels: The new component model that should replace the existing component.
   ///   - yOffset: The y offset of the component.
   fileprivate func newComponent(atIndex index: Int, controller: SpotsController, newComponentModels: [ComponentModel], yOffset: inout CGFloat) {
-    let component = Component(model: newComponentModels[index])
+    let component = Component(model: newComponentModels[index], configuration: controller.configuration)
     controller.components.append(component)
     controller.setupComponent(at: index, component: component)
 
@@ -370,7 +370,7 @@ public class SpotsControllerManager {
         return
       }
 
-      let newComponents: [Component] = Parser.parse(json)
+      let newComponents: [Component] = Parser.parse(json, configuration: controller.configuration)
       let newComponentModels = newComponents.map { $0.model }
       let oldComponentModels = controller.components.map { $0.model }
 
@@ -423,7 +423,7 @@ public class SpotsControllerManager {
       let performCleanup = !controller.components.isEmpty
       let previousContentOffset = controller.scrollView.contentOffset
 
-      controller.components = Parser.parse(models)
+      controller.components = Parser.parse(models, configuration: controller.configuration)
 
       if performCleanup {
         if controller.scrollView.superview == nil {
@@ -460,7 +460,7 @@ public class SpotsControllerManager {
         return
       }
 
-      controller.components = Parser.parse(json)
+      controller.components = Parser.parse(json, configuration: controller.configuration)
 
       if controller.scrollView.superview == nil {
         controller.view.addSubview(controller.scrollView)
@@ -709,7 +709,7 @@ public class SpotsControllerManager {
   ///   - completion: A completion closure that will run if updates where performed.
   /// - Returns: Will return `true` if updates where performed, otherwise `false`.
   @discardableResult private func updateComponentModel(_ model: ComponentModel, on component: Component, in controller: SpotsController, withAnimation animation: Animation = .automatic, completion: Completion) -> Bool {
-    let tempComponent = Component(model: model)
+    let tempComponent = Component(model: model, configuration: controller.configuration)
     tempComponent.setup(with: component.view.frame.size)
     tempComponent.model.size = CGSize(
       width: controller.view.frame.width,

--- a/Sources/Shared/Classes/ViewPreparer.swift
+++ b/Sources/Shared/Classes/ViewPreparer.swift
@@ -10,10 +10,9 @@
 /// It also makes sure that the resolved views get configured by invoking `configure(_ item: inout Item)` from `ItemConfigurable`
 /// on the view in question.
 class ViewPreparer {
+  let configuration: Configuration
 
-  var configuration: Configuration
-
-  init(configuration: Configuration) {
+  init(configuration: Configuration = .shared) {
     self.configuration = configuration
   }
 

--- a/Sources/Shared/Classes/ViewPreparer.swift
+++ b/Sources/Shared/Classes/ViewPreparer.swift
@@ -11,6 +11,12 @@
 /// on the view in question.
 class ViewPreparer {
 
+  var configuration: Configuration
+
+  init(configuration: Configuration) {
+    self.configuration = configuration
+  }
+
   /// Prepare the view located at a specific index inside of a component using the parent frame.
   ///
   /// - Parameters:
@@ -42,13 +48,13 @@ class ViewPreparer {
   func prepareWrappableView(_ view: Wrappable, atIndex index: Int, in component: Component, parentFrame: CGRect = CGRect.zero) {
     let identifier = component.identifier(at: index)
 
-    if let wrappedView = Configuration.views.make(identifier, parentFrame: parentFrame)?.view {
+    if let wrappedView = configuration.views.make(identifier, parentFrame: parentFrame)?.view {
       view.configure(with: wrappedView)
       if let configurableView = wrappedView as? ItemConfigurable {
         prepareItemConfigurableView(configurableView, atIndex: index, in: component)
       } else {
         if let model = component.model.items[index].model {
-          guard let configurator = Configuration.presenters[component.model.items[index].kind] else {
+          guard let configurator = configuration.presenters[component.model.items[index].kind] else {
             return
           }
 
@@ -81,7 +87,7 @@ class ViewPreparer {
         return
       }
 
-      guard let presenter = Configuration.presenters[item.kind] else {
+      guard let presenter = configuration.presenters[item.kind] else {
         return
       }
 

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -217,10 +217,10 @@ public extension Component {
   ///
   /// - returns: A string identifier for the view, defaults to the `defaultIdentifier` on the component.
   public func identifier(at index: Int) -> String {
-    if let item = item(at: index), Configuration.views.storage[item.kind] != nil {
+    if let item = item(at: index), configuration.views.storage[item.kind] != nil {
       return item.kind
     } else {
-      return Configuration.views.defaultIdentifier
+      return configuration.views.defaultIdentifier
     }
   }
 

--- a/Sources/Shared/Protocols/SpotsProtocol.swift
+++ b/Sources/Shared/Protocols/SpotsProtocol.swift
@@ -62,13 +62,13 @@ public protocol SpotsProtocol: class {
   func resolve(component closure: (_ index: Int, _ component: Component) -> Bool) -> Component?
 
   #if os(OSX)
-  init(components: [Component], backgroundType: ControllerBackground)
+  init(components: [Component], configuration: Configuration, backgroundType: ControllerBackground)
   #else
   /// A required initializer for initializing a controller with components.
   ///
   /// - parameter components: A collection of components. that should be setup and be added to the view hierarchy.
   ///
   /// - returns: An initalized controller.
-  init(components: [Component])
+  init(components: [Component], configuration: Configuration)
   #endif
 }

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -1,6 +1,5 @@
 ///// A protocol used for composition inside components.
 public protocol UserInterface: class {
-
   var visibleViews: [View] { get }
 
   #if !os(OSX)
@@ -87,7 +86,7 @@ public protocol UserInterface: class {
   func reloadDataSource()
 
   /// Register all views from Configuration on user interface object.
-  func register()
+  func register(with configuration: Configuration)
 
   /// Recalculate the receiver’s layout, if required.
   func layoutIfNeeded()

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -147,7 +147,7 @@ public struct ComponentModel: Mappable, Equatable, DictionaryConvertible {
   public init(identifier: String? = nil,
               header: Item? = nil,
               footer: Item? = nil,
-              kind: ComponentKind = Configuration.defaultComponentKind,
+              kind: ComponentKind = Configuration.shared.defaultComponentKind,
               layout: Layout = Layout(),
               interaction: Interaction = .init(),
               items: [Item] = [],

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -12,25 +12,38 @@ struct PlatformDefaults {
   #endif
 }
 
-public struct Configuration {
-
+public class Configuration {
+  public static let shared: Configuration = Configuration()
   public typealias ConfigurationClosure = (_ view: View, _ model: ItemCodable, _ containerSize: CGSize) -> CGSize
 
-  /// Default setting for stretching the last `Component` to occupy the full height of `SpotsScrollView`.
-  /// See `SpotsScrollView.stretchLastComponent` for more details.
-  public static var stretchLastComponent: Bool = false
+  /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
+  /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
+  ///
+  /// ```
+  ///  Enabled    Disabled
+  ///  --------   --------
+  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
+  /// ||      || ||      ||
+  /// ||______|| ||______||
+  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
+  /// ||      || ||      ||
+  /// ||      || ||______||
+  /// ||______|| |        |
+  ///  --------   --------
+  /// ```
+  public var stretchLastComponent: Bool = false
 
-  public static var defaultComponentKind: ComponentKind = .grid
-  public static var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
-  public static var views: Registry = .init()
-  public static var models: [String: ItemCodable.Type] = .init()
-  public static var presenters: [String: ConfigurationClosure] = .init()
+  public var defaultComponentKind: ComponentKind = .grid
+  public var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
+  public var views: Registry = .init()
+  public var models: [String: ItemCodable.Type] = .init()
+  public var presenters: [String: ConfigurationClosure] = .init()
 
   /// Register a nib file with identifier on the component.
   ///
   /// - parameter nib:        A Nib file that should be used for identifier
   /// - parameter identifier: A StringConvertible identifier for the registered nib.
-  public static func register(nib: Nib, identifier: StringConvertible) {
+  public func register(nib: Nib, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.nib(nib)
   }
 
@@ -38,7 +51,7 @@ public struct Configuration {
   ///
   /// - parameter view:       The view type that should be registered with an identifier.
   /// - parameter identifier: A StringConvertible identifier for the registered view type.
-  public static func register<T, U: ItemModel>(view: T.Type, identifier: StringConvertible, model: U.Type?, presenter: Presenter<T, U>? = nil) {
+  public func register<T, U: ItemModel>(view: T.Type, identifier: StringConvertible, model: U.Type?, presenter: Presenter<T, U>? = nil) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
 
     if let model = model {
@@ -54,14 +67,14 @@ public struct Configuration {
   ///
   /// - parameter view:       The view type that should be registered with an identifier.
   /// - parameter identifier: A StringConvertible identifier for the registered view type.
-  public static func register(view: View.Type, identifier: StringConvertible) {
+  public func register(view: View.Type, identifier: StringConvertible) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
   }
 
   /// Register default view for the component.
   ///
   /// - parameter view: The view type that should be used as the default view
-  public static func registerDefault(view: View.Type) {
+  public func registerDefault(view: View.Type) {
     views.defaultItem = Registry.Item.classType(view)
   }
 }

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -7,7 +7,7 @@ public struct Parser {
   /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
   ///
   /// - returns: A collection of components
-  public static func parse(_ json: [String : Any], key: String = "components") -> [Component] {
+  public static func parse(_ json: [String : Any], key: String = "components", configuration: Configuration = .shared) -> [Component] {
     var components: [ComponentModel] = parse(json, key: key)
 
     for element in components.indices {
@@ -15,7 +15,7 @@ public struct Parser {
     }
 
     return components.map { model in
-      Component(model: model)
+      Component(model: model, configuration: configuration)
     }
   }
 
@@ -25,7 +25,7 @@ public struct Parser {
   /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
   ///
   /// - returns: A collection of `ComponentModel`s
-  public static func parse(_ json: [String : Any], key: String = "components") -> [ComponentModel] {
+  public static func parse(_ json: [String : Any], key: String = "components", configuration: Configuration = .shared) -> [ComponentModel] {
     guard let payloads = json[key] as? [[String : Any]] else { return [] }
 
     var models = [ComponentModel]()
@@ -45,7 +45,7 @@ public struct Parser {
   /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
   ///
   /// - returns: A collection of `ComponentModel`s
-  public static func parse(_ json: [String : Any]?, key: String = "components") -> [ComponentModel] {
+  public static func parse(_ json: [String : Any]?, key: String = "components", configuration: Configuration = .shared) -> [ComponentModel] {
     guard let payload = json else { return [] }
 
     return Parser.parse(payload)
@@ -56,17 +56,17 @@ public struct Parser {
   /// - parameter json: A JSON dictionary of components and items.
   ///
   /// - returns: A collection of components
-  public static func parse(_ json: [[String : Any]]?) -> [Component] {
+  public static func parse(_ json: [[String : Any]]?, configuration: Configuration = .shared) -> [Component] {
     guard let json = json else { return [] }
 
     return json.map { model in
-      Component(model: ComponentModel(model))
+      Component(model: ComponentModel(model), configuration: configuration)
     }
   }
 
-  public static func parse(_ models: [ComponentModel]) -> [Component] {
+  public static func parse(_ models: [ComponentModel], configuration: Configuration = .shared) -> [Component] {
     return models.map { model in
-      Component(model: model)
+      Component(model: model, configuration: configuration)
     }
   }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -95,7 +95,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `UITableView` or `UICollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either UICollectionView or UITableView).
-  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared, parentComponent: Component? = nil) {
+  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared) {
     self.model = model
     self.view = view
     self.configuration = configuration

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -87,7 +87,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     return userInterface as? CollectionView
   }
 
-  public var configuration: Configuration!
+  public let configuration: Configuration
 
   /// Default initializer for creating a component.
   ///

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -22,7 +22,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// interaction, behaviour and look-and-feel. See `ComponentModel` for more information.
   public var model: ComponentModel
   /// An engine that handles mutation of the component model data source.
-  public var manager: ComponentManager = ComponentManager()
+  public var manager: ComponentManager
   /// A configuration closure that will be invoked when views are added to the component.
   public var configure: ((ItemConfigurable) -> Void)? {
     didSet {
@@ -71,7 +71,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public var view: ScrollView {
     didSet {
       if let userInterface = view as? UserInterface {
-        userInterface.register()
+        userInterface.register(with: configuration)
       }
     }
   }
@@ -87,36 +87,40 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     return userInterface as? CollectionView
   }
 
+  public var configuration: Configuration!
+
   /// Default initializer for creating a component.
   ///
   /// - Parameters:
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `UITableView` or `UICollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either UICollectionView or UITableView).
-  public required init(model: ComponentModel, view: ScrollView, parentComponent: Component? = nil) {
+  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared, parentComponent: Component? = nil) {
     self.model = model
     self.view = view
+    self.configuration = configuration
+    self.manager = ComponentManager(configuration: configuration)
     super.init()
     registerDefaultIfNeeded(view: DefaultItemView.self)
-    userInterface?.register()
+    userInterface?.register(with: configuration)
 
     if let collectionViewLayout = collectionView?.flowLayout {
       model.layout.configure(collectionViewLayout: collectionViewLayout)
     }
 
-    self.componentDataSource = DataSource(component: self)
-    self.componentDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self, with: configuration)
+    self.componentDelegate = Delegate(component: self, with: configuration)
   }
 
   /// A convenience init for creating a component with a `ComponentModel`.
   ///
   /// - Parameter model: A component model that is used for constructing and configurating the component.
-  public required convenience init(model: ComponentModel) {
+  public required convenience init(model: ComponentModel, configuration: Configuration = .shared) {
     let view = model.kind == .list
       ? ComponentTableView()
       : ComponentCollectionView(frame: .zero, collectionViewLayout: CollectionLayout())
 
-    self.init(model: model, view: view)
+    self.init(model: model, view: view, configuration: configuration)
 
     (tableView as? ComponentTableView)?.component = self
     (collectionView as? ComponentCollectionView)?.component = self
@@ -125,10 +129,10 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// A convenience init for creating a component with view state functionality.
   ///
   /// - Parameter cacheKey: The unique cache key that should be used for storing and restoring the component.
-  public convenience init(cacheKey: String) {
+  public convenience init(cacheKey: String, configuration: Configuration = .shared) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(model: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()), configuration: configuration)
     self.stateCache = stateCache
   }
 
@@ -143,8 +147,8 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func setup(with size: CGSize) {
     view.frame.size = size
 
-    setupFooter()
-    setupHeader()
+    setupFooter(with: configuration)
+    setupHeader(with: configuration)
 
     if let tableView = self.tableView {
       setupTableView(tableView, with: size)
@@ -256,11 +260,11 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///
   /// - Parameter view: The view that should be registred as the default view.
   func registerDefaultIfNeeded(view: View.Type) {
-    guard Configuration.views.defaultItem == nil else {
+    guard configuration.views.defaultItem == nil else {
       return
     }
 
-    Configuration.views.defaultItem = Registry.Item.classType(view)
+    configuration.views.defaultItem = Registry.Item.classType(view)
   }
 
   /// Configure the page control for the component.

--- a/Sources/iOS/Classes/DefaultItemView.swift
+++ b/Sources/iOS/Classes/DefaultItemView.swift
@@ -48,10 +48,10 @@ open class DefaultItemView: UITableViewCell, ItemConfigurable {
   }
 
   open func computeSize(for item: Item, containerSize: CGSize) -> CGSize {
-    let itemHeight = item.size.height > 0.0 ? item.size.height : Configuration.defaultViewSize.height
+    let itemHeight = item.size.height > 0.0 ? item.size.height : Configuration.shared.defaultViewSize.height
 
     return .init(
-      width: Configuration.defaultViewSize.width,
+      width: Configuration.shared.defaultViewSize.width,
       height: itemHeight
     )
   }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -95,13 +95,15 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   weak public var scrollDelegate: ScrollDelegate?
 
   /// A custom scroll view that handles the scrolling for all internal scroll views.
-  open var scrollView: SpotsScrollView = SpotsScrollView()
+  open var scrollView: SpotsScrollView
 
   #if os(iOS)
   /// A UIRefresh control.
   /// Note: Only available on iOS.
   open lazy private(set) var refreshControl: UIRefreshControl = SpotsRefreshControl()
   #endif
+
+  public var configuration: Configuration
 
   // MARK: Initializer
 
@@ -110,8 +112,10 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// - parameter components: A collection of components. that should be setup and be added to the view hierarchy.
   ///
   /// - returns: An initalized controller.
-  public required init(components: [Component] = []) {
+  public required init(components: [Component] = [], configuration: Configuration = .shared) {
     self.components = components
+    self.configuration = configuration
+    self.scrollView = SpotsScrollView(frame: .zero, configuration: configuration)
     super.init(nibName: nil, bundle: nil)
 
     let notificationName = NSNotification.Name(rawValue: NotificationKeys.deviceDidRotateNotification.rawValue)
@@ -126,8 +130,8 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// - parameter component: A Component object
   ///
   /// - returns: An initialized controller containing one object.
-  public convenience init(component: Component) {
-    self.init(components: [component])
+  public convenience init(component: Component, configuration: Configuration = .shared) {
+    self.init(components: [component], configuration: configuration)
   }
 
   /// Initialize a new controller using JSON.
@@ -135,8 +139,9 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// - parameter json: A JSON dictionary that gets parsed into UI elements.
   ///
   /// - returns: An initialized controller with components. built from JSON.
-  public convenience init(_ json: [String : Any]) {
-    self.init(components: Parser.parse(json))
+  public convenience init(_ json: [String : Any], configuration: Configuration = .shared) {
+    self.init(components: Parser.parse(json, configuration: configuration),
+              configuration: configuration)
   }
 
   /// Initialize a new controller with a cache key.
@@ -144,9 +149,10 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// - parameter cacheKey: A key that will be used to identify the StateCache.
   ///
   /// - returns: An initialized controller with a cache.
-  public convenience init(cacheKey: String) {
+  public convenience init(cacheKey: String, configuration: Configuration = .shared) {
     let stateCache = StateCache(key: cacheKey)
-    self.init(components: Parser.parse(stateCache.load()))
+    self.init(components: Parser.parse(stateCache.load(), configuration: configuration),
+              configuration: configuration)
     self.stateCache = stateCache
   }
 

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -103,7 +103,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   open lazy private(set) var refreshControl: UIRefreshControl = SpotsRefreshControl()
   #endif
 
-  public var configuration: Configuration
+  let configuration: Configuration
 
   // MARK: Initializer
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -12,22 +12,6 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
     }
   }
 
-  /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
-  /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
-  ///
-  /// ```
-  ///  Enabled    Disabled
-  ///  --------   --------
-  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
-  /// ||      || ||      ||
-  /// ||______|| ||______||
-  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
-  /// ||      || ||      ||
-  /// ||      || ||______||
-  /// ||______|| |        |
-  ///  --------   --------
-  /// ```
-  public var stretchLastComponent = Configuration.stretchLastComponent
   /// A collection of UIView's that resemble the order of the views in the scroll view
   fileprivate var subviewsInLayoutOrder = [UIView]()
   private var observers = [Observer]()
@@ -47,6 +31,8 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   /// A container view that works as a proxy layer for scroll view
   open var componentsView: SpotsContentView = SpotsContentView()
 
+  var configuration: Configuration
+
   /// A deinitiazlier that removes all subviews from contentView
   deinit {
     subviewsInLayoutOrder.removeAll()
@@ -59,7 +45,8 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   ///  This method uses the frame rectangle to set the center and bounds properties accordingly.
   ///
   /// - returns: An initialized components scroll view
-  override init(frame: CGRect) {
+  public required init(frame: CGRect, configuration: Configuration) {
+    self.configuration = configuration
     super.init(frame: frame)
     componentsView.autoresizingMask = self.autoresizingMask
     addSubview(componentsView)
@@ -210,7 +197,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
         let remainingBoundsHeight = fmax(bounds.maxY - frame.minY, 0.0)
         let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
 
-        if stretchLastComponent && scrollView.isEqual(lastView) {
+        if configuration.stretchLastComponent && scrollView.isEqual(lastView) {
           let newHeight = self.frame.size.height - scrollView.frame.origin.y + self.contentOffset.y
           frame.size.height = newHeight
         } else {

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -31,7 +31,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   /// A container view that works as a proxy layer for scroll view
   open var componentsView: SpotsContentView = SpotsContentView()
 
-  var configuration: Configuration
+  let configuration: Configuration
 
   /// A deinitiazlier that removes all subviews from contentView
   deinit {

--- a/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
+++ b/Sources/iOS/Extensions/Component+iOS+HeaderFooter.swift
@@ -2,12 +2,12 @@ import UIKit
 
 extension Component {
 
-  func setupHeader() {
+  func setupHeader(with configuration: Configuration = .shared) {
     guard let header = model.header, headerView == nil else {
       return
     }
 
-    if let headerView = Configuration.views.make(header.kind)?.view {
+    if let headerView = configuration.views.make(header.kind)?.view {
       self.headerView = headerView
       reloadHeader()
       headerView.layer.zPosition = 100
@@ -25,12 +25,12 @@ extension Component {
     }
   }
 
-  func setupFooter() {
+  func setupFooter(with configuration: Configuration = .shared) {
     guard let footer = model.footer, footerView == nil else {
       return
     }
 
-    if let footerView = Configuration.views.make(footer.kind)?.view {
+    if let footerView = configuration.views.make(footer.kind)?.view {
       self.footerView = footerView
       reloadFooter()
       footerView.layer.zPosition = 99

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -1,13 +1,12 @@
 import UIKit
 
 extension UICollectionView: UserInterface {
-
-  public func register() {
-    if Configuration.views.defaultItem == nil {
-      register(GridWrapper.self, forCellWithReuseIdentifier: Configuration.views.defaultIdentifier)
+  public func register(with configuration: Configuration) {
+    if configuration.views.defaultItem == nil {
+      register(GridWrapper.self, forCellWithReuseIdentifier: configuration.views.defaultIdentifier)
     }
 
-    for (identifier, item) in Configuration.views.storage {
+    for (identifier, item) in configuration.views.storage {
       switch item {
       case .classType(let type):
         if type is UICollectionViewCell.Type {

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -2,12 +2,12 @@ import UIKit
 
 extension UITableView: UserInterface {
 
-  public func register() {
-    if Configuration.views.defaultItem == nil {
-      register(ListWrapper.self, forCellReuseIdentifier: Configuration.views.defaultIdentifier)
+  public func register(with configuration: Configuration) {
+    if configuration.views.defaultItem == nil {
+      register(ListWrapper.self, forCellReuseIdentifier: configuration.views.defaultIdentifier)
     }
 
-    for (identifier, item) in Configuration.views.storage {
+    for (identifier, item) in configuration.views.storage {
       switch item {
       case .classType(let type):
         if type is UITableViewCell.Type {

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -121,7 +121,7 @@ import Tailor
     return userInterface as? CollectionView
   }
 
-  public var configuration: Configuration!
+  public let configuration: Configuration
 
   /// Default initializer for creating a component.
   ///

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -129,7 +129,7 @@ import Tailor
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `NSTableView` or `NSCollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either NSCollectionView or NSTableView).
-  public required init(model: ComponentModel, configuration: Configuration = .shared, userInterface: UserInterface, parentComponent: Component? = nil) {
+  public required init(model: ComponentModel, configuration: Configuration = .shared, userInterface: UserInterface) {
     self.model = model
     self.userInterface = userInterface
     self.configuration = configuration

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -20,7 +20,7 @@ import Tailor
   /// interaction, behaviour and look-and-feel. See `ComponentModel` for more information.
   public var model: ComponentModel
   /// An engine that handles mutation of the component model data source.
-  public var manager: ComponentManager = ComponentManager()
+  public var manager: ComponentManager
   /// A configuration closure that will be invoked when views are added to the component.
   public var configure: ((ItemConfigurable) -> Void)? {
     didSet {
@@ -121,28 +121,31 @@ import Tailor
     return userInterface as? CollectionView
   }
 
+  public var configuration: Configuration!
+
   /// Default initializer for creating a component.
   ///
   /// - Parameters:
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `NSTableView` or `NSCollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either NSCollectionView or NSTableView).
-  public required init(model: ComponentModel, userInterface: UserInterface, parentComponent: Component? = nil) {
+  public required init(model: ComponentModel, configuration: Configuration = .shared, userInterface: UserInterface, parentComponent: Component? = nil) {
     self.model = model
     self.userInterface = userInterface
-
+    self.configuration = configuration
+    self.manager = ComponentManager(configuration: configuration)
     super.init()
     registerDefaultIfNeeded(view: DefaultItemView.self)
-    userInterface.register()
+    userInterface.register(with: configuration)
 
-    self.componentDataSource = DataSource(component: self)
-    self.componentDelegate = Delegate(component: self)
+    self.componentDataSource = DataSource(component: self, with: configuration)
+    self.componentDelegate = Delegate(component: self, with: configuration)
   }
 
   /// A convenience init for creating a component with a `ComponentModel`.
   ///
   /// - Parameter model: A component model that is used for constructing and configurating the component.
-  public required convenience init(model: ComponentModel, userInterface: UserInterface? = nil) {
+  public required convenience init(model: ComponentModel, configuration: Configuration = .shared, userInterface: UserInterface? = nil) {
     var userInterface: UserInterface! = userInterface
 
     if userInterface == nil, model.kind == .list {
@@ -153,7 +156,7 @@ import Tailor
       userInterface = collectionView
     }
 
-    self.init(model: model, userInterface: userInterface!)
+    self.init(model: model, configuration: configuration, userInterface: userInterface!)
 
     scrollView.documentView = userInterface as? View
 
@@ -166,10 +169,10 @@ import Tailor
   /// A convenience init for creating a component with view state functionality.
   ///
   /// - Parameter cacheKey: The unique cache key that should be used for storing and restoring the component.
-  public convenience init(cacheKey: String) {
+  public convenience init(cacheKey: String, configuration: Configuration = .shared) {
     let stateCache = StateCache(key: cacheKey)
 
-    self.init(model: ComponentModel(stateCache.load()))
+    self.init(model: ComponentModel(stateCache.load()), configuration: configuration)
     self.stateCache = stateCache
   }
 
@@ -196,8 +199,8 @@ import Tailor
   public func setup(with size: CGSize) {
     scrollView.frame.size = size
 
-    setupHeader()
-    setupFooter()
+    setupHeader(with: configuration)
+    setupFooter(with: configuration)
 
     configureDataSourceAndDelegate()
 
@@ -305,11 +308,11 @@ import Tailor
   ///
   /// - Parameter view: The view that should be registred as the default view.
   func registerDefaultIfNeeded(view: View.Type) {
-    guard Configuration.views.storage[Configuration.views.defaultIdentifier] == nil else {
+    guard configuration.views.storage[configuration.views.defaultIdentifier] == nil else {
       return
     }
 
-    Configuration.views.defaultItem = Registry.Item.classType(view)
+    configuration.views.defaultItem = Registry.Item.classType(view)
   }
 
   /// This method is invoked when a double click is performed on a view.

--- a/Sources/macOS/Classes/DefaultItemView.swift
+++ b/Sources/macOS/Classes/DefaultItemView.swift
@@ -86,6 +86,6 @@ open class DefaultItemView: NSTableRowView, ItemConfigurable {
   }
 
   open func computeSize(for item: Item, containerSize: CGSize) -> CGSize {
-    return Configuration.defaultViewSize
+    return Configuration.shared.defaultViewSize
   }
 }

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -50,7 +50,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
   }
 
   /// A custom scroll view that handles the scrolling for all internal scroll views
-  public var scrollView: SpotsScrollView = SpotsScrollView()
+  public var scrollView: SpotsScrollView
 
   /// A scroll delegate for handling didReachBeginning and didReachEnd
   weak open var scrollDelegate: ScrollDelegate?
@@ -60,13 +60,17 @@ open class SpotsController: NSViewController, SpotsProtocol {
 
   fileprivate let backgroundType: ControllerBackground
 
+  public var configuration: Configuration
+
   /**
    - parameter components: An array of components.
    - parameter backgroundType: The type of background that the Controller should use, .Regular or .Dynamic
    */
-  public required init(components: [Component] = [], backgroundType: ControllerBackground = .regular) {
+  public required init(components: [Component] = [], configuration: Configuration = .shared, backgroundType: ControllerBackground = .regular) {
+    self.configuration = configuration
     self.components = components
     self.backgroundType = backgroundType
+    self.scrollView = SpotsScrollView(frame: .zero, configuration: configuration)
     super.init(nibName: nil, bundle: nil)!
 
     NotificationCenter.default.addObserver(self, selector: #selector(SpotsController.scrollViewDidScroll(_:)), name: NSNotification.Name.NSScrollViewDidLiveScroll, object: scrollView)
@@ -79,24 +83,24 @@ open class SpotsController: NSViewController, SpotsProtocol {
   /**
    - parameter cacheKey: A key that will be used to identify the StateCache
    */
-  public convenience init(cacheKey: String) {
+  public convenience init(cacheKey: String, configuration: Configuration = .shared) {
     let stateCache = StateCache(key: cacheKey)
-    self.init(components: Parser.parse(stateCache.load()))
+    self.init(components: Parser.parse(stateCache.load(), configuration: configuration))
     self.stateCache = stateCache
   }
 
   /**
    - parameter component: A Component object
    */
-  public convenience init(component: Component) {
-    self.init(components: [component])
+  public convenience init(component: Component, configuration: Configuration = .shared) {
+    self.init(components: [component], configuration: configuration)
   }
 
   /**
    - parameter json: A JSON dictionary that gets parsed into UI elements
    */
-  public convenience init(_ json: [String : Any]) {
-    self.init(components: Parser.parse(json))
+  public convenience init(_ json: [String : Any], configuration: Configuration = .shared) {
+    self.init(components: Parser.parse(json, configuration: configuration))
   }
 
   /**

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -60,7 +60,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
 
   fileprivate let backgroundType: ControllerBackground
 
-  public var configuration: Configuration
+  let configuration: Configuration
 
   /**
    - parameter components: An array of components.

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -14,12 +14,12 @@ open class SpotsScrollView: NSScrollView {
   /// The document view of SpotsScrollView.
   lazy open var componentsView: SpotsContentView = SpotsContentView()
 
-  var configuration: Configuration
+  let configuration: Configuration
 
   /// Initializes and returns a newly allocated NSView object with a specified frame rectangle.
   ///
   /// - Parameter frameRect: The frame rectangle for the created view object.
-  init(frame frameRect: NSRect, configuration: Configuration) {
+  init(frame frameRect: NSRect, configuration: Configuration = .shared) {
     self.configuration = configuration
     super.init(frame: frameRect)
     self.documentView = componentsView

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -4,23 +4,6 @@ open class SpotsScrollView: NSScrollView {
   /// Use the flipped coordinates system so that origin.y = 0 is at the top left corner.
   override open var isFlipped: Bool { return true }
 
-  /// When enabled, the last `Component` in the collection will be stretched to occupy the remaining space.
-  /// This can be enabled globally by setting `Configuration.stretchLastComponent` to `true`.
-  ///
-  /// ```
-  ///  Enabled    Disabled
-  ///  --------   --------
-  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
-  /// ||      || ||      ||
-  /// ||______|| ||______||
-  /// ||¯¯¯¯¯¯|| ||¯¯¯¯¯¯||
-  /// ||      || ||      ||
-  /// ||      || ||______||
-  /// ||______|| |        |
-  ///  --------   --------
-  /// ```
-  public var stretchLastComponent = Configuration.stretchLastComponent
-
   /// A KVO context used to monitor changes in contentSize, frames and bounds
   let subviewContext: UnsafeMutableRawPointer? = UnsafeMutableRawPointer(mutating: nil)
 
@@ -31,10 +14,13 @@ open class SpotsScrollView: NSScrollView {
   /// The document view of SpotsScrollView.
   lazy open var componentsView: SpotsContentView = SpotsContentView()
 
+  var configuration: Configuration
+
   /// Initializes and returns a newly allocated NSView object with a specified frame rectangle.
   ///
   /// - Parameter frameRect: The frame rectangle for the created view object.
-  override init(frame frameRect: NSRect) {
+  init(frame frameRect: NSRect, configuration: Configuration) {
+    self.configuration = configuration
     super.init(frame: frameRect)
     self.documentView = componentsView
     drawsBackground = false
@@ -141,7 +127,7 @@ open class SpotsScrollView: NSScrollView {
       var newHeight: CGFloat = 0.0
       var shouldScroll: Bool = true
 
-      if stretchLastComponent && scrollView.isEqual(lastView) {
+      if configuration.stretchLastComponent && scrollView.isEqual(lastView) {
         let stretchedHeight = self.frame.size.height - scrollView.frame.origin.y + self.contentOffset.y
         if stretchedHeight <= self.frame.size.height {
           newHeight = stretchedHeight

--- a/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
+++ b/Sources/macOS/Extensions/Component+macOS+HeaderFooter.swift
@@ -2,12 +2,12 @@ import Cocoa
 
 extension Component {
 
-  func setupHeader() {
+  func setupHeader(with configuration: Configuration) {
     guard let header = model.header, headerView == nil else {
       return
     }
 
-    if let headerView = Configuration.views.make(header.kind)?.view {
+    if let headerView = configuration.views.make(header.kind)?.view {
       self.headerView = headerView
       reloadHeader()
       (collectionView?.flowLayout)?.headerReferenceSize = headerView.frame.size
@@ -15,12 +15,12 @@ extension Component {
     }
   }
 
-  func setupFooter() {
+  func setupFooter(with configuration: Configuration) {
     guard let footer = model.footer, footerView == nil else {
       return
     }
 
-    if let footerView = Configuration.views.make(footer.kind)?.view {
+    if let footerView = configuration.views.make(footer.kind)?.view {
       self.footerView = footerView
       reloadFooter()
       (collectionView?.flowLayout)?.footerReferenceSize = footerView.frame.size

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -93,7 +93,7 @@ extension Delegate: NSTableViewDelegate {
 
     let reuseIdentifier = component.identifier(at: row)
 
-    guard let viewContainer = Configuration.views.make(reuseIdentifier) else {
+    guard let viewContainer = configuration.views.make(reuseIdentifier) else {
       return nil
     }
 

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -28,16 +28,16 @@ extension NSCollectionView: UserInterface {
   }
 
   // swiftlint:disable empty_enum_arguments
-  public func register() {
+  public func register(with configuration: Configuration) {
     register(GridWrapper.self, forItemWithIdentifier: CollectionView.compositeIdentifier)
 
-    for (identifier, item) in Configuration.views.storage {
+    for (identifier, item) in configuration.views.storage {
       switch item {
       case .classType(_):
         register(GridWrapper.self,
                  forItemWithIdentifier: identifier)
         register(GridWrapper.self,
-                 forItemWithIdentifier: Configuration.views.defaultIdentifier)
+                 forItemWithIdentifier: configuration.views.defaultIdentifier)
       case .nib(let nib):
         register(nib, forItemWithIdentifier: identifier)
       }

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -21,8 +21,8 @@ extension NSTableView: UserInterface {
     return "list-composite"
   }
 
-  public func register() {
-    Configuration.register(view: ListWrapper.self, identifier: TableView.compositeIdentifier)
+  public func register(with configuration: Configuration) {
+    configuration.register(view: ListWrapper.self, identifier: TableView.compositeIdentifier)
   }
 
   public func view<T>(at index: Int) -> T? {

--- a/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
+++ b/SpotsTests/Shared/ComponentFlowLayoutSharedTests.swift
@@ -11,8 +11,8 @@ import XCTest
 class ComponentFlowLayoutSharedTests: XCTestCase {
 
   override func setUp() {
-    Configuration.register(view: TestView.self, identifier: ComponentFlowLayoutSharedTests.identifier)
-    Configuration.views.purge()
+    Configuration.shared.register(view: TestView.self, identifier: ComponentFlowLayoutSharedTests.identifier)
+    Configuration.shared.views.purge()
   }
 
   static let identifier: String = "MockIdentifier"

--- a/SpotsTests/Shared/ComponentManagerTests.swift
+++ b/SpotsTests/Shared/ComponentManagerTests.swift
@@ -21,7 +21,7 @@ class ComponentManagerTests: XCTestCase {
   var component: Component!
 
   override func setUp() {
-    Configuration.registerDefault(view: TestView.self)
+    Configuration.shared.registerDefault(view: TestView.self)
 
     let items = [
       Item(title: "foo"),
@@ -34,7 +34,7 @@ class ComponentManagerTests: XCTestCase {
   }
 
   func testComponentManagerWithPresenter() {
-    Configuration.register(view: MockView.self,
+    Configuration.shared.register(view: MockView.self,
                            identifier: "MockPresenter",
                            model: MockModel.self,
                            presenter: Presenter({ (view, model, containerSize) -> CGSize in

--- a/SpotsTests/Shared/ComponentModelTests.swift
+++ b/SpotsTests/Shared/ComponentModelTests.swift
@@ -45,16 +45,16 @@ class ComponentModelTests: XCTestCase {
   }
 
   func testConfifugrationDefaultKind() {
-    Configuration.defaultComponentKind = .list
+    Configuration.shared.defaultComponentKind = .list
     let firstModel = ComponentModel()
     XCTAssertEqual(firstModel.kind, .list)
 
-    Configuration.defaultComponentKind = .grid
+    Configuration.shared.defaultComponentKind = .grid
     let secondModel = ComponentModel()
     XCTAssertEqual(secondModel.kind, .grid)
 
     // Reset configuration to the default
-    Configuration.defaultComponentKind = .grid
+    Configuration.shared.defaultComponentKind = .grid
   }
 
   func testEquatable() {

--- a/SpotsTests/Shared/ComponentSharedTests.swift
+++ b/SpotsTests/Shared/ComponentSharedTests.swift
@@ -20,9 +20,9 @@ class ComponentSharedTests: XCTestCase {
   }
 
   override func setUp() {
-    Configuration.defaultViewSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
-    Configuration.registerDefault(view: DefaultItemView.self)
-    Configuration.views.purge()
+    Configuration.shared.defaultViewSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.views.purge()
   }
 
   func testAppendingMultipleItemsToComponent() {
@@ -76,7 +76,7 @@ class ComponentSharedTests: XCTestCase {
   func testResolvingUIFromGridableComponent() {
     let kind = "test-view"
 
-    Configuration.register(view: TestView.self, identifier: kind)
+    Configuration.shared.register(view: TestView.self, identifier: kind)
 
     let parentSize = CGSize(width: 100, height: 100)
     let model = ComponentModel(items: [Item(title: "foo", kind: kind)])
@@ -98,7 +98,7 @@ class ComponentSharedTests: XCTestCase {
   func testResolvingUIFromListableComponent() {
     let kind = "test-view"
 
-    Configuration.register(view: TestView.self, identifier: kind)
+    Configuration.shared.register(view: TestView.self, identifier: kind)
 
     let parentSize = CGSize(width: 100, height: 100)
     let model = ComponentModel(items: [Item(title: "foo", kind: kind)])
@@ -118,7 +118,7 @@ class ComponentSharedTests: XCTestCase {
   }
 
   func testCarouselComponentConfigurationClosure() {
-    Configuration.register(view: TestView.self, identifier: "test-view")
+    Configuration.shared.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
     let component = Component(model: ComponentModel(kind: .carousel, layout: Layout(span: 0.0), items: items))
@@ -134,7 +134,7 @@ class ComponentSharedTests: XCTestCase {
   }
 
   func testListComponentConfigurationClosure() {
-    Configuration.register(view: TestView.self, identifier: "test-view")
+    Configuration.shared.register(view: TestView.self, identifier: "test-view")
 
     let items = [Item(title: "Item A", kind: "test-view"), Item(title: "Item B")]
     let component = Component(model: ComponentModel(kind: .list, items: items))
@@ -192,7 +192,7 @@ class ComponentSharedTests: XCTestCase {
   }
 
   func testResolvingItemModel() {
-    Configuration.register(view: MockView.self,
+    Configuration.shared.register(view: MockView.self,
                            identifier: "Mock",
                            model: MockModel.self,
                            presenter: Presenter({ (view, model, containerSize) -> CGSize in

--- a/SpotsTests/Shared/ItemConfigurableComputeSizeTests.swift
+++ b/SpotsTests/Shared/ItemConfigurableComputeSizeTests.swift
@@ -56,11 +56,11 @@ class ItemConfigurableComputeSizeTests: XCTestCase {
   }
 
   override func setUp() {
-    Configuration.register(view: WrappedViewMock.self, identifier: Identifier.wrapped.identifier)
-    Configuration.register(view: ListViewMock.self, identifier: Identifier.list.identifier)
-    Configuration.register(view: ContainerSizeAwaredViewMock.self,
+    Configuration.shared.register(view: WrappedViewMock.self, identifier: Identifier.wrapped.identifier)
+    Configuration.shared.register(view: ListViewMock.self, identifier: Identifier.list.identifier)
+    Configuration.shared.register(view: ContainerSizeAwaredViewMock.self,
                            identifier: Identifier.containerSizeAwareWrapped.identifier)
-    Configuration.register(view: GridViewMock.self, identifier: Identifier.grid.identifier)
+    Configuration.shared.register(view: GridViewMock.self, identifier: Identifier.grid.identifier)
   }
 
   func testWrappedDynamicViewInGrid() {

--- a/SpotsTests/Shared/ItemModelPresenterTests.swift
+++ b/SpotsTests/Shared/ItemModelPresenterTests.swift
@@ -17,7 +17,7 @@ class ItemModelPresenterTests: XCTestCase {
   }
 
   func testConfiguringViewWithItemModel() {
-    Configuration.register(view: MockView.self,
+    Configuration.shared.register(view: MockView.self,
                            identifier: "Mock",
                            model: MockModel.self,
                            presenter: Presenter({ (view, model, containerSize) -> CGSize in

--- a/SpotsTests/Shared/RegistryTests.swift
+++ b/SpotsTests/Shared/RegistryTests.swift
@@ -17,13 +17,13 @@ class RegistryTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    Configuration.register(view: RegistryViewMock.self, identifier: "registry-mock")
+    Configuration.shared.register(view: RegistryViewMock.self, identifier: "registry-mock")
   }
 
   func testCreatingView() {
     let frame = CGRect(origin: .zero, size: .init(width: 50, height: 50))
     let item = Item(title: "foo", kind: "registry-mock")
-    let view: RegistryViewMock? = Configuration.views.makeView(from: item, with: frame)
+    let view: RegistryViewMock? = Configuration.shared.views.makeView(from: item, with: frame)
 
     XCTAssertNotNil(view)
     XCTAssertEqual(view?.frame, frame)

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -11,7 +11,7 @@ class SpotsControllerManagerTests: XCTestCase {
     ]))
 
   override func setUp() {
-    Configuration.registerDefault(view: TestView.self)
+    Configuration.shared.registerDefault(view: TestView.self)
 
     controller = SpotsController(components: [component])
     controller.prepareController()

--- a/SpotsTests/Shared/SpotsControllerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerTests.swift
@@ -7,7 +7,7 @@ class ComponentDelegateMock: ComponentDelegate {}
 class SpotsControllerTests: XCTestCase {
 
   override func setUp() {
-    Configuration.views.purge()
+    Configuration.shared.views.purge()
   }
 
   func testSpotAtIndex() {
@@ -537,8 +537,8 @@ class SpotsControllerTests: XCTestCase {
   }
 
   func testReloadIfNeededWithComponentModels() {
-    Configuration.registerDefault(view: DefaultItemView.self)
-    Configuration.defaultViewSize = .init(width: 0, height: 44)
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.defaultViewSize = .init(width: 0, height: 44)
     let initialComponentModels = [
       ComponentModel(
         kind: .list,

--- a/SpotsTests/Shared/UserInterfaceTests.swift
+++ b/SpotsTests/Shared/UserInterfaceTests.swift
@@ -13,7 +13,7 @@ class UserInterfaceTests: XCTestCase {
   }
 
   func testVisibleViewsOnListComponent() {
-    Configuration.views.defaultItem = nil
+    Configuration.shared.views.defaultItem = nil
     let items = [
       Item(title: "foo"),
       Item(title: "bar"),

--- a/SpotsTests/iOS/ComponentDelegateiOSTests.swift
+++ b/SpotsTests/iOS/ComponentDelegateiOSTests.swift
@@ -72,7 +72,7 @@ class ComponentDelegateiOSTests: XCTestCase {
   }
 
   func testTableViewHeightForRowOnListable() {
-    Configuration.defaultViewSize = .init(width: 0, height: 44)
+    Configuration.shared.defaultViewSize = .init(width: 0, height: 44)
     let component = Component(model: ComponentModel(kind: .list, layout: Layout(span: 1), items: [Item(title: "title 1")]))
     component.setup(with: CGSize(width: 100, height: 100))
 
@@ -86,9 +86,9 @@ class ComponentDelegateiOSTests: XCTestCase {
   }
 
   func testTableViewHeaderHeight() {
-    Configuration.register(view: RegularView.self, identifier: "regular-header")
-    Configuration.register(view: ItemConfigurableView.self, identifier: "item-configurable-header")
-    Configuration.register(view: CustomListHeaderView.self, identifier: "custom-header")
+    Configuration.shared.register(view: RegularView.self, identifier: "regular-header")
+    Configuration.shared.register(view: ItemConfigurableView.self, identifier: "item-configurable-header")
+    Configuration.shared.register(view: CustomListHeaderView.self, identifier: "custom-header")
 
     let component = Component(model: ComponentModel(header: Item(kind: "custom-header"), kind: .list))
     component.setup(with: CGSize(width: 100, height: 100))
@@ -139,9 +139,9 @@ class ComponentDelegateiOSTests: XCTestCase {
   }
 
   func testTableViewFooterHeight() {
-    Configuration.register(view: RegularView.self, identifier: "regular-footer")
-    Configuration.register(view: ItemConfigurableView.self, identifier: "item-configurable-footer")
-    Configuration.register(view: CustomListHeaderView.self, identifier: "custom-footer")
+    Configuration.shared.register(view: RegularView.self, identifier: "regular-footer")
+    Configuration.shared.register(view: ItemConfigurableView.self, identifier: "item-configurable-footer")
+    Configuration.shared.register(view: CustomListHeaderView.self, identifier: "custom-footer")
 
     let component = Component(model: ComponentModel(footer: Item(kind: "custom-footer"), kind: .list))
     component.setup(with: CGSize(width: 100, height: 100))

--- a/SpotsTests/iOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/iOS/ComponentFlowLayoutTests.swift
@@ -16,8 +16,8 @@ class ComponentFlowLayoutTests: XCTestCase {
   let parentSize = CGSize(width: 100, height: 100)
 
   override func setUp() {
-    Configuration.registerDefault(view: DefaultItemView.self)
-    Configuration.views.purge()
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.views.purge()
   }
 
   func testContentSizeForHorizontalLayoutsWithoutInsets() {

--- a/SpotsTests/iOS/ComponentTests.swift
+++ b/SpotsTests/iOS/ComponentTests.swift
@@ -4,15 +4,15 @@ import XCTest
 class ComponentTests: XCTestCase {
 
   override func setUp() {
-    Configuration.views.defaultItem = nil
-    Configuration.register(view: HeaderView.self, identifier: "Header")
-    Configuration.register(view: TextView.self, identifier: "TextView")
-    Configuration.register(view: FooterView.self, identifier: "Footer")
+    Configuration.shared.views.defaultItem = nil
+    Configuration.shared.register(view: HeaderView.self, identifier: "Header")
+    Configuration.shared.register(view: TextView.self, identifier: "TextView")
+    Configuration.shared.register(view: FooterView.self, identifier: "Footer")
     StateCache.removeAll()
   }
 
   func testDefaultValues() {
-    Configuration.defaultViewSize = .init(width: 0, height: 44)
+    Configuration.shared.defaultViewSize = .init(width: 0, height: 44)
     let items = [Item(title: "A"), Item(title: "B")]
     let model = ComponentModel(kind: .list, items: items)
     let component = Component(model: model)

--- a/SpotsTests/iOS/ComponentiOSTests.swift
+++ b/SpotsTests/iOS/ComponentiOSTests.swift
@@ -14,8 +14,8 @@ class ComponentiOSTests: XCTestCase {
   var cachedSpot: Component!
 
   override func setUp() {
-    Configuration.views.purge()
-    Configuration.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.views.purge()
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
     component = Component(model: ComponentModel(layout: Layout(span: 1)))
     cachedSpot = Component(cacheKey: "cached-carousel-component")
     XCTAssertNotNil(cachedSpot.stateCache)
@@ -57,15 +57,15 @@ class ComponentiOSTests: XCTestCase {
     let carouselComponent = Component(model: model)
     let indexPath = IndexPath(row: 0, section: 0)
 
-    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.views.defaultIdentifier)
+    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.shared.views.defaultIdentifier)
 
-    Configuration.views.defaultItem = Registry.Item.classType(CustomListCell.self)
-    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.views.defaultIdentifier)
+    Configuration.shared.views.defaultItem = Registry.Item.classType(CustomListCell.self)
+    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.shared.views.defaultIdentifier)
 
-    Configuration.views.defaultItem = Registry.Item.classType(CustomGridCell.self)
-    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.views.defaultIdentifier)
+    Configuration.shared.views.defaultItem = Registry.Item.classType(CustomGridCell.self)
+    XCTAssertEqual(carouselComponent.identifier(for: indexPath), Configuration.shared.views.defaultIdentifier)
 
-    Configuration.views["custom-item-kind"] = Registry.Item.classType(CustomGridCell.self)
+    Configuration.shared.views["custom-item-kind"] = Registry.Item.classType(CustomGridCell.self)
     XCTAssertEqual(carouselComponent.identifier(for: indexPath), "custom-item-kind")
   }
 
@@ -123,7 +123,7 @@ class ComponentiOSTests: XCTestCase {
   }
 
   func testCarouselSetupWithPagination() {
-    Configuration.defaultViewSize = .init(width: 88, height: 88)
+    Configuration.shared.defaultViewSize = .init(width: 88, height: 88)
 
     let json: [String : Any] = [
       "kind" : "carousel",
@@ -182,7 +182,7 @@ class ComponentiOSTests: XCTestCase {
   }
 
   func testPageIndicatorOverlayPlacement() {
-    Configuration.defaultViewSize = .init(width: 88, height: 88)
+    Configuration.shared.defaultViewSize = .init(width: 88, height: 88)
     let json: [String : Any] = [
       "items": [
         ["title": "foo", "kind": "carousel"],
@@ -414,7 +414,7 @@ class ComponentiOSTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height * CGFloat(items.count))
+    XCTAssertEqual(component.computedHeight, Configuration.shared.defaultViewSize.height * CGFloat(items.count))
   }
 
   func testComputedHeightForGridComponent() {
@@ -429,7 +429,7 @@ class ComponentiOSTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height * CGFloat(items.count))
+    XCTAssertEqual(component.computedHeight, Configuration.shared.defaultViewSize.height * CGFloat(items.count))
   }
 
   func testComputedHeightForCarouselComponent() {
@@ -444,11 +444,11 @@ class ComponentiOSTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: .init(width: 100, height: 100))
 
-    XCTAssertEqual(component.computedHeight, Configuration.defaultViewSize.height)
+    XCTAssertEqual(component.computedHeight, Configuration.shared.defaultViewSize.height)
   }
 
   func testListScrollTo() {
-    Configuration.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "item1", size: CGSize(width: 100, height: 44)),
       Item(title: "item2", size: CGSize(width: 100, height: 44)),
@@ -466,7 +466,7 @@ class ComponentiOSTests: XCTestCase {
   }
 
   func testGridScrollTo() {
-    Configuration.registerDefault(view: DefaultItemView.self)
+    Configuration.shared.registerDefault(view: DefaultItemView.self)
     let items = [
       Item(title: "item1"),
       Item(title: "item2"),
@@ -503,7 +503,7 @@ class ComponentiOSTests: XCTestCase {
 
   func testComponentComputedHeightConstraint() {
     let identifier = "testComponentComputedHeightConstraint"
-    Configuration.register(view: ComponentTestView.self, identifier: identifier)
+    Configuration.shared.register(view: ComponentTestView.self, identifier: identifier)
 
     let spotsContentView = SpotsContentView(frame: .init(origin: .zero, size: CGSize(width: 500, height: 500)))
     let items = [

--- a/SpotsTests/iOS/DataSourceiOSTests.swift
+++ b/SpotsTests/iOS/DataSourceiOSTests.swift
@@ -5,11 +5,11 @@ import XCTest
 class DataSourceiOSTests: XCTestCase {
 
   override func setUp() {
-    Configuration.register(view: CustomGridCell.self, identifier: "custom")
+    Configuration.shared.register(view: CustomGridCell.self, identifier: "custom")
   }
 
   func testDataSourceForListableObject() {
-    Configuration.register(view: CustomListCell.self, identifier: "custom")
+    Configuration.shared.register(view: CustomListCell.self, identifier: "custom")
     let component = Component(model: ComponentModel(kind: .list, layout: Layout(span: 1.0), items: [
       Item(title: "title 1", kind: "custom"),
       Item(title: "title 2", kind: "custom")
@@ -81,7 +81,7 @@ class DataSourceiOSTests: XCTestCase {
   }
 
   func testDataSourceForGridableCustomHeader() {
-    Configuration.register(view: CustomGridHeaderView.self, identifier: "custom-header")
+    Configuration.shared.register(view: CustomGridHeaderView.self, identifier: "custom-header")
     let component = Component(model: ComponentModel(
       header: Item(kind: "custom-header"),
       kind: .grid,

--- a/SpotsTests/iOS/SpotsScrollViewTests.swift
+++ b/SpotsTests/iOS/SpotsScrollViewTests.swift
@@ -183,7 +183,7 @@ class SpotsScrollViewTests: XCTestCase {
     /// The first and the last component should be equal in height
     XCTAssertEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
 
-    controller.scrollView.stretchLastComponent = true
+    controller.scrollView.configuration.stretchLastComponent = true
     controller.scrollView.layoutSubviews()
 
     /// The first and last component should not be equal as the last one should be stretched.

--- a/SpotsTests/macOS/ComponentFlowLayoutTests.swift
+++ b/SpotsTests/macOS/ComponentFlowLayoutTests.swift
@@ -14,8 +14,8 @@ class ItemsPerRowViewMock: View, ItemConfigurable {
 class ComponentFlowLayoutTests: XCTestCase {
 
   override func setUp() {
-    Configuration.registerDefault(view: ItemsPerRowViewMock.self)
-    Configuration.views.purge()
+    Configuration.shared.registerDefault(view: ItemsPerRowViewMock.self)
+    Configuration.shared.views.purge()
   }
 
   func testItemsPerRow() {

--- a/SpotsTests/macOS/ComponentMacOSTests.swift
+++ b/SpotsTests/macOS/ComponentMacOSTests.swift
@@ -4,10 +4,10 @@ import XCTest
 class ComponentMacOSTests: XCTestCase {
 
   override func setUp() {
-    Configuration.views.defaultItem = nil
-    Configuration.register(view: HeaderView.self, identifier: "Header")
-    Configuration.register(view: TextView.self, identifier: "TextView")
-    Configuration.register(view: FooterView.self, identifier: "Footer")
+    Configuration.shared.views.defaultItem = nil
+    Configuration.shared.register(view: HeaderView.self, identifier: "Header")
+    Configuration.shared.register(view: TextView.self, identifier: "TextView")
+    Configuration.shared.register(view: FooterView.self, identifier: "Footer")
   }
   
   class ComponentTestView: View, ItemConfigurable {
@@ -19,7 +19,7 @@ class ComponentMacOSTests: XCTestCase {
 
   func testComponentComputedHeightConstraint() {
     let identifier = "testComponentComputedHeightConstraint"
-    Configuration.register(view: ComponentTestView.self, identifier: identifier)
+    Configuration.shared.register(view: ComponentTestView.self, identifier: identifier)
     let items = [
       Item(kind: identifier),
       Item(kind: identifier),
@@ -43,9 +43,9 @@ class ComponentMacOSTests: XCTestCase {
   }
 
   func testDefaultValuesWithList() {
-    Configuration.views.purge()
-    Configuration.defaultComponentKind = .list
-    Configuration.defaultViewSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
+    Configuration.shared.views.purge()
+    Configuration.shared.defaultComponentKind = .list
+    Configuration.shared.defaultViewSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
     let items = [Item(title: "A"), Item(title: "B")]
     let model = ComponentModel(items: items)
     let component = Component(model: model)

--- a/SpotsTests/macOS/SpotsScrollViewTests.swift
+++ b/SpotsTests/macOS/SpotsScrollViewTests.swift
@@ -15,7 +15,7 @@ class SpotsScrollViewTests: XCTestCase {
     /// The first and the last component should be equal in height
     XCTAssertEqual(controller.components.first?.view.frame.size, controller.components.last?.view.frame.size)
 
-    controller.scrollView.stretchLastComponent = true
+    controller.scrollView.configuration.stretchLastComponent = true
     controller.scrollView.layoutViews()
 
     /// The first and last component should not be equal as the last one should be stretched.


### PR DESCRIPTION
⚠️**Breaking change**⚠️
The migration process for this change is pretty straight forward:
When registering your views.

**Before**
```swift
Configuration.register(view: YourView.self, identifier: "identifier")
```

**After**
```swift
Configuration.shared.register(view: YourView.self, identifier: "identifier")
```

Before we only had a global configuration for Spots, this commit
refactors the code to inject the Configuration going from controller
onto component and all the internal classes.

There is still a `.shared` static variable on `Configuration` that can
be used for global configuration.