### PR TITLE
Improve/fast scrolling on tvos part3

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -224,7 +224,6 @@ public class ItemManager {
   public func sizeForItem(at indexPath: IndexPath, in component: Component) -> CGSize {
     var size = component.item(at: indexPath)?.size ?? .zero
     size.width = max(size.width, 0)
-    size.height = max(size.height, 0)
 
     #if os(macOS)
       // Make sure that the item width never exceeds the frame view width.
@@ -253,6 +252,8 @@ public class ItemManager {
         size.height = component.view.frame.size.height - CGFloat(component.model.layout.inset.bottom)
       }
     #endif
+
+    size.height = fmax(size.height, 0)
 
     return size
   }

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -47,6 +47,8 @@ extension SpotsScrollView {
       if let collectionView = scrollView as? UICollectionView,
         let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout, layout.scrollDirection == .horizontal {
         scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
+      } else if subviewsInLayoutOrder.count > 1 {
+        scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
       }
 
       frame.size.height = newHeight

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -46,14 +46,9 @@ extension SpotsScrollView {
         newHeight = calculatedHeight
       }
 
-      let isVisibleOnScreen = scrollView.frame.intersects(.init(origin: self.contentOffset,
-                                                                size: self.frame.size))
-
-      Swift.print("isVisibleOnScreen(\(offset)): \(isVisibleOnScreen)")
 
       if let component = (scrollView.delegate as? Delegate)?.component {
-        switch component.model.kind {
-        case .carousel:
+        if component.model.kind == .carousel {
           newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
           if contentOffset.y < scrollView.frame.size.height {
             scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
@@ -61,21 +56,13 @@ extension SpotsScrollView {
             scrollView.frame.size.height = newHeight
             continue
           }
-        case .grid:
+        } else if component.model.kind == .grid {
           if subviewsInLayoutOrder.count > 1 {
+            if contentOffset.y > scrollView.contentOffset.y {
+              scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
+            }
             newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
-
-//            let isVisibleOnScreen = scrollView.frame.intersects(.init(origin: self.contentOffset,
-//                                                                      size: self.frame.size))
-//
-//            if isVisibleOnScreen {
-//              scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
-//            } else {
-//              continue
-//            }
           }
-        default:
-          break
         }
       }
 

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -3,9 +3,7 @@ import UIKit
 
 extension SpotsScrollView {
   /// Layout views in linear order based of view index in `subviewsInLayoutOrder`
-  func layoutViews(file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-//    Swift.print("file: \(file):\(function):\(line)")
-
+  func layoutViews() {
     guard let superview = superview else {
       return
     }

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -44,11 +44,12 @@ extension SpotsScrollView {
         newHeight = calculatedHeight
       }
 
+      let shouldModifyContentOffset = contentOffset.y < scrollView.frame.size.height || contentOffset.y > scrollView.contentOffset.y
 
       if let component = (scrollView.delegate as? Delegate)?.component {
         if component.model.kind == .carousel {
           newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
-          if contentOffset.y < scrollView.frame.size.height {
+          if shouldModifyContentOffset {
             scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
           } else {
             scrollView.frame.size.height = newHeight
@@ -56,7 +57,7 @@ extension SpotsScrollView {
           }
         } else if component.model.kind == .grid {
           if subviewsInLayoutOrder.count > 1 {
-            if contentOffset.y > scrollView.contentOffset.y {
+            if shouldModifyContentOffset {
               scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
             }
             newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)


### PR DESCRIPTION
This commit optimizes the SpotsScrollView extension on tvOS. The performance hog that we previously had was caused by all of the components trying to scroll at once. Now it will only try to scroll components that are not visible on screen. This is determined by checking the content offset before trying to scroll the component.

It also improves safety by slightly adjusting the `ItemManager` to never return negative heights. If it were to return a negative height then the `UICollectionFlowLayout` will throw an exception. It could become negative if `insets` is used in combination with the frame being zero. The easy fix is to use `max(size.height, 0)`, then it will never be less than zero.