### PR TITLE
Add needsLayout to setup() & layout() methods on Component

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -719,7 +719,7 @@ public class SpotsControllerManager {
     }
 
     let tempComponent = Component(model: model, configuration: controller.configuration)
-    tempComponent.setup(with: setupSize)
+    tempComponent.setup(with: setupSize, needsLayout: false)
     tempComponent.model.size = CGSize(
       width: controller.view.frame.width,
       height: ceil(tempComponent.view.frame.height))

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -169,7 +169,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// Setup up the component with a given size, this is usually the parent size when used in a controller context.
   ///
   /// - Parameter size: A `CGSize` that is used to set the frame of the user interface.
-  public func setup(with size: CGSize) {
+  public func setup(with size: CGSize, needsLayout: Bool = true) {
     view.frame.size = size
 
     setupFooter(with: configuration)
@@ -181,7 +181,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       setupCollectionView(collectionView, with: size)
     }
 
-    layout(with: size)
+    layout(with: size, needsLayout: needsLayout)
     configurePageControl()
     Component.configure?(self)
 
@@ -194,7 +194,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// Configure the view frame with a given size.
   ///
   /// - Parameter size: A `CGSize` used to set a new size to the user interface.
-  public func layout(with size: CGSize) {
+  public func layout(with size: CGSize, needsLayout: Bool = true) {
     if let tableView = self.tableView {
       layoutTableView(tableView, with: size)
     } else if let collectionView = self.collectionView {
@@ -202,7 +202,13 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     layoutHeaderFooterViews(size)
+
+    guard needsLayout else {
+      return
+    }
+
     view.setNeedsLayout()
+
     // Only call `layoutIfNeeded` if the `Component` is not a part of a `SpotsController`.
     if let spotsScrollView = (focusDelegate as? SpotsController)?.scrollView {
       let isVisibleOnScreen = view.frame.intersects(.init(origin: spotsScrollView.contentOffset,
@@ -357,4 +363,3 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     view.superview?.layoutIfNeeded()
   }
 }
-

--- a/Sources/macOS/Classes/Component.swift
+++ b/Sources/macOS/Classes/Component.swift
@@ -207,7 +207,7 @@ import Cocoa
   /// Setup up the component with a given size, this is usually the parent size when used in a controller context.
   ///
   /// - Parameter size: A `CGSize` that is used to set the frame of the user interface.
-  public func setup(with size: CGSize) {
+  public func setup(with size: CGSize, needsLayout: Bool = false) {
     scrollView.frame.size = size
 
     setupHeader(with: configuration)
@@ -221,7 +221,7 @@ import Cocoa
       setupCollectionView(collectionView, with: size)
     }
 
-    layout(with: size, animated: false)
+    layout(with: size, needsLayout: needsLayout, animated: false)
     Component.configure?(self)
   }
 
@@ -230,7 +230,7 @@ import Cocoa
   /// - Parameter size: A `CGSize` used to set a new size to the user interface.
   /// - Parameter animated: Determines if the `Component` should perform animation when
   ///                       applying its new size.
-  public func layout(with size: CGSize, animated: Bool = true) {
+  public func layout(with size: CGSize, needsLayout: Bool = false, animated: Bool = true) {
     userInterface?.layoutIfNeeded()
 
     if let tableView = self.tableView {
@@ -254,6 +254,13 @@ import Cocoa
         view.superview?.layoutSubviews()
       }
     }
+
+    guard needsLayout else {
+      return
+    }
+
+    view.needsLayout = true
+    view.layoutIfNeeded()
   }
 
   /// Setup a collection view with a specific size.


### PR DESCRIPTION
This improves performance when reloading large collections as the temporary component no longer call `setNeedsLayout()` and `layoutIfNeeded()`. The temporary components that are used for
comparing and collecting differences between the new and old payload don't need to be rendered on screen which leads to a huge performance improvement when working with larger collection of components. Before this could cause a bit of UI stutter as the `Component` needs to be
prepared in the main queue. The UI stutter would happen if there are no changes to the new and old collection.

To achieve this optimization, we simply add another variable to the `setup` and `layout` signature, telling the component what to do. If `needsLayout` is set to `true` (which is the default) then it would do the normal expected behavior. Internally when crafting temporary components it will be set to `false` in `SpotsControllerManager`.

This is a non-breaking change as it has a default value.