### PR TITLE
Optimize component layout methods

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -177,7 +177,16 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     layoutHeaderFooterViews(size)
     view.setNeedsLayout()
-    view.layoutIfNeeded()
+    // Only call `layoutIfNeeded` if the `Component` is not a part of a `SpotsController`.
+    if let spotsScrollView = (focusDelegate as? SpotsController)?.scrollView {
+      let isVisibleOnScreen = view.frame.intersects(.init(origin: spotsScrollView.contentOffset,
+                                                          size: spotsScrollView.frame.size))
+      if isVisibleOnScreen {
+        view.layoutIfNeeded()
+      }
+    } else {
+      view.layoutIfNeeded()
+    }
   }
 
   /// This method is invoked by `ComponentCollectionView.layoutSubviews()`.

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -58,7 +58,10 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     }
 
     self.layoutAttributes = layoutAttributes
+    computeContentSize(with: component)
+  }
 
+  func computeContentSize(with component: Component) {
     switch scrollDirection {
     case .horizontal:
       contentSize = .zero

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -308,7 +308,6 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
       setupComponent(at: index, component: component)
       animated?(component.view)
     }
-
     manager.purgeCachedViews(in: components)
   }
 

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -33,20 +33,16 @@ extension Component {
       return
     }
 
-    let componentComputedHeight = computedHeight
+    collectionViewLayout.computeContentSize(with: self)
 
     // This fixes a constraints warning when trying to prepare a collection view
     // before it has gotten its initial frame.
     if collectionViewLayout.contentSize.height < collectionView.frame.size.height {
-      collectionView.frame.size.height = componentComputedHeight
+      collectionView.frame.size.height = computedHeight
     }
 
     collectionView.frame.size.width = size.width
-    collectionView.frame.size.height = componentComputedHeight
-
-    if collectionView.contentSize == .zero {
-      collectionView.contentSize = collectionViewLayout.contentSize
-    }
+    collectionView.frame.size.height = collectionViewLayout.contentSize.height
 
     configurePageControl(collectionView: collectionView, collectionViewLayout: collectionViewLayout)
   }

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -33,16 +33,20 @@ extension Component {
       return
     }
 
+    let componentComputedHeight = computedHeight
+
     // This fixes a constraints warning when trying to prepare a collection view
     // before it has gotten its initial frame.
     if collectionViewLayout.contentSize.height < collectionView.frame.size.height {
-      collectionView.frame.size.height = computedHeight
+      collectionView.frame.size.height = componentComputedHeight
     }
 
-    collectionViewLayout.prepare()
-    collectionViewLayout.invalidateLayout()
     collectionView.frame.size.width = size.width
-    collectionView.frame.size.height = computedHeight
+    collectionView.frame.size.height = componentComputedHeight
+
+    if collectionView.contentSize == .zero {
+      collectionView.contentSize = collectionViewLayout.contentSize
+    }
 
     configurePageControl(collectionView: collectionView, collectionViewLayout: collectionViewLayout)
   }


### PR DESCRIPTION
This PR tries to optimize the layout methods that is invoked when creating components the first time.
I re-worked some logic on when a `Component` should call `layoutIfNeeded`, the best way that I found was to check if the view is currently on screen, if its not, then opt out from doing unnecessary work.

`layoutHorizontalCollectionView` also got some optimization by not calling `computedHeight` multiple times. And it will no longer manually invoke `invalidateLayout` and `prepare`