### PR TITLE
Improve: item model equatable

### DIFF
--- a/Sources/Shared/Classes/DiffManager.swift
+++ b/Sources/Shared/Classes/DiffManager.swift
@@ -161,7 +161,7 @@ class DiffManager {
 
     if let newModel = newModel.model {
       if let oldModel = oldModel.model {
-        if !(newModel == oldModel) {
+        if !(newModel.equal(to: oldModel)) {
           return .model
         }
       } else {

--- a/Sources/Shared/Protocols/ItemModel.swift
+++ b/Sources/Shared/Protocols/ItemModel.swift
@@ -1,25 +1,23 @@
 import Foundation
 
-public protocol ItemCodable: Codable {}
+public protocol ItemCodable: Codable {
+    func equal(to rhs: ItemCodable) -> Bool
+}
 public protocol ItemModel: ItemCodable, Equatable {}
 
-public func == (lhs: ItemCodable, rhs: ItemCodable) -> Bool {
-  guard type(of: lhs) == type(of: rhs) else {
-    return false
-  }
-
-  var lhsOutput = ""
-  var rhsOutput = ""
-  dump(lhs, to: &lhsOutput)
-  dump(rhs, to: &rhsOutput)
-
-  return lhsOutput == rhsOutput
+public extension ItemCodable where Self : Equatable {
+    func equal(to rhs: ItemCodable) -> Bool {
+        guard let rhs = rhs as? Self else {
+            return false
+        }
+        return self == rhs
+    }
 }
 
 extension ItemCodable {
-  func serialize() -> Data? {
-    let encoder = JSONEncoder()
-    let data = try? encoder.encode(self)
-    return data
-  }
+    func serialize() -> Data? {
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(self)
+        return data
+    }
 }

--- a/Sources/Shared/Protocols/ItemModel.swift
+++ b/Sources/Shared/Protocols/ItemModel.swift
@@ -1,23 +1,23 @@
 import Foundation
 
 public protocol ItemCodable: Codable {
-    func equal(to rhs: ItemCodable) -> Bool
+  func equal(to rhs: ItemCodable) -> Bool
 }
 public protocol ItemModel: ItemCodable, Equatable {}
 
 public extension ItemCodable where Self: Equatable {
-    func equal(to rhs: ItemCodable) -> Bool {
-        guard let rhs = rhs as? Self else {
-            return false
-        }
-        return self == rhs
+  func equal(to rhs: ItemCodable) -> Bool {
+    guard let rhs = rhs as? Self else {
+      return false
     }
+    return self == rhs
+  }
 }
 
 extension ItemCodable {
-    func serialize() -> Data? {
-        let encoder = JSONEncoder()
-        let data = try? encoder.encode(self)
-        return data
-    }
+  func serialize() -> Data? {
+    let encoder = JSONEncoder()
+    let data = try? encoder.encode(self)
+    return data
+  }
 }

--- a/Sources/Shared/Protocols/ItemModel.swift
+++ b/Sources/Shared/Protocols/ItemModel.swift
@@ -5,7 +5,7 @@ public protocol ItemCodable: Codable {
 }
 public protocol ItemModel: ItemCodable, Equatable {}
 
-public extension ItemCodable where Self : Equatable {
+public extension ItemCodable where Self: Equatable {
     func equal(to rhs: ItemCodable) -> Bool {
         guard let rhs = rhs as? Self else {
             return false

--- a/Sources/Shared/Structs/Item.swift
+++ b/Sources/Shared/Structs/Item.swift
@@ -293,7 +293,7 @@ public func == (lhs: Item, rhs: Item) -> Bool {
   var modelsAreEqual: Bool = true
   if let lhsModel = lhs.model {
     if let rhsModel = rhs.model {
-      modelsAreEqual = lhsModel == rhsModel
+      modelsAreEqual = lhsModel.equal(to: rhsModel)
     } else {
       modelsAreEqual = false
     }
@@ -334,7 +334,7 @@ public func === (lhs: Item, rhs: Item) -> Bool {
   var modelsAreEqual: Bool = true
   if let lhsModel = lhs.model {
     if let rhsModel = rhs.model {
-      modelsAreEqual = lhsModel == rhsModel
+      modelsAreEqual = lhsModel.equal(to: rhsModel)
     } else {
       modelsAreEqual = false
     }

--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -59,4 +59,3 @@ class FocusEngineManager {
     return contentInset
   }
 }
-

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 		BD165A3A1E6EAF310023AF82 /* ComponentFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentFlowLayout.swift; sourceTree = "<group>"; };
 		BD1D17241EA89A36000DBCF8 /* SpotsRefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsRefreshControl.swift; sourceTree = "<group>"; };
 		BD1F9A881F908866003E6D8D /* ItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemModel.swift; sourceTree = "<group>"; };
-		BD1F9A8C1F9088C6003E6D8D /* ItemModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemModelTests.swift; sourceTree = "<group>"; };
+		BD1F9A8C1F9088C6003E6D8D /* ItemModelTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ItemModelTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 		BD1F9E0E1EA39DFD009C018B /* SpotsController+iOS+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SpotsController+iOS+Extensions.swift"; sourceTree = "<group>"; };
 		BD1F9E141EA39F02009C018B /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		BD20E65F1F384672008C2B8B /* DiffManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffManager.swift; sourceTree = "<group>"; };

--- a/SpotsTests/Shared/ItemModelTests.swift
+++ b/SpotsTests/Shared/ItemModelTests.swift
@@ -6,11 +6,11 @@ final class ItemModelTests: XCTestCase {
   func testEqualToWithEquatables() {
     // When equal
     do {
-        let a = "foo"
-        let b = "foo"
-        XCTAssertTrue(a.equal(to: b))
+      let a = "foo"
+      let b = "foo"
+      XCTAssertTrue(a.equal(to: b))
     }
-    
+
     // When not equal
     do {
       let a = "foo"

--- a/SpotsTests/Shared/ItemModelTests.swift
+++ b/SpotsTests/Shared/ItemModelTests.swift
@@ -2,75 +2,29 @@
 import Foundation
 import XCTest
 
-class ItemModelTests: XCTestCase {
-
-  struct EquatableSubjectA: ItemModel, Equatable {
-    let value: String
-
-    static func ==(lhs: EquatableSubjectA, rhs: EquatableSubjectA) -> Bool {
-      return lhs.value == rhs.value
-    }
-  }
-
-  struct EquatableSubjectB: ItemModel, Equatable {
-    let value: String
-
-    static func ==(lhs: EquatableSubjectB, rhs: EquatableSubjectB) -> Bool {
-      return lhs.value == rhs.value
-    }
-  }
-
-  struct SubjectA: ItemCodable {
-    let value: String
-  }
-
-  struct SubjectB: ItemCodable {
-    let value: String
-  }
-
-  func testEqualToOnItemModel() {
-
-    // Compare two equal objects
-    do {
-      let a = SubjectA(value: "foo")
-      let b = SubjectA(value: "foo")
-
-      XCTAssertTrue(a == b)
-    }
-
-    // Compare two equal objects with different identifiers
-    do {
-      let a = SubjectA(value: "foo")
-      let b = SubjectA(value: "bar")
-      XCTAssertFalse(a == b)
-    }
-
-    // Compare two objects with the same identifier signature but with different types.
-    do {
-      let a = SubjectA(value: "foo")
-      let b = SubjectB(value: "foo")
-      XCTAssertFalse(a == b)
-    }
-
-    // Compare two objects with unequal identifier and with different types.
-    do {
-      let a = SubjectA(value: "foo")
-      let b = SubjectB(value: "bar")
-      XCTAssertFalse(a == b)
-    }
-  }
-
-  func testEquatableWithNonEquatable() {
-    let a = EquatableSubjectA(value: "foo")
-    let b = SubjectA(value: "foo")
-    XCTAssertFalse(a == b)
-  }
-
+final class ItemModelTests: XCTestCase {
   func testEqualToWithEquatables() {
+    // When equal
     do {
-      let a = EquatableSubjectA(value: "foo")
-      let b = EquatableSubjectA(value: "foo")
-      XCTAssertTrue(a == b)
+        let a = "foo"
+        let b = "foo"
+        XCTAssertTrue(a.equal(to: b))
     }
+    
+    // When not equal
+    do {
+      let a = "foo"
+      let b = "bar"
+      XCTAssertFalse(a.equal(to: b))
+    }
+  }
+
+  func testEqualToWithEquatablesOfDifferentTypes() {
+    let a = "foo"
+    let b = 1
+    XCTAssertFalse(a.equal(to: b))
   }
 }
+
+extension String: ItemModel {}
+extension Int: ItemModel {}


### PR DESCRIPTION
- This PR removes default implementation where we used `dump` to compare two `ItemCodable` objects and adds `equal(to` function instead. 
- There is a default implementation for `equal(to` when `ItemCodable` is `Equatable` and it should be enough because we force to use `Equatable` and never use `ItemCodable` directly.