### PR TITLE
Optimize tvOS performance

### DIFF
--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -146,7 +146,12 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           return
         }
 
-        if newValue != value.oldValue {
+        guard let oldValue = value.oldValue else {
+          strongSelf.layoutViews()
+          return
+        }
+
+        if newValue.y != oldValue.y {
           strongSelf.layoutViews()
         }
       })
@@ -160,7 +165,12 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           return
         }
 
-        if newValue != value.oldValue {
+        guard let oldValue = value.oldValue else {
+          strongSelf.layoutViews()
+          return
+        }
+
+        if newValue.origin.y != oldValue.origin.y {
           strongSelf.layoutViews()
         }
       })

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -94,7 +94,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
     #else
       if subviewsInLayoutOrder.count > 1 {
         for case let scrollView as ScrollView in subviewsInLayoutOrder {
-          scrollView.isScrollEnabled = false
+          scrollView.isScrollEnabled = (scrollView as? UICollectionView)?.flowLayout?.scrollDirection == .horizontal
         }
       } else {
         scrollView.isScrollEnabled = true

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -93,7 +93,9 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
       }
     #else
       if subviewsInLayoutOrder.count > 1 {
-        scrollView.isScrollEnabled = false
+        for case let scrollView as ScrollView in subviewsInLayoutOrder {
+          scrollView.isScrollEnabled = false
+        }
       } else {
         scrollView.isScrollEnabled = true
       }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -136,12 +136,12 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
           return
         }
 
-        if newValue != value.oldValue {
+        if scrollView.contentSize != newValue {
           strongSelf.layoutViews()
         }
       })
 
