### PR TITLE
Refactor SpotsScrollView to work better with fast scrolling in vertical collection views

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -85,16 +85,16 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
     #if os(iOS)
       scrollView.scrollsToTop = false
-      scrollView.isScrollEnabled = false
+      if let collectionView = scrollView as? UICollectionView,
+        let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout, layout.scrollDirection == .horizontal {
+        scrollView.isScrollEnabled = true
+      } else {
+        scrollView.isScrollEnabled = false
+      }
     #else
       scrollView.isScrollEnabled = true
     #endif
 
-
-    if let collectionView = scrollView as? UICollectionView,
-      let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout, layout.scrollDirection == .horizontal {
-      scrollView.isScrollEnabled = true
-    }
     setNeedsLayout()
     layoutSubviews()
   }

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -44,6 +44,11 @@ extension SpotsScrollView {
         newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
       }
 
+      if let collectionView = scrollView as? UICollectionView,
+        let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout, layout.scrollDirection == .horizontal {
+        scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
+      }
+
       frame.size.height = newHeight
 
       // Using `.integral` can sometimes set the height back to 1.
@@ -58,7 +63,6 @@ extension SpotsScrollView {
       }
 
       scrollView.frame = frame
-      scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
 
       sizeCache[offset] = yOffsetOfCurrentSubview
       yOffsetOfCurrentSubview += scrollView.contentSize.height


### PR DESCRIPTION
This fixes fast scrolling in collection views on tvOS. The reason for it not working before was that both views tried to scroll at the same time.