### PR TITLE
Remove manual handling of content offset for horizontal components

### DIFF
--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -2,7 +2,6 @@ import UIKit
 
 class FocusEngineManager {
   weak var lastFocusedComponent: Component?
-  var lastOffset: CGFloat = 0.0
 
   enum Direction {
     case up, down, noscroll
@@ -18,73 +17,10 @@ class FocusEngineManager {
   }
 
   func handleScrolling(in scrollView: ScrollView, for component: Component, itemIndex: Int, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    switch component.model.kind {
-    case .carousel:
-      handleHorizontalComponent(in: scrollView, for: component, itemIndex: itemIndex, targetContentOffset: targetContentOffset)
-    case .grid:
-      handleVerticalComponent(in: scrollView, for: component, itemIndex: itemIndex, targetContentOffset: targetContentOffset)
-    default:
-      break
+    defer {
+      lastFocusedComponent = component
     }
 
-    lastFocusedComponent = component
-  }
-
-  private func handleHorizontalComponent(in scrollView: ScrollView, for component: Component, itemIndex: Int, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let contentInsetTop: CGFloat = contentInset(for: scrollView).top
-    // Reached the top
-    guard component.model.index > 0 else {
-      targetContentOffset.pointee.y = -contentInsetTop
-      return
-    }
-
-    let frameCache = (component.collectionView?.collectionViewLayout as? ComponentFlowLayout)?.cachedFrames
-    let itemSize = component.item(at: itemIndex)!.size
-    var itemOffset = itemSize.height
-
-    if let frameCache = frameCache, itemIndex < frameCache.count {
-      itemOffset = frameCache[itemIndex].maxY
-    }
-
-    // Don't invoke this behavior if the pointee is the same as the scroll views content offset.
-    guard scrollView.contentOffset != targetContentOffset.pointee else {
-      return
-    }
-
-    // Reached the end of the screen.
-    let maximumContentOffset = scrollView.contentSize.height - scrollView.frame.size.height
-    if targetContentOffset.pointee.y >= maximumContentOffset {
-      targetContentOffset.pointee.y = maximumContentOffset
-      return
-    }
-
-    var layoutOffset = CGFloat(component.model.layout.inset.top + component.model.layout.inset.bottom)
-    layoutOffset += component.headerHeight
-    layoutOffset += component.footerHeight
-
-    let direction = Direction.determine(lhs: scrollView.contentOffset,
-                                        rhs: targetContentOffset.pointee)
-
-    if lastFocusedComponent == component &&
-      direction != .noscroll &&
-      lastOffset == itemOffset {
-      targetContentOffset.pointee.y = scrollView.contentOffset.y
-      return
-    }
-
-    switch direction {
-    case .up:
-      targetContentOffset.pointee.y = scrollView.contentOffset.y - itemOffset - layoutOffset
-    case .down:
-      targetContentOffset.pointee.y = scrollView.contentOffset.y + itemOffset + layoutOffset
-    case .noscroll:
-      targetContentOffset.pointee.y = scrollView.contentOffset.y
-    }
-
-    lastOffset = itemOffset
-  }
-
-  private func handleVerticalComponent(in scrollView: ScrollView, for component: Component, itemIndex: Int, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
     let contentInsetTop: CGFloat = contentInset(for: scrollView).top
     // Reached the top
     if component.model.index == 0 && itemIndex < Int(component.model.layout.span) {
@@ -120,3 +56,4 @@ class FocusEngineManager {
     return contentInset
   }
 }
+


### PR DESCRIPTION
I found that the solution that we have for vertical layout worked for both so... we can just use one. Yay!