### PR TITLE
Improve comparing models

### DIFF
--- a/Sources/Shared/Classes/DiffManager.swift
+++ b/Sources/Shared/Classes/DiffManager.swift
@@ -159,6 +159,18 @@ class DiffManager {
       return .size
     }
 
+    if let newModel = newModel.model {
+      if let oldModel = oldModel.model {
+        if !(newModel == oldModel) {
+          return .model
+        }
+      } else {
+        return .model
+      }
+    } else if oldModel.model != nil {
+      return .model
+    }
+
     if newModel.image != oldModel.image {
       return .image
     }

--- a/Sources/Shared/Enums/ItemDiff.swift
+++ b/Sources/Shared/Enums/ItemDiff.swift
@@ -1,3 +1,3 @@
 public enum ItemDiff {
-  case identifier, index, title, subtitle, text, image, kind, action, meta, relations, size, new, removed, none, move(Int, Int)
+  case identifier, index, title, subtitle, text, image, model, kind, action, meta, relations, size, new, removed, none, move(Int, Int)
 }

--- a/Sources/Shared/Protocols/ItemModel.swift
+++ b/Sources/Shared/Protocols/ItemModel.swift
@@ -8,7 +8,12 @@ public func == (lhs: ItemCodable, rhs: ItemCodable) -> Bool {
     return false
   }
 
-  return String(describing: lhs).hashValue == String(describing: rhs).hashValue
+  var lhsOutput = ""
+  var rhsOutput = ""
+  dump(lhs, to: &lhsOutput)
+  dump(rhs, to: &rhsOutput)
+
+  return lhsOutput == rhsOutput
 }
 
 extension ItemCodable {


### PR DESCRIPTION
Adds `.model` as a property that will trigger a change when comparing component models.
When comparing `ItemModel`, it will now use `dump` and do string comparison using that output instead of using `String(describing: lhs).hashValue`. This is not optimal but it will render more valid results.