### PR TITLE
Add type to view(at:) method on UserInterface

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -286,10 +286,11 @@ public class ComponentManager {
         }
         updateHeightAndIndexes = true
       case .soft:
-        if let view: ItemConfigurable = component.userInterface?.view(at: index) {
+        if let view: View = component.userInterface?.view(at: index),
+          let itemConfigurable = view as? ItemConfigurable {
           component.userInterface?.performUpdates({
-            view.configure(with: component.model.items[index])
-            component.model.items[index].size.height = view.computeSize(for: component.model.items[index], containerSize: component.view.frame.size).height
+            itemConfigurable.configure(with: component.model.items[index])
+            component.model.items[index].size.height = itemConfigurable.computeSize(for: component.model.items[index], containerSize: component.view.frame.size).height
           }, completion: {
             self.finishComponentOperation(component, updateHeightAndIndexes: updateHeightAndIndexes, completion: completion)
           })

--- a/Sources/Shared/Extensions/Component+Core.swift
+++ b/Sources/Shared/Extensions/Component+Core.swift
@@ -86,7 +86,7 @@ public extension Component {
   /// - parameter index: The index of the UI component
   ///
   /// - returns: An optional view of inferred type
-  public func ui<T>(at index: Int) -> T? {
+  public func ui<T: View>(at index: Int) -> T? {
     return userInterface?.view(at: index)
   }
 

--- a/Sources/Shared/Extensions/SpotsController+Extensions.swift
+++ b/Sources/Shared/Extensions/SpotsController+Extensions.swift
@@ -13,7 +13,7 @@ public extension SpotsController {
   /// - parameter includeElement: A filter predicate used to match the UI that should be resolved.
   ///
   /// - returns: An optional object with inferred type.
-  public func ui<T>(_ includeElement: (Item) -> Bool) -> T? {
+  public func ui<T: View>(_ includeElement: (Item) -> Bool) -> T? {
     for component in components {
       if let first = component.model.items.filter(includeElement).first {
         return component.ui(at: first.index)

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -36,7 +36,7 @@ public protocol UserInterface: class {
   /// - parameter index: The index of the UI that you are looking for.
   ///
   /// - returns: Find UI element with generic type inferred.
-  func view<T>(at index: Int) -> T?
+  func view<T: View>(at index: Int) -> T?
 
   ///  A convenience method for performing inserts on a UserInterface
   ///

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -103,7 +103,7 @@ extension UICollectionView: UserInterface {
   ///
   /// - Parameter index: The item index that should be used to resolve the view.
   /// - Returns: The view that is resolved at the index casted into the inferred type.
-  public func view<T>(at index: Int) -> T? {
+  public func view<T: View>(at index: Int) -> T? {
     let view: UICollectionViewCell? = cell(at: index)
     switch view {
     case let view as GridWrapper:


### PR DESCRIPTION
To make `view(at:)` easier to use, it now uses `View` as its type when trying to resolve a view. That way you don't always have to specify the type if you simply rely on it just being a normal view.