### PR TITLE
Optimize component setup and prepare methods

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -30,9 +30,12 @@ public class ItemManager {
     return max((componentWidth / CGFloat(component.model.layout.span)) - CGFloat(component.model.layout.itemSpacing), 0)
   }
 
-  func prepareItems(component: Component) {
+  func prepareItems(component: Component, purgeViews: Bool) {
     component.model.items = prepare(component: component, items: component.model.items)
-    configuration.views.purge()
+
+    if purgeViews {
+      configuration.views.purge()
+    }
   }
 
   func prepare(component: Component, items: [Item]) -> [Item] {

--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -30,10 +30,10 @@ public class ItemManager {
     return max((componentWidth / CGFloat(component.model.layout.span)) - CGFloat(component.model.layout.itemSpacing), 0)
   }
 
-  func prepareItems(component: Component, purgeViews: Bool) {
+  func prepareItems(component: Component, purgeCachedViews: Bool) {
     component.model.items = prepare(component: component, items: component.model.items)
 
-    if purgeViews {
+    if purgeCachedViews {
       configuration.views.purge()
     }
   }

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -327,8 +327,8 @@ public class SpotsControllerManager {
           fallthrough
         case .items:
           if index == lastItemChange {
-            completion = {
-              strongSelf.purgeCachedViews(in: controller.components)
+            completion = { [weak self] in
+              self?.purgeCachedViews(in: controller.components)
               finalCompletion?()
             }
             runCompletion = false

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -328,7 +328,7 @@ public class SpotsControllerManager {
         case .items:
           if index == lastItemChange {
             completion = {
-              strongSelf.purgeViews(in: controller.components)
+              strongSelf.purgeCachedViews(in: controller.components)
               finalCompletion?()
             }
             runCompletion = false
@@ -751,7 +751,7 @@ public class SpotsControllerManager {
     }
   }
 
-  func purgeViews(in components: [Component]) {
+  func purgeCachedViews(in components: [Component]) {
     for component in components {
       component.configuration.views.purge()
     }

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -327,7 +327,10 @@ public class SpotsControllerManager {
           fallthrough
         case .items:
           if index == lastItemChange {
-            completion = finalCompletion
+            completion = {
+              strongSelf.purgeViews(in: controller.components)
+              finalCompletion?()
+            }
             runCompletion = false
           }
 
@@ -745,6 +748,12 @@ public class SpotsControllerManager {
                        completion: completion)
         }
       }
+    }
+  }
+
+  func purgeViews(in components: [Component]) {
+    for component in components {
+      component.configuration.views.purge()
     }
   }
 }

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -77,8 +77,8 @@ public extension Component {
     }
   }
 
-  public func prepareItems(purgeViews: Bool = false) {
-    manager.itemManager.prepareItems(component: self, purgeViews: purgeViews)
+  public func prepareItems(purgeCachedViews: Bool = false) {
+    manager.itemManager.prepareItems(component: self, purgeCachedViews: purgeCachedViews)
   }
 
   /// Resolve a UI component at index with inferred type

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -77,8 +77,8 @@ public extension Component {
     }
   }
 
-  public func prepareItems() {
-    manager.itemManager.prepareItems(component: self)
+  public func prepareItems(purgeViews: Bool = false) {
+    manager.itemManager.prepareItems(component: self, purgeViews: purgeViews)
   }
 
   /// Resolve a UI component at index with inferred type

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -178,7 +178,11 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     layoutHeaderFooterViews(size)
 
     view.setNeedsLayout()
-    view.layoutIfNeeded()
+
+    // Only call `layoutIfNeeded` if the `Component` is not a part of a `SpotsController`.
+    if !(view.superview is SpotsContentView) {
+      view.layoutIfNeeded()
+    }
   }
 
   /// This method is invoked by `ComponentCollectionView.layoutSubviews()`.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -176,13 +176,8 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     layoutHeaderFooterViews(size)
-
     view.setNeedsLayout()
-
-    // Only call `layoutIfNeeded` if the `Component` is not a part of a `SpotsController`.
-    if !(view.superview is SpotsContentView) {
-      view.layoutIfNeeded()
-    }
+    view.layoutIfNeeded()
   }
 
   /// This method is invoked by `ComponentCollectionView.layoutSubviews()`.
@@ -323,7 +318,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   public func afterUpdate() {
     reloadHeader()
     reloadFooter()
-
     pageControl.numberOfPages = model.items.count
     view.superview?.layoutIfNeeded()
   }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -304,10 +304,12 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
   ///
   /// - parameter animated: An optional animation closure that is invoked when setting up the component.
   open func setupComponents(animated: ((_ view: UIView) -> Void)? = nil) {
-    components.enumerated().forEach { index, component in
+    for (index, component) in components.enumerated() {
       setupComponent(at: index, component: component)
       animated?(component.view)
     }
+
+    manager.purgeViews(in: components)
   }
 
   /// Set up Spot at index

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -309,7 +309,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
       animated?(component.view)
     }
 
-    manager.purgeViews(in: components)
+    manager.purgeCachedViews(in: components)
   }
 
   /// Set up Spot at index


### PR DESCRIPTION
This PR is all about doing small optimization that have a great impact when the payload of your constructors scale.

- Cached views will no longer be purged per `Component`, instead the controller manager will purge when the entire structure is done. That way the view cache is shared cross components.