### PR TITLE
Improve `delegate.didReachEnd` algorithm

### DIFF
--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -21,12 +21,14 @@ extension SpotsController {
     let multiplier: CGFloat = !refreshPositions.isEmpty
       ? CGFloat(1 + refreshPositions.count)
       : 1
+    let windowHeight = scrollView.window?.frame.size.height ?? 0
+    let windowViewOffset = windowHeight - scrollView.frame.size.height
     let itemOffset = (size.height - scrollView.bounds.size.height * 2) > 0
       ? scrollView.bounds.size.height * 2
       : (components.last?.model.items.last?.size.height ?? 0) * 6
     let shouldFetch = !refreshing &&
       size.height > scrollView.bounds.height &&
-      offset.y > size.height - scrollView.bounds.height * multiplier &&
+      offset.y > size.height - windowViewOffset - scrollView.bounds.height * multiplier &&
       !refreshPositions.contains(size.height - itemOffset)
 
     guard let delegate = scrollDelegate else {


### PR DESCRIPTION
Use window view offset when calculating when the scroll view should
start to fetch content. This only applies when the view does not own
the entire window real-estate.