### PR TITLE
Feature focus guide on Component

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -8,6 +8,8 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   open static var configure: ((Component) -> Void)?
   /// A focus delegate that returns which component is focused.
   weak public var focusDelegate: ComponentFocusDelegate?
+  /// A focus guide for the component
+  public var focusGuide: UIFocusGuide
   /// A component delegate, used for interaction and to pick up on mutation made to
   /// `self.components`. See `ComponentDelegate` for more information.
   weak public var delegate: ComponentDelegate?
@@ -95,10 +97,11 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `UITableView` or `UICollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either UICollectionView or UITableView).
-  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared) {
+  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared, focusGuide: UIFocusGuide = .init()) {
     self.model = model
     self.view = view
     self.configuration = configuration
+    self.focusGuide = focusGuide
     self.manager = ComponentManager(configuration: configuration)
     super.init()
     registerDefaultIfNeeded(view: DefaultItemView.self)
@@ -110,6 +113,13 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
 
     self.componentDataSource = DataSource(component: self, with: configuration)
     self.componentDelegate = Delegate(component: self, with: configuration)
+
+    view.addLayoutGuide(focusGuide)
+    focusGuide.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+    focusGuide.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+    focusGuide.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+    focusGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    focusGuide.isEnabled = false
   }
 
   /// A convenience init for creating a component with a `ComponentModel`.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -8,8 +8,10 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   open static var configure: ((Component) -> Void)?
   /// A focus delegate that returns which component is focused.
   weak public var focusDelegate: ComponentFocusDelegate?
+  #if os(tvOS)
   /// A focus guide for the component
-  public var focusGuide: UIFocusGuide
+  public lazy var focusGuide: UIFocusGuide = .init()
+  #endif
   /// A component delegate, used for interaction and to pick up on mutation made to
   /// `self.components`. See `ComponentDelegate` for more information.
   weak public var delegate: ComponentDelegate?
@@ -97,11 +99,10 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   ///   - model: A `ComponentModel` that is used to configure the interaction, behavior and look-and-feel of the component.
   ///   - view: A scroll view, should either be a `UITableView` or `UICollectionView`.
   ///   - kind: The `kind` defines which user interface the component should render (either UICollectionView or UITableView).
-  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared, focusGuide: UIFocusGuide = .init()) {
+  public required init(model: ComponentModel, view: ScrollView, configuration: Configuration = .shared) {
     self.model = model
     self.view = view
     self.configuration = configuration
-    self.focusGuide = focusGuide
     self.manager = ComponentManager(configuration: configuration)
     super.init()
     registerDefaultIfNeeded(view: DefaultItemView.self)
@@ -114,12 +115,14 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     self.componentDataSource = DataSource(component: self, with: configuration)
     self.componentDelegate = Delegate(component: self, with: configuration)
 
+    #if os(tvOS)
     view.addLayoutGuide(focusGuide)
     focusGuide.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
     focusGuide.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
     focusGuide.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
     focusGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     focusGuide.isEnabled = false
+    #endif
   }
 
   /// A convenience init for creating a component with a `ComponentModel`.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -85,6 +85,7 @@ extension Delegate: UICollectionViewDelegate {
     if let component = component, indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
+      component.focusGuide.preferredFocusedView = collectionView.view(at: indexPath.item)
     }
 
     return context.nextFocusedView?.canBecomeFocused ?? false
@@ -168,6 +169,7 @@ extension Delegate: UITableViewDelegate {
     if let component = component, indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
+      component.focusGuide.preferredFocusedView = tableView.view(at: indexPath.item)
     }
 
     return true

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -85,7 +85,9 @@ extension Delegate: UICollectionViewDelegate {
     if let component = component, indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
+      #if os(tvOS)
       component.focusGuide.preferredFocusedView = collectionView.view(at: indexPath.item)
+      #endif
     }
 
     return context.nextFocusedView?.canBecomeFocused ?? false
@@ -169,7 +171,9 @@ extension Delegate: UITableViewDelegate {
     if let component = component, indexPath.item < component.model.items.count {
       component.focusDelegate?.focusedComponent = component
       component.focusDelegate?.focusedItemIndex = indexPath.item
+      #if os(tvOS)
       component.focusGuide.preferredFocusedView = tableView.view(at: indexPath.item)
+      #endif
     }
 
     return true


### PR DESCRIPTION
This adds a focus guide to `Component`, by enabling the focus guide,
the component can remember the last focus view when navigating between
interfaces that are built using multiple components. It also opens up
for setting the preferred focused view for an individual component. The
focus guide is disabled by default.