-      let contentOffsetObserver = scrollView.observe(\.contentOffset, options: [.new, .old], changeHandler: { [weak self] (scrollView, value) in
+      let contentOffsetObserver = scrollView.observe(\.contentOffset, options: [.new, .old], changeHandler: { [weak self] (_, value) in
         guard let strongSelf = self, let newValue = value.newValue else {
           return
         }
@@ -160,7 +160,7 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
       observers.append(Observer(view: view, keyValueObservation: contentOffsetObserver))
       fallthrough
     default:
-      let boundsObserver = view.observe(\.bounds, options: [.new, .old], changeHandler: { [weak self] (view, value) in
+      let boundsObserver = view.observe(\.bounds, options: [.new, .old], changeHandler: { [weak self] (_, value) in
         guard let strongSelf = self, let newValue = value.newValue else {
           return
         }

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -131,46 +131,37 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
 
     switch view {
     case let scrollView as UIScrollView:
-      let contentSizeObserver = scrollView.observe(\.contentSize, options: [.new], changeHandler: { [weak self] (scrollView, value) in
-        guard let `self` = self else {
+      let contentSizeObserver = scrollView.observe(\.contentSize, options: [.new, .old], changeHandler: { [weak self] (scrollView, value) in
+        guard let strongSelf = self, let newValue = value.newValue else {
           return
         }
 
-        guard !(self.compare(size: scrollView.contentSize, to: value.newValue)) else {
-          return
+        if newValue != value.oldValue {
+          strongSelf.layoutViews()
         }
-
-        self.layoutViews()
       })
 
-      let contentOffsetObserver = scrollView.observe(\.contentOffset, options: [.new], changeHandler: { [weak self] (scrollView, value) in
-        guard let `self` = self else {
+      let contentOffsetObserver = scrollView.observe(\.contentOffset, options: [.new, .old], changeHandler: { [weak self] (scrollView, value) in
+        guard let strongSelf = self, let newValue = value.newValue else {
           return
         }
 
-        guard !(self.compare(point: scrollView.contentOffset, to: value.newValue)) else {
-          return
+        if newValue != value.oldValue {
+          strongSelf.layoutViews()
         }
-
-        self.layoutViews()
       })
 
       observers.append(Observer(view: view, keyValueObservation: contentSizeObserver))
       observers.append(Observer(view: view, keyValueObservation: contentOffsetObserver))
       fallthrough
     default:
-      let boundsObserver = view.observe(\.bounds, options: [.new], changeHandler: { [weak self] (view, value) in
-        guard let `self` = self else {
+      let boundsObserver = view.observe(\.bounds, options: [.new, .old], changeHandler: { [weak self] (view, value) in
+        guard let strongSelf = self, let newValue = value.newValue else {
           return
         }
 
-        if !self.compare(rect: view.bounds, to: value.oldValue) {
-          self.layoutViews()
-          return
-        }
-
-        if !self.compare(rect: view.bounds, to: value.newValue) {
-          self.layoutViews()
+        if newValue != value.oldValue {
+          strongSelf.layoutViews()
         }
       })
 

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -92,7 +92,11 @@ open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
         scrollView.isScrollEnabled = false
       }
     #else
-      scrollView.isScrollEnabled = true
+      if subviewsInLayoutOrder.count > 1 {
+        scrollView.isScrollEnabled = false
+      } else {
+        scrollView.isScrollEnabled = true
+      }
     #endif
 
     setNeedsLayout()

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// A scroll view extension on CarouselComponent to handle scrolling specifically for this object.
 extension Delegate: UIScrollViewDelegate {
-
+  #if os(iOS)
   public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     if let spotsScrollView = scrollView.superview?.superview as? SpotsScrollView {
       let spotsScrollGesture = spotsScrollView.panGestureRecognizer
@@ -22,11 +22,14 @@ extension Delegate: UIScrollViewDelegate {
       }
     }
   }
+  #endif
 
   public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    #if os(iOS)
     if let spotsScrollView = scrollView.superview?.superview as? SpotsScrollView {
       spotsScrollView.panGestureRecognizer.isEnabled = true
     }
+    #endif
 
     if let component = component {
       if let footerView = component.footerView {

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -11,6 +11,7 @@ extension SpotsController {
 
   open func scrollViewDidScroll(_ scrollView: UIScrollView) {
     #if os(tvOS)
+      self.scrollView.layoutViews()
       guard scrollDelegate?.didScroll(in: scrollView) != true else {
         return
       }

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -14,13 +14,15 @@ extension SpotsController {
       guard scrollDelegate?.didScroll(in: scrollView) != true else {
         return
       }
+      let multiplier: CGFloat = 1
+    #else
+      let multiplier: CGFloat = !refreshPositions.isEmpty
+        ? CGFloat(1 + refreshPositions.count)
+        : 1
     #endif
 
     let offset = scrollView.contentOffset
     let size = scrollView.contentSize
-    let multiplier: CGFloat = !refreshPositions.isEmpty
-      ? CGFloat(1 + refreshPositions.count)
-      : 1
     let windowHeight = scrollView.window?.frame.size.height ?? 0
     let windowViewOffset = windowHeight - scrollView.frame.size.height
     let itemOffset = (size.height - scrollView.bounds.size.height * 2) > 0

--- a/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
+++ b/Sources/iOS/Extensions/SpotsController+UIScrollViewDelegate.swift
@@ -64,8 +64,10 @@ extension SpotsController {
   }
 
   public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-    for case let componentView as ScrollView in self.scrollView.componentsView.subviews where !componentView.panGestureRecognizer.isEnabled {
-      componentView.panGestureRecognizer.isEnabled = true
-    }
+    #if os(iOS)
+      for case let componentView as ScrollView in self.scrollView.componentsView.subviews where !componentView.panGestureRecognizer.isEnabled {
+        componentView.panGestureRecognizer.isEnabled = true
+      }
+    #endif
   }
 }

--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -56,4 +56,3 @@ class FocusEngineManager {
     return contentInset
   }
 }
-

--- a/Sources/tvOS/Extensions/SpotsController+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsController+tvOS.swift
@@ -38,10 +38,6 @@ extension SpotsController {
   }
 
   public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    defer {
-      self.scrollView.layoutViews()
-    }
-
     // Determine if the default behavior has been overriden by a delegate.
     if let scrollDelegate = scrollDelegate {
       guard scrollDelegate.didEndDragging(in: scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset) == false else {

--- a/Sources/tvOS/Extensions/SpotsController+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsController+tvOS.swift
@@ -38,6 +38,12 @@ extension SpotsController {
   }
 
   public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    #if os(tvOS)
+      if scrollView.contentOffset != targetContentOffset.pointee {
+        self.scrollView.layoutViews()
+      }
+    #endif
+
     // Determine if the default behavior has been overriden by a delegate.
     if let scrollDelegate = scrollDelegate {
       guard scrollDelegate.didEndDragging(in: scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset) == false else {

--- a/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
+++ b/Sources/tvOS/Extensions/SpotsScrollView+tvOS.swift
@@ -13,10 +13,13 @@ extension SpotsScrollView {
 
     var yOffsetOfCurrentSubview: CGFloat = 0.0
     let lastView = subviewsInLayoutOrder.last
+    let multipleComponents = subviewsInLayoutOrder.count > 1
+    let scrollViews = subviewsInLayoutOrder.flatMap({ $0 as? ScrollView })
 
-    for (offset, view) in subviewsInLayoutOrder.enumerated() {
-      guard let scrollView = view as? UIScrollView else {
-        return
+    for (offset, scrollView) in scrollViews.enumerated() {
+      defer {
+        sizeCache[offset] = yOffsetOfCurrentSubview
+        yOffsetOfCurrentSubview += scrollView.contentSize.height
       }
 
       var frame = scrollView.frame
@@ -30,54 +33,30 @@ extension SpotsScrollView {
         frame.origin.y = self.contentOffset.y
       }
 
-      sizeCache[offset] = yOffsetOfCurrentSubview
-      yOffsetOfCurrentSubview += scrollView.contentSize.height
-
-      let remainingBoundsHeight = fmax(bounds.maxY - frame.minY, 0.0)
+      let remainingBoundsHeight = fmax(bounds.maxY - yOffsetOfCurrentSubview, 0.0)
       let remainingContentHeight = fmax(scrollView.contentSize.height - contentOffset.y, 0.0)
-      let calculatedHeight = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
 
       var newHeight: CGFloat
       if configuration.stretchLastComponent && scrollView.isEqual(lastView) {
         newHeight = self.frame.size.height - scrollView.frame.origin.y + self.contentOffset.y
       } else {
-        newHeight = calculatedHeight
+        newHeight = ceil(fmin(remainingBoundsHeight, remainingContentHeight))
       }
 
-      let shouldModifyContentOffset = contentOffset.y < scrollView.frame.size.height || contentOffset.y > scrollView.contentOffset.y
-
-      if let component = (scrollView.delegate as? Delegate)?.component {
-        if component.model.kind == .carousel {
-          newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
-          if shouldModifyContentOffset {
-            scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
-          } else {
-            scrollView.frame.size.height = newHeight
-            continue
-          }
-        } else if component.model.kind == .grid {
-          if subviewsInLayoutOrder.count > 1 {
-            if shouldModifyContentOffset {
-              scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
-            }
-          }
-          newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
+      switch multipleComponents {
+      case true:
+        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height
+        newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
+        if shouldModifyContentOffset {
+          scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
+        } else {
+          frame.origin.y = yOffsetOfCurrentSubview
         }
+      case false:
+        newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
       }
 
       frame.size.height = newHeight
-
-      // Using `.integral` can sometimes set the height back to 1.
-      // To avoid this we check if the height is zero before we run `.integral`.
-      // If it was, then we set it to zero again to not have frame heights jump between
-      // one and zero when scrolling. Jump frame heights can cause rendering issues and
-      // make `UICollectionView` not render corretly when you use multiple components.
-      let shouldResetFrameHeightToZero = frame.size.height == 0
-      frame = frame.integral
-      if shouldResetFrameHeightToZero {
-        frame.size.height = 0
-      }
-
       scrollView.frame = frame
     }
 


### PR DESCRIPTION
This refactors the rendering algorithm on tvOS, it also improves how views are being observed in `SpotsScrollView` which applies to both iOS and tvOS.

On tvOS, you don't want to pre-fetch as fast as you do on iOS so the multipler that is applied when the user reaches the end of the screen is set to constant `1` on tvOS.

The new thing about the new algorithm on tvOS is that is know nothing about what type of component it is.