### PR TITLE
Feature/support for collection view titles

### DIFF
--- a/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // MARK: - ComponentDelegate extension
 public extension ComponentDelegate {
   /// Triggered when ever a user taps on an item
@@ -11,7 +13,7 @@ public extension ComponentDelegate {
   /// - parameter components: The collection of new components.
   func componentsDidChange(_ components: [Component]) {}
 
-  #if !os(macOS)
+  #if os(tvOS)
   func componentIndexTitles(_ component: Component) -> [String]? {
     return nil
   }

--- a/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
@@ -14,10 +14,22 @@ public extension ComponentDelegate {
   func componentsDidChange(_ components: [Component]) {}
 
   #if os(tvOS)
+  /// A collection of strings that represent the contents of your component.
+  ///
+  /// - Parameter component: The component that owns the collection of strings.
+  /// - Returns: A collection of strings used for accelerated scrolling indexing.
   func componentIndexTitles(_ component: Component) -> [String]? {
     return nil
   }
 
+  /// The index path of the current indexed string.
+  ///
+  /// - Parameters:
+  ///   - component: The component that owns the items.
+  ///   - item: The item that is located at the index.
+  ///   - index: The index of the current item.
+  ///   - title: The title that the item is matched against.
+  /// - Returns: The index path used for focusing when using accelerated scrolling.
   func componentIndexPath(_ component: Component, item: Item, at index: Int, for title: String) -> IndexPath {
     return IndexPath(item: index, section: 0)
   }

--- a/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
+++ b/Sources/Shared/Extensions/ComponentDelegate+Extensions.swift
@@ -11,6 +11,16 @@ public extension ComponentDelegate {
   /// - parameter components: The collection of new components.
   func componentsDidChange(_ components: [Component]) {}
 
+  #if !os(macOS)
+  func componentIndexTitles(_ component: Component) -> [String]? {
+    return nil
+  }
+
+  func componentIndexPath(_ component: Component, item: Item, at index: Int, for title: String) -> IndexPath {
+    return IndexPath(item: index, section: 0)
+  }
+  #endif
+
   /// A delegate method that is triggered when ever a view is going to be displayed.
   ///
   /// - parameter component: The component that will display the view.

--- a/Sources/Shared/Protocols/ComponentDelegate.swift
+++ b/Sources/Shared/Protocols/ComponentDelegate.swift
@@ -12,6 +12,12 @@ public protocol ComponentDelegate: class {
   /// - parameter components: New collection of components.
   func componentsDidChange(_ components: [Component])
 
+  #if !os(macOS)
+  func componentIndexTitles(_ component: Component) -> [String]?
+
+  func componentIndexPath(_ component: Component, item: Item, at index: Int, for title: String) -> IndexPath
+  #endif
+
   /// A delegate method that is triggered when ever a view is going to be displayed.
   ///
   /// - parameter component: The component that will display the item.

--- a/Sources/Shared/Protocols/ComponentDelegate.swift
+++ b/Sources/Shared/Protocols/ComponentDelegate.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A generic delegate for Spots
 public protocol ComponentDelegate: class {
 
@@ -12,7 +14,7 @@ public protocol ComponentDelegate: class {
   /// - parameter components: New collection of components.
   func componentsDidChange(_ components: [Component])
 
-  #if !os(macOS)
+  #if os(tvOS)
   func componentIndexTitles(_ component: Component) -> [String]?
 
   func componentIndexPath(_ component: Component, item: Item, at index: Int, for title: String) -> IndexPath

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -80,6 +80,7 @@ extension DataSource: UICollectionViewDataSource {
     return cell
   }
 
+  #if os(tvOS)
   public func indexTitles(for collectionView: UICollectionView) -> [String]? {
     guard let component = component else {
       return nil
@@ -96,6 +97,7 @@ extension DataSource: UICollectionViewDataSource {
 
     return indexPath
   }
+  #endif
 }
 
 extension DataSource: UITableViewDataSource {

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -79,6 +79,23 @@ extension DataSource: UICollectionViewDataSource {
 
     return cell
   }
+
+  public func indexTitles(for collectionView: UICollectionView) -> [String]? {
+    guard let component = component else {
+      return nil
+    }
+    return component.delegate?.componentIndexTitles(component)
+  }
+
+  public func collectionView(_ collectionView: UICollectionView, indexPathForIndexTitle title: String, at index: Int) -> IndexPath {
+    guard let component = component,
+      let item = component.item(at: index),
+      let indexPath = component.delegate?.componentIndexPath(component, item: item, at: index, for: title) else {
+        return IndexPath(item: index, section: 0)
+    }
+
+    return indexPath
+  }
 }
 
 extension DataSource: UITableViewDataSource {


### PR DESCRIPTION
This PR adds support for title indexes for collection views on `tvOS`.
To get this behavior you need to implement two methods in your component delegate.

```swift
// An array of all the titles that should be displayed.
func componentIndexTitles(_ component: Component) -> [String]?

// The index path for the title when it gain focus, it tells the collection view where to navigate.
// This should be the first index path of the first item that matches the letter if you index your
// list via the first letter of your items.
func componentIndexPath(_ component: Component, item: Item, at index: Int, for title: String) -> IndexPath
```

**Note**: This feature is scope to tvOS but can be made available for `iOS`.

Extract from the docs for both new methods.
```
Availability

iOS 10.3+
tvOS 10.2+
```

## Screenshot

![simulator screen shot - apple tv 4k at 1080p - 2017-12-27 at 16 06 44](https://user-images.githubusercontent.com/57446/34410687-4898a784-ebd2-11e7-97c2-9f8a9e4d2b60.png)