### PR TITLE
Fix focus engine bug when reaching the top.

### DIFF
--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -22,7 +22,10 @@ class FocusEngineManager {
     }
 
     let contentInsetTop: CGFloat = contentInset(for: scrollView).top
-    let hasReachedTop = component.model.index == 0 && (component.model.kind == .carousel || itemIndex < Int(component.model.layout.span))
+    let isFirstComponent = component.model.index == 0
+    let firstRowItemIsFocused = component.model.kind == .carousel || itemIndex < Int(component.model.layout.span)
+    let hasReachedTop = isFirstComponent && firstRowItemIsFocused
+
     if hasReachedTop {
       targetContentOffset.pointee.y = -contentInsetTop
       return

--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -22,8 +22,8 @@ class FocusEngineManager {
     }
 
     let contentInsetTop: CGFloat = contentInset(for: scrollView).top
-    // Reached the top
-    if component.model.index == 0 && itemIndex < Int(component.model.layout.span) {
+    let hasReachedTop = component.model.index == 0 && (component.model.kind == .carousel || itemIndex < Int(component.model.layout.span))
+    if hasReachedTop {
       targetContentOffset.pointee.y = -contentInsetTop
       return
     }


### PR DESCRIPTION
The validation did not work for carousels, the condition has been
changed to be invoked for both types. The comment has been removed as
the variable has a descriptive name.