### PR TITLE
Feature/built in injection support

### DIFF
--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -2,6 +2,14 @@
 public protocol UserInterface: class {
   var visibleViews: [View] { get }
 
+  /// Reload visible views with animation and completion.
+  ///
+  /// - Parameters:
+  ///   - animation: The animation that should be used for reloading.
+  ///   - completion: A completion closure that is invoked when the update
+  ///                 is completed.
+  func reloadVisibleViews(with animation: Animation, completion: Completion)
+
   #if !os(OSX)
   /// The index of the current selected item
   @available(iOS 9.0, *)

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -116,12 +116,19 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     self.componentDelegate = Delegate(component: self, with: configuration)
 
     #if os(tvOS)
-    view.addLayoutGuide(focusGuide)
-    focusGuide.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-    focusGuide.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
-    focusGuide.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-    focusGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-    focusGuide.isEnabled = false
+      view.addLayoutGuide(focusGuide)
+      focusGuide.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+      focusGuide.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+      focusGuide.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+      focusGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+      focusGuide.isEnabled = false
+    #endif
+
+    #if DEBUG
+      NotificationCenter.default.addObserver(self,
+                                             selector: #selector(didInject),
+                                             name: NSNotification.Name(rawValue: "INJECTION_BUNDLE_NOTIFICATION"),
+                                             object: nil)
     #endif
   }
 
@@ -151,6 +158,12 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   deinit {
     componentDataSource = nil
     componentDelegate = nil
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  @objc private func didInject() {
+    userInterface?.register(with: configuration)
+    userInterface?.reloadVisibleViews(with: .none, completion: nil)
   }
 
   /// Setup up the component with a given size, this is usually the parent size when used in a controller context.
@@ -344,3 +357,4 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     view.superview?.layoutIfNeeded()
   }
 }
+

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -1,6 +1,11 @@
 import UIKit
 
 extension UICollectionView: UserInterface {
+  public func reloadVisibleViews(with animation: Animation = .none, completion: Completion) {
+    let indexes = indexPathsForVisibleItems.map { $0.item }
+    reload(indexes, withAnimation: animation, completion: completion)
+  }
+
   public func register(with configuration: Configuration) {
     if configuration.views.defaultItem == nil {
       register(GridWrapper.self, forCellWithReuseIdentifier: configuration.views.defaultIdentifier)

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -1,6 +1,10 @@
 import UIKit
 
 extension UITableView: UserInterface {
+  public func reloadVisibleViews(with animation: Animation = .none, completion: Completion) {
+    let indexes = indexPathsForVisibleRows?.map { $0.item } ?? []
+    reload(indexes, withAnimation: animation, completion: completion)
+  }
 
   public func register(with configuration: Configuration) {
     if configuration.views.defaultItem == nil {

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -139,6 +139,13 @@ import Cocoa
 
     self.componentDataSource = DataSource(component: self, with: configuration)
     self.componentDelegate = Delegate(component: self, with: configuration)
+
+    #if DEBUG
+      NotificationCenter.default.addObserver(self,
+                                             selector: #selector(didInject),
+                                             name: NSNotification.Name(rawValue: "INJECTION_BUNDLE_NOTIFICATION"),
+                                             object: nil)
+    #endif
   }
 
   /// A convenience init for creating a component with a `ComponentModel`.
@@ -178,6 +185,12 @@ import Cocoa
     componentDataSource = nil
     componentDelegate = nil
     userInterface = nil
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  @objc private func didInject() {
+    userInterface?.register(with: configuration)
+    userInterface?.reloadVisibleViews(with: .none, completion: nil)
   }
 
   /// Configure user interface data source and delegate.

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -1,6 +1,11 @@
 import Cocoa
 
 extension NSCollectionView: UserInterface {
+  public func reloadVisibleViews(with animation: Animation, completion: Completion) {
+    let indexes = indexPathsForVisibleItems().map { $0.item }
+    reload(indexes, withAnimation: animation, completion: completion)
+  }
+
   public var visibleViews: [View] {
     var views = [View]()
 

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -1,6 +1,14 @@
 import Cocoa
 
 extension NSTableView: UserInterface {
+  public func reloadVisibleViews(with animation: Animation, completion: Completion) {
+    let rows = self.rows(in: visibleRect)
+    var indexes = [Int]()
+    for row in rows.location..<rows.length-rows.location {
+      indexes.append(row)
+    }
+    reload(indexes, withAnimation: animation, completion: completion)
+  }
 
   public var visibleViews: [View] {
     let rows = self.rows(in: visibleRect)


### PR DESCRIPTION
This PR does two things, it adds a new feature for user interfaces to reload the visible views that are on screen. User interfaces are used on `Component`.

It also adds built-in support for Injection (https://github.com/johnno1962/InjectionIII).
If Spots is built with `DEBUG` enabled, then all component will register for notifications that is posted when injection happens. This enables you to get React Native-esque reloading behavior when building/experimenting with view layouts.