### PR TITLE
Add a generic initializer for ComponentModel

### DIFF
--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -78,6 +78,38 @@ public struct ComponentModel: Codable, Equatable {
     self.meta = meta
   }
 
+  /// Initializes a component and configures it with the provided parameters
+  ///
+  /// - parameter identifier: A optional string.
+  /// - parameter header: Determines which header item that should be used for the model.
+  /// - parameter kind: The type of ComponentModel that should be used.
+  /// - parameter layout: Configures the layout properties for the model.
+  /// - parameter interaction: Configures the interaction properties for the model.
+  /// - parameter span: Configures the layout span for the model.
+  /// - parameter model: A generic component model that conforms to `ComponentSubModel`.
+  /// - parameter items: A collection of view models
+  ///
+  /// - returns: An initialized component
+  public init<T: ComponentSubModel>(identifier: String? = nil,
+                                    header: Item? = nil,
+                                    footer: Item? = nil,
+                                    kind: ComponentKind = Configuration.shared.defaultComponentKind,
+                                    layout: Layout = Layout(),
+                                    interaction: Interaction = .init(),
+                                    items: [Item] = [],
+                                    model: T? = nil,
+                                    meta: [String : Any] = [:]) {
+    self.init(identifier: identifier,
+              header: header,
+              footer: footer,
+              kind: kind,
+              layout: layout,
+              interaction: interaction,
+              items: items,
+              meta: meta)
+    self.model = model
+  }
+
   // MARK: - Codable
 
   /// Initialize with a decoder.

--- a/Sources/Shared/Structs/ComponentModel.swift
+++ b/Sources/Shared/Structs/ComponentModel.swift
@@ -96,8 +96,8 @@ public struct ComponentModel: Codable, Equatable {
                                     kind: ComponentKind = Configuration.shared.defaultComponentKind,
                                     layout: Layout = Layout(),
                                     interaction: Interaction = .init(),
-                                    items: [Item] = [],
                                     model: T? = nil,
+                                    items: [Item] = [],
                                     meta: [String : Any] = [:]) {
     self.init(identifier: identifier,
               header: header,

--- a/SpotsTests/Shared/ComponentModelTests.swift
+++ b/SpotsTests/Shared/ComponentModelTests.swift
@@ -49,9 +49,9 @@ class ComponentModelTests: XCTestCase {
     var codeComponentModel = ComponentModel(
       kind: ComponentKind(rawValue: json["kind"] as! String)!,
       layout: layout,
+      model: Model(version: "2.0.1"),
       items: [item],
       meta: json["meta"] as! [String : String])
-    codeComponentModel.update(model: Model(version: "2.0.1"))
 
     XCTAssertEqual(codeComponentModel.kind.rawValue, json["kind"] as? String)
     XCTAssertEqual(codeComponentModel.layout.span, (json["layout"] as? [String : Any])?["span"] as? Double)
@@ -62,6 +62,10 @@ class ComponentModelTests: XCTestCase {
 
     // Compare JSON and programmatically created component
     XCTAssert(jsonComponentModel == codeComponentModel)
+
+    // Verify that the model updates
+    codeComponentModel.update(model: Model(version: "2.0.2"))
+    XCTAssert(codeComponentModel.resolveModel() == Model(version: "2.0.2"))
   }
 
   func testConfifugrationDefaultKind() {


### PR DESCRIPTION
Minor code change, it adds a generic initializer for `ComponentModel` so that you get the opportunity to add the model directly without having the model be mutable.