### PR TITLE
Fix bug when you try to reload an empty Component

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -149,12 +149,16 @@ public class SpotsControllerManager {
   ///   - index: The index of the component
   ///   - controller: A SpotsController
   ///   - newComponentModels: The new component model that should replace the existing component.
-  fileprivate func replaceComponent(atIndex index: Int, with preparedComponent: Component? = nil, controller: SpotsController, newComponentModels: [ComponentModel]) {
+  fileprivate func replaceComponent(atIndex index: Int, with preparedComponent: Component? = nil, controller: SpotsController, newComponentModels: [ComponentModel], completion: Completion = nil) {
     let component: Component
     let oldComponent = controller.components[index]
 
     if let preparedComponent = preparedComponent {
       component = preparedComponent
+
+      defer {
+        completion?()
+      }
     } else {
       component = Component(model: newComponentModels[index], configuration: controller.configuration)
       component.view.frame = oldComponent.view.frame
@@ -732,7 +736,7 @@ public class SpotsControllerManager {
         // If the component is empty, then replace the old one with the temporary component
         // used for diffing.
         if component.model.items.isEmpty {
-          self?.replaceComponent(atIndex: component.model.index, with: tempComponent, controller: controller, newComponentModels: [])
+          self?.replaceComponent(atIndex: component.model.index, with: tempComponent, controller: controller, newComponentModels: [], completion: completion)
           return
         }
 

--- a/Sources/macOS/Classes/SpotsContentView.swift
+++ b/Sources/macOS/Classes/SpotsContentView.swift
@@ -20,7 +20,10 @@ open class SpotsContentView: NSView {
   ///   - view: The view that should be inserted.
   ///   - index: The index that the view should be inserted at.
   func insertSubview(_ view: View, at index: Int) {
-    subviews.insert(view, at: index)
+    if !subviews.contains(view) {
+      subviews.insert(view, at: index)
+    }
+
     rebuildSubviewsInLayoutOrder()
     resolveSpotsScrollView { scrollView in
       scrollView.layoutViews(animated: true)


### PR DESCRIPTION
This fixes a bug where you try to reload items in an empty Component.
The bug occurs because the Component tries to prepare its items without
a frame. To solve this issue, we simply replace the existing Component
with the temporary component that we already create to diff the
payloads.