### PR TITLE
Migrate source code to Swift 4

### DIFF
--- a/RxSpots/RxSpotsDelegate.swift
+++ b/RxSpots/RxSpotsDelegate.swift
@@ -45,7 +45,7 @@ public final class RxComponentDelegate: DelegateProxy, DelegateProxyType, Compon
   }
 
   public func component(_ component: Component, itemSelected item: Item) {
-    componentDidSelectItem.onNext(component, item)
+    componentDidSelectItem.onNext((component, item))
   }
 
   public func componentsDidChange(_ components: [Component]) {
@@ -53,11 +53,11 @@ public final class RxComponentDelegate: DelegateProxy, DelegateProxyType, Compon
   }
 
   public func component(_ component: Component, willDisplay view: ComponentView, item: Item) {
-    componentWillDisplayView.onNext(component, view, item)
+    componentWillDisplayView.onNext((component, view, item))
   }
 
   public func component(_ component: Component, didEndDisplaying view: ComponentView, item: Item) {
-    componentDidEndDisplayingView.onNext(component, view, item)
+    componentDidEndDisplayingView.onNext((component, view, item))
   }
 }
 

--- a/RxSpotsTests/RxSpotsDelegateTests.swift
+++ b/RxSpotsTests/RxSpotsDelegateTests.swift
@@ -21,7 +21,7 @@ class RxComponentDelegateTests: XCTestCase {
     var isCalled = false
 
     delegateProxy.didSelectItem
-      .bindNext({ component, item in
+      .bind(onNext: { component, item in
         isCalled = (component.model.kind == .list) && item.title == "Test"
       }).addDisposableTo(disposeBag)
 
@@ -35,7 +35,7 @@ class RxComponentDelegateTests: XCTestCase {
     var isCalled = false
 
     delegateProxy.didChange
-      .bindNext({ components in
+      .bind(onNext: { components in
         isCalled = (components[0].model.kind == .list) && (components[1].collectionView != nil)
       })
       .addDisposableTo(disposeBag)
@@ -51,7 +51,7 @@ class RxComponentDelegateTests: XCTestCase {
     var isCalled = false
 
     delegateProxy.willDisplayView
-      .bindNext({ component, view, item in
+      .bind(onNext: { component, view, item in
         isCalled = (component.model.kind == .list) && (view == componentView) && item.title == "Test"
       })
       .addDisposableTo(disposeBag)
@@ -67,7 +67,7 @@ class RxComponentDelegateTests: XCTestCase {
     var isCalled = false
 
     delegateProxy.didEndDisplayingView
-      .bindNext({ component, view, item in
+      .bind(onNext: { component, view, item in
         isCalled = (component.model.kind == .list) && (view == componentView) && item.title == "Test"
       })
       .addDisposableTo(disposeBag)

--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -18,7 +18,9 @@ public class ComponentManager {
   let diffManager: DiffManager
   let configuration: Configuration
 
-  init(itemManager: ItemManager = .init(), diffManager: DiffManager = .init(),  configuration: Configuration) {
+  init(itemManager: ItemManager = .init(),
+       diffManager: DiffManager = .init(),
+       configuration: Configuration) {
     self.configuration = configuration
     self.itemManager = itemManager
     self.diffManager = diffManager
@@ -225,7 +227,8 @@ public class ComponentManager {
   /// - parameter component: The component that should be mutated.
   /// - parameter animation:  A Animation that is used when performing the mutation (currently not in use).
   /// - parameter completion: A completion closure that is executed in the main queue when the view model has been removed.
-  public func update(item: Item, atIndex index: Int, component: Component, withAnimation animation: Animation = .automatic, completion: Completion = nil) {
+  public func update(item: Item, atIndex index: Int, component: Component,
+                     withAnimation animation: Animation = .automatic, completion: Completion = nil) {
     Dispatch.main { [weak self] in
       guard let `self` = self else {
         return

--- a/Sources/Shared/Enums/Animation.swift
+++ b/Sources/Shared/Enums/Animation.swift
@@ -21,7 +21,7 @@ public enum Animation: Int {
   ///
   /// Resolves a Animation into a NSTableViewAnimationOptions
   ///
-  public var tableViewAnimation: NSTableViewAnimationOptions {
+  public var tableViewAnimation: NSTableView.AnimationOptions {
     switch self {
     case .fade:
       return .effectFade
@@ -34,7 +34,7 @@ public enum Animation: Int {
     case .bottom:
       return .slideDown
     case .none:
-      return NSTableViewAnimationOptions()
+      return NSTableView.AnimationOptions()
     case .middle:
       return .effectGap
     case .automatic:

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -91,7 +91,7 @@ public extension Component {
   ///
   /// - returns: Self as a Component type
   public var type: Component.Type {
-    return type(of: self)
+    return Swift.type(of: self)
   }
 
   /// Resolve a UI component at index with inferred type

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -51,7 +51,7 @@ public class Configuration {
   ///
   /// - parameter view:       The view type that should be registered with an identifier.
   /// - parameter identifier: A StringConvertible identifier for the registered view type.
-  public func register<T, U: ItemModel>(view: T.Type, identifier: StringConvertible, model: U.Type?, presenter: Presenter<T, U>? = nil) {
+  public func register<T, U>(view: T.Type, identifier: StringConvertible, model: U.Type?, presenter: Presenter<T, U>? = nil) {
     self.views.storage[identifier.string] = Registry.Item.classType(view)
 
     if let model = model {

--- a/Sources/Shared/Structs/Registry.swift
+++ b/Sources/Shared/Structs/Registry.swift
@@ -91,7 +91,7 @@ public struct Registry {
       }
       #if os(OSX)
         var views: NSArray?
-        if nib.instantiate(withOwner: nil, topLevelObjects: &views!) {
+        if nib.instantiate(withOwner: nil, topLevelObjects: &views) {
           view = views?.filter({ $0 is NSTableRowView }).first as? View
         }
       #else

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -193,7 +193,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// Handle rotation for views that are not on screen.
   ///
   /// - parameter notification: A notification containing the new size.
-  func deviceDidRotate(_ notification: Notification) {
+  @objc func deviceDidRotate(_ notification: Notification) {
     if let userInfo = (notification as NSNotification).userInfo as? [String : Any],
       let rotationSize = userInfo["size"] as? RotationSize, view.window == nil {
       configure(withSize: rotationSize.size)
@@ -319,7 +319,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   /// Refresh action for UIRefreshControl
   ///
   /// - parameter refreshControl: The refresh control used to refresh the controller.
-  open func refreshComponent(_ refreshControl: UIRefreshControl) {
+  @objc open func refreshComponent(_ refreshControl: UIRefreshControl) {
     Dispatch.main { [weak self] in
       guard let strongSelf = self else {
         return

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -204,7 +204,7 @@ extension UICollectionView: UserInterface {
   public func processChanges(_ changes: Changes,
                              withAnimation animation: Animation = .automatic,
                              updateDataSource: () -> Void,
-                             completion: ((()) -> Void)? = nil) {
+                             completion: (() -> Void)? = nil) {
     let insertions = changes.insertions.map { IndexPath(row: $0, section: 0) }
     let reloads = changes.reloads.map { IndexPath(row: $0, section: 0) }
     let deletions = changes.deletions.map { IndexPath(row: $0, section: 0) }

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -204,7 +204,7 @@ extension UITableView: UserInterface {
   public func processChanges(_ changes: Changes,
                              withAnimation animation: Animation = .automatic,
                              updateDataSource: () -> Void,
-                             completion: ((()) -> Void)? = nil) {
+                             completion: (() -> Void)? = nil) {
     let insertions = changes.insertions.map { IndexPath(row: $0, section: 0) }
     let reloads = changes.reloads.map { IndexPath(row: $0, section: 0) }
     let deletions = changes.deletions.map { IndexPath(row: $0, section: 0) }

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -235,7 +235,7 @@ import Tailor
     if model.items.isEmpty, !model.layout.showEmptyComponent {
       if animated {
         view.animator().frame.size.height = 0
-        DispatchQueue.main.asyncAfter(deadline: .now() + NSAnimationContext.current().duration) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + NSAnimationContext.current.duration) { [weak self] in
           self?.view.superview?.animator().layoutSubviews()
         }
       } else {
@@ -318,7 +318,7 @@ import Tailor
   /// This method is invoked when a double click is performed on a view.
   ///
   /// - Parameter sender: The view that was tapped.
-  open func doubleMouseClick(_ sender: Any?) {
+  @objc open func doubleMouseClick(_ sender: Any?) {
     guard let tableView = tableView,
       let item = item(at: tableView.clickedRow) else {
       return
@@ -334,7 +334,7 @@ import Tailor
   /// This method is invoked when a single click is performed on a view.
   ///
   /// - Parameter sender: The view that was tapped.
-  open func singleMouseClick(_ sender: Any?) {
+  @objc open func singleMouseClick(_ sender: Any?) {
     guard let tableView = tableView,
       let item = item(at: tableView.clickedRow) else {
         return

--- a/Sources/macOS/Classes/DefaultItemView.swift
+++ b/Sources/macOS/Classes/DefaultItemView.swift
@@ -44,7 +44,7 @@ open class DefaultItemView: NSTableRowView, ItemConfigurable {
     lineView.wantsLayer = true
     lineView.layer = CALayer()
     lineView.layer?.backgroundColor = NSColor.gray.withAlphaComponent(0.4).cgColor
-    lineView.autoresizingMask = .viewWidthSizable
+    lineView.autoresizingMask = NSView.AutoresizingMask.width
 
     return lineView
   }()

--- a/Sources/macOS/Classes/SpotsController.swift
+++ b/Sources/macOS/Classes/SpotsController.swift
@@ -71,13 +71,13 @@ open class SpotsController: NSViewController, SpotsProtocol {
     self.components = components
     self.backgroundType = backgroundType
     self.scrollView = SpotsScrollView(frame: .zero, configuration: configuration)
-    super.init(nibName: nil, bundle: nil)!
+    super.init(nibName: nil, bundle: nil)
 
-    NotificationCenter.default.addObserver(self, selector: #selector(SpotsController.scrollViewDidScroll(_:)), name: NSNotification.Name.NSScrollViewDidLiveScroll, object: scrollView)
+    NotificationCenter.default.addObserver(self, selector: #selector(SpotsController.scrollViewDidScroll(_:)), name: NSScrollView.didLiveScrollNotification, object: scrollView)
 
-    NotificationCenter.default.addObserver(self, selector: #selector(windowDidResize(_:)), name: NSNotification.Name.NSWindowDidResize, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(windowDidResize(_:)), name: NSWindow.didResizeNotification, object: nil)
 
-    NotificationCenter.default.addObserver(self, selector: #selector(windowDidEndLiveResize(_:)), name: NSNotification.Name.NSWindowDidEndLiveResize, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(windowDidEndLiveResize(_:)), name: NSWindow.didEndLiveResizeNotification, object: nil)
   }
 
   /**
@@ -152,7 +152,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
       view = visualEffectView
     }
 
-    view.autoresizingMask = .viewWidthSizable
+    view.autoresizingMask = NSView.AutoresizingMask.width
     view.autoresizesSubviews = true
     self.view = view
   }
@@ -163,7 +163,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
 
     view.addSubview(scrollView)
     scrollView.hasVerticalScroller = true
-    scrollView.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
+    scrollView.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
 
     SpotsController.configure?(scrollView)
   }
@@ -251,7 +251,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
   /// Invoked when the window that the controller belongs to is resized.
   ///
   /// - Parameter notification: A container for information broadcast through a notification center to all registered observers.
-  open func windowDidResize(_ notification: Notification) {
+  @objc open func windowDidResize(_ notification: Notification) {
     for component in components {
       component.didResize(size: view.frame.size, type: .live)
     }
@@ -261,7 +261,7 @@ open class SpotsController: NSViewController, SpotsProtocol {
   /// Invoked when window has received its new size.
   ///
   /// - Parameter notification: A container for information broadcast through a notification center to all registered observers.
-  public func windowDidEndLiveResize(_ notification: Notification) {
+  @objc public func windowDidEndLiveResize(_ notification: Notification) {
     components.forEach { component in
       component.didResize(size: view.frame.size, type: .end)
     }
@@ -272,10 +272,10 @@ open class SpotsController: NSViewController, SpotsProtocol {
   /// Handles calling `didReachEnd` and `didReachBeginning` on the `ScrollDelegate`.
   ///
   /// - Parameter notification: A container for information broadcast through a notification center to all registered observers.
-  open func scrollViewDidScroll(_ notification: NSNotification) {
+  @objc open func scrollViewDidScroll(_ notification: NSNotification) {
     guard let scrollView = notification.object as? SpotsScrollView,
       let delegate = scrollDelegate,
-      NSApplication.shared().mainWindow != nil
+      NSApplication.shared.mainWindow != nil
       else {
         return
     }

--- a/Sources/macOS/Classes/SpotsScrollView.swift
+++ b/Sources/macOS/Classes/SpotsScrollView.swift
@@ -25,7 +25,7 @@ open class SpotsScrollView: NSScrollView {
     self.documentView = componentsView
     drawsBackground = false
     NotificationCenter.default.addObserver(self, selector: #selector(contentViewBoundsDidChange(_:)),
-                                           name: NSNotification.Name.NSViewBoundsDidChange,
+                                           name: NSView.boundsDidChangeNotification,
                                            object: contentView)
     contentView.postsBoundsChangedNotifications = true
   }
@@ -40,7 +40,7 @@ open class SpotsScrollView: NSScrollView {
   }
 
   /// The bounds of the scroll view clip view did change.
-  func contentViewBoundsDidChange(_ notification: NSNotification) {
+  @objc func contentViewBoundsDidChange(_ notification: NSNotification) {
     guard (notification.object as? NSClipView) === contentView else {
       return
     }

--- a/Sources/macOS/Extensions/Component+macOS+List.swift
+++ b/Sources/macOS/Extensions/Component+macOS+List.swift
@@ -31,7 +31,7 @@ extension Component {
       return
     }
 
-    let column = NSTableColumn(identifier: "tableview-column")
+    let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "tableview-column"))
     column.maxWidth = 250
     column.width = 250
     column.minWidth = 150

--- a/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/DataSource+macOS+Extensions.swift
@@ -2,7 +2,7 @@ import Cocoa
 
 extension DataSource: NSCollectionViewDataSource {
 
-  public func collectionView(_ collectionView: NSCollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> NSView {
+  public func collectionView(_ collectionView: NSCollectionView, viewForSupplementaryElementOfKind kind: NSCollectionView.SupplementaryElementKind, at indexPath: IndexPath) -> NSView {
     return NSView()
   }
 
@@ -26,7 +26,7 @@ extension DataSource: NSCollectionViewDataSource {
     }
 
     let reuseIdentifier = component.identifier(at: indexPath.item)
-    let item = collectionView.makeItem(withIdentifier: reuseIdentifier, for: indexPath)
+    let item = collectionView.makeItem(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: reuseIdentifier), for: indexPath)
 
     switch item {
     case let item as Wrappable:
@@ -58,7 +58,7 @@ extension DataSource: NSTableViewDataSource {
   /// - parameter operation: The type of dragging operation.
   ///
   /// - returns: true if the drop operation was successful, otherwise false.
-  public func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableViewDropOperation) -> Bool {
+  public func tableView(_ tableView: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation: NSTableView.DropOperation) -> Bool {
     return false
   }
 }

--- a/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
+++ b/Sources/macOS/Extensions/Delegate+macOS+Extensions.swift
@@ -103,7 +103,7 @@ extension Delegate: NSTableViewDelegate {
       case .regular:
         resolvedView = viewContainer.view
       case .nib:
-        resolvedView = tableView.make(withIdentifier: reuseIdentifier, owner: nil)
+        resolvedView = tableView.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: reuseIdentifier), owner: nil)
       }
     }
 
@@ -131,7 +131,7 @@ extension Delegate: NSTableViewDelegate {
       }
     }
 
-    (resolvedView as? NSTableRowView)?.identifier = reuseIdentifier
+    (resolvedView as? NSTableRowView)?.identifier = NSUserInterfaceItemIdentifier(rawValue: reuseIdentifier)
 
     return resolvedView as? NSTableRowView
   }

--- a/Sources/macOS/Extensions/Layout+macOS.swift
+++ b/Sources/macOS/Extensions/Layout+macOS.swift
@@ -12,7 +12,7 @@ extension Layout {
   }
 
   public func configure(collectionViewLayout: FlowLayout) {
-    collectionViewLayout.sectionInset = EdgeInsets(
+    collectionViewLayout.sectionInset = NSEdgeInsets(
       top: CGFloat(inset.top),
       left: CGFloat(inset.left),
       bottom: CGFloat(inset.bottom),

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -29,17 +29,17 @@ extension NSCollectionView: UserInterface {
 
   // swiftlint:disable empty_enum_arguments
   public func register(with configuration: Configuration) {
-    register(GridWrapper.self, forItemWithIdentifier: CollectionView.compositeIdentifier)
+    register(GridWrapper.self, forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: CollectionView.compositeIdentifier))
 
     for (identifier, item) in configuration.views.storage {
       switch item {
       case .classType(_):
         register(GridWrapper.self,
-                 forItemWithIdentifier: identifier)
+                 forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: identifier))
         register(GridWrapper.self,
-                 forItemWithIdentifier: configuration.views.defaultIdentifier)
+                 forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: configuration.views.defaultIdentifier))
       case .nib(let nib):
-        register(nib, forItemWithIdentifier: identifier)
+        register(nib, forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: identifier))
       }
     }
   }
@@ -161,7 +161,7 @@ extension NSCollectionView: UserInterface {
       reloadSets.isEmpty &&
       deletionSets.isEmpty &&
       changes.moved.isEmpty {
-      completion?()
+      completion?(())
       return
     }
 
@@ -177,7 +177,7 @@ extension NSCollectionView: UserInterface {
                       to: IndexPath(item: move.value, section: 0))
       }
     }, completionHandler: nil)
-    completion?()
+    completion?(())
     removeAnimation()
   }
 

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -127,7 +127,7 @@ extension NSTableView: UserInterface {
       !reloadSets.isEmpty &&
       !deletionSets.isEmpty &&
       changes.moved.isEmpty {
-      completion?()
+      completion?(())
       return
     }
 
@@ -152,7 +152,7 @@ extension NSTableView: UserInterface {
       component.model.items[index] = item
     }
 
-    completion?()
+    completion?(())
     endUpdates()
   }
 

--- a/Sources/macOS/Extensions/NSView+Extensions.swift
+++ b/Sources/macOS/Extensions/NSView+Extensions.swift
@@ -6,7 +6,7 @@ public extension NSView {
     needsLayout = true
   }
 
-  func layoutSubviews() {
+  @objc func layoutSubviews() {
     layout()
   }
 

--- a/Sources/macOS/Extensions/Wrappable+macOS.swift
+++ b/Sources/macOS/Extensions/Wrappable+macOS.swift
@@ -11,7 +11,7 @@ extension Wrappable {
       return
     }
 
-    let options: NSTrackingAreaOptions = [.inVisibleRect, .mouseEnteredAndExited, .activeInKeyWindow]
+    let options: NSTrackingArea.Options = [NSTrackingArea.Options.inVisibleRect, NSTrackingArea.Options.mouseEnteredAndExited, NSTrackingArea.Options.activeInKeyWindow]
     let trackingArea = NSTrackingArea(rect: wrappedView.bounds,
                                       options: options,
                                       owner: self, userInfo: nil)

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -399,10 +399,8 @@
 		BDFBB76E1F75094600421BCF /* ComponentTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFBB76C1F75094600421BCF /* ComponentTableView.swift */; };
 		BDFC474F1E747B2B008700BF /* GridWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474C1E747B2B008700BF /* GridWrapperTests.swift */; };
 		BDFC47521E747B2B008700BF /* ListWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC474D1E747B2B008700BF /* ListWrapperTests.swift */; };
-		D55B7AF91E423122000125C8 /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478E91C440726006EBA49 /* Tailor.framework */; };
 		D55B7B081E4231A4000125C8 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D55B7B071E4231A4000125C8 /* RxCocoa.framework */; };
 		D55B7B0C1E4234C3000125C8 /* RxSpotsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55B7B0A1E423417000125C8 /* RxSpotsDelegate.swift */; };
-		D55B7B0D1E4234CE000125C8 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D55B7B431E423B86000125C8 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D55B7B4C1E423BC0000125C8 /* RxSpots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D55B7B021E423122000125C8 /* RxSpots.framework */; };
 		D55B7B4F1E423C65000125C8 /* RxSpotsDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55B7B4E1E423C65000125C8 /* RxSpotsDelegateTests.swift */; };
@@ -415,6 +413,7 @@
 		D58A10F11F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
 		D58A10F21F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
 		D58A10F31F4C6E35005A466E /* Component+HeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A10F01F4C6E35005A466E /* Component+HeaderFooter.swift */; };
+		D5BFD0611F96AE050089BA61 /* Spots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58478091C43FEB8006EBA49 /* Spots.framework */; };
 		D5D282671E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282681E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
 		D5D282691E54710D004BF251 /* ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D282661E54710D004BF251 /* ViewState.swift */; };
@@ -693,9 +692,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D55B7B0D1E4234CE000125C8 /* Spots.framework in Frameworks */,
+				D5BFD0611F96AE050089BA61 /* Spots.framework in Frameworks */,
 				D55B7B081E4231A4000125C8 /* RxCocoa.framework in Frameworks */,
-				D55B7AF91E423122000125C8 /* Tailor.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1394,32 +1392,33 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Hyper Interaktiv AS";
 				TargetAttributes = {
 					BD7396FD1D718CD2000AF2DE = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					BD7397311D718CDB000AF2DE = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					D55B7B241E423B86000125C8 = {
 						LastSwiftMigration = 0820;
 					};
 					D58478081C43FEB8006EBA49 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					D58478121C43FEB9006EBA49 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0900;
 					};
 					D58478C71C440567006EBA49 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					D58478D01C440567006EBA49 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 				};
 			};
@@ -2137,7 +2136,8 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -2165,7 +2165,8 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -2184,7 +2185,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2201,7 +2203,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2224,7 +2227,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Spots;
 				PRODUCT_NAME = RxSpots;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2247,7 +2250,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Spots;
 				PRODUCT_NAME = RxSpots;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2264,7 +2267,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2280,7 +2283,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2292,14 +2295,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2342,14 +2351,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2397,7 +2412,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Spots;
 				PRODUCT_NAME = Spots;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2420,7 +2436,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Spots;
 				PRODUCT_NAME = Spots;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2435,7 +2452,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2450,7 +2468,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SpotsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2476,7 +2495,8 @@
 				PRODUCT_NAME = Spots;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2502,7 +2522,8 @@
 				PRODUCT_NAME = Spots;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2522,7 +2543,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Spots-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2542,7 +2564,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.Spots-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Spots.xcodeproj/xcshareddata/xcschemes/RxSpots-iOS.xcscheme
+++ b/Spots.xcodeproj/xcshareddata/xcschemes/RxSpots-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Spots.xcodeproj/xcshareddata/xcschemes/Spots-iOS.xcscheme
+++ b/Spots.xcodeproj/xcshareddata/xcschemes/Spots-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Spots.xcodeproj/xcshareddata/xcschemes/Spots-macOS.xcscheme
+++ b/Spots.xcodeproj/xcshareddata/xcschemes/Spots-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Spots.xcodeproj/xcshareddata/xcschemes/Spots-tvOS.xcscheme
+++ b/Spots.xcodeproj/xcshareddata/xcschemes/Spots-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -70,6 +71,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/SpotsTests/Shared/ComponentResolvableTests.swift
+++ b/SpotsTests/Shared/ComponentResolvableTests.swift
@@ -10,7 +10,7 @@ class ComponentResolvableTests: XCTestCase {
       XCTAssertEqual(component, resolvedComponent)
     }
 
-    dataSource.resolveComponentItem(at: IndexPath(item: 0, section: 0)) { _ in
+    dataSource.resolveComponentItem(at: IndexPath(item: 0, section: 0)) { _, _  in
       XCTFail("The component item should not be resolved because the component does not have any items.")
     }
 

--- a/SpotsTests/Shared/SpotsControllerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerTests.swift
@@ -458,9 +458,18 @@ class SpotsControllerTests: XCTestCase {
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is TableView }))
     XCTAssertNotNil(controller.resolve(component: { $1.userInterface is CollectionView }))
     XCTAssertNotNil(controller.resolve(component: { $1.model.items.filter { $0.title == "Item" }.first != nil }))
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 0 })?.model.identifier, "ListComponent")
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 1 })?.model.identifier, "ListComponent2")
-    XCTAssertEqual(controller.resolve(component: { $0.0 == 2 })?.model.identifier, "GridComponent")
+    XCTAssertEqual(
+      controller.resolve(component: { index, _ in index == 0 })?.model.identifier,
+      "ListComponent"
+    )
+    XCTAssertEqual(
+      controller.resolve(component: { index, _ in index == 1 })?.model.identifier,
+      "ListComponent2"
+    )
+    XCTAssertEqual(
+      controller.resolve(component: { index, _ in index == 2 })?.model.identifier,
+      "GridComponent"
+    )
 
     XCTAssertEqual(controller.filter(components: { $0.userInterface is TableView }).count, 2)
     XCTAssertEqual(controller.filter(components: { $0.userInterface is CollectionView }).count, 1)

--- a/SpotsTests/macOS/TestAnimations.swift
+++ b/SpotsTests/macOS/TestAnimations.swift
@@ -5,12 +5,12 @@ import XCTest
 class AnimationTests: XCTestCase {
 
   func testResolvingAnimations() {
-    XCTAssertEqual(Animation.automatic.tableViewAnimation, NSTableViewAnimationOptions.effectFade)
-    XCTAssertEqual(Animation.fade.tableViewAnimation, NSTableViewAnimationOptions.effectFade)
-    XCTAssertEqual(Animation.right.tableViewAnimation, NSTableViewAnimationOptions.slideRight)
-    XCTAssertEqual(Animation.left.tableViewAnimation, NSTableViewAnimationOptions.slideLeft)
-    XCTAssertEqual(Animation.top.tableViewAnimation, NSTableViewAnimationOptions.slideUp)
-    XCTAssertEqual(Animation.bottom.tableViewAnimation, NSTableViewAnimationOptions.slideDown)
-    XCTAssertEqual(Animation.middle.tableViewAnimation, NSTableViewAnimationOptions.effectGap)
+    XCTAssertEqual(Animation.automatic.tableViewAnimation, NSTableView.AnimationOptions.effectFade)
+    XCTAssertEqual(Animation.fade.tableViewAnimation, NSTableView.AnimationOptions.effectFade)
+    XCTAssertEqual(Animation.right.tableViewAnimation, NSTableView.AnimationOptions.slideRight)
+    XCTAssertEqual(Animation.left.tableViewAnimation, NSTableView.AnimationOptions.slideLeft)
+    XCTAssertEqual(Animation.top.tableViewAnimation, NSTableView.AnimationOptions.slideUp)
+    XCTAssertEqual(Animation.bottom.tableViewAnimation, NSTableView.AnimationOptions.slideDown)
+    XCTAssertEqual(Animation.middle.tableViewAnimation, NSTableView.AnimationOptions.effectGap)
   }
 }


### PR DESCRIPTION
This PR migrates source code of all the Spots frameworks to Swift 4. The next step is to use updated versions of dependencies.