### PR TITLE
Implement support for custom models on ComponentModel's

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -312,7 +312,7 @@ public class SpotsControllerManager {
 
       for (index, change) in changes.enumerated() {
         switch change {
-        case .identifier, .kind, .layout, .meta:
+        case .identifier, .kind, .layout, .meta, .model:
           strongSelf.replaceComponent(atIndex: index, controller: controller, newComponentModels: newComponentModels)
         case .new:
           strongSelf.newComponent(atIndex: index, controller: controller, newComponentModels: newComponentModels)

--- a/Sources/Shared/Enums/ComponentModelDiff.swift
+++ b/Sources/Shared/Enums/ComponentModelDiff.swift
@@ -11,5 +11,5 @@
 /// - removed:    Indicates that the component was removed
 /// - none:       Indicates that nothing did change
 public enum ComponentModelDiff {
-  case identifier, kind, layout, header, footer, meta, items, new, removed, none
+  case identifier, kind, layout, header, footer, meta, model, items, new, removed, none
 }

--- a/Sources/Shared/Extensions/Codable+Extensions.swift
+++ b/Sources/Shared/Extensions/Codable+Extensions.swift
@@ -127,6 +127,13 @@ extension KeyedDecodingContainer {
     }
     return try coder.decode(from: self, forKey: key)
   }
+
+  func decodeIfPresentWithModelCoder(forKey key: K) throws -> ItemCodable? {
+    guard let coder = Configuration.shared.modelCoder else {
+      return nil
+    }
+    return try coder.decode(from: self, forKey: key)
+  }
 }
 
 // MARK: - KeyedEncodingContainer
@@ -138,10 +145,18 @@ extension KeyedEncodingContainer {
     }
   }
 
-  mutating func encodeIfPresent(model: ItemCodable?,
+  mutating func encodeIfPresent(model: ComponentModelCodable?,
                                 forKey key: KeyedEncodingContainer.Key,
                                 kind: String) throws {
     guard let model = model, let coder = Configuration.shared.coders[kind] else {
+      return
+    }
+    try coder.encode(model: model, forKey: key, container: &self)
+  }
+
+  mutating func encodeIfPresentWithModel(_ model: ComponentModelCodable?,
+                                         forKey key: KeyedEncodingContainer.Key) throws {
+    guard let model = model, let coder = Configuration.shared.modelCoder else {
       return
     }
     try coder.encode(model: model, forKey: key, container: &self)

--- a/Sources/Shared/Protocols/ItemModel.swift
+++ b/Sources/Shared/Protocols/ItemModel.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+public typealias ComponentModelCodable = ItemCodable
+public typealias ComponentSubModel = ItemModel
+
 public protocol ItemCodable: Codable {
   func equal(to rhs: ItemCodable) -> Bool
 }

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -37,6 +37,7 @@ public class Configuration {
   public var views: Registry = .init()
   var presenters: [String: AnyPresenter] = .init()
   var coders: [String: AnyItemModelCoder] = .init()
+  var modelCoder: AnyItemModelCoder?
 
   /// Register a nib file with identifier on the component.
   ///
@@ -69,5 +70,9 @@ public class Configuration {
   /// - parameter view: The view type that should be used as the default view
   public func registerDefault(view: View.Type) {
     views.defaultItem = Registry.Item.classType(view)
+  }
+
+  public func registerComponentModel<T: ComponentSubModel>(_ model: T.Type) {
+    modelCoder = ItemModelCoder<T>()
   }
 }


### PR DESCRIPTION
This commit adds support for custom models on `ComponentModel`. 
It reuses the same implementation that we use for custom models on Item's.