### PR TITLE
Improve/internal performance

### DIFF
--- a/Sources/Shared/Classes/ComponentManager.swift
+++ b/Sources/Shared/Classes/ComponentManager.swift
@@ -454,6 +454,20 @@ public class ComponentManager {
       return
     }
 
+    var notVisibleUpdates = updates
+    var updates = updates
+
+    if let visibleIndexes = component.userInterface?.visibleIndexes {
+      notVisibleUpdates = updates.filter { !visibleIndexes.contains($0) }
+      updates = updates.filter { visibleIndexes.contains($0) }
+      reload(indexes: notVisibleUpdates,
+             component: component,
+             withAnimation: animation,
+             completion: updates.isEmpty
+              ? completion
+              : nil)
+    }
+
     let lastUpdate = updates.last
     for index in updates {
       guard let item = component.item(at: index) else {

--- a/Sources/Shared/Protocols/UserInterface.swift
+++ b/Sources/Shared/Protocols/UserInterface.swift
@@ -1,6 +1,7 @@
 ///// A protocol used for composition inside components.
 public protocol UserInterface: class {
   var visibleViews: [View] { get }
+  var visibleIndexes: [Int] { get }
 
   /// Reload visible views with animation and completion.
   ///

--- a/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UICollectionView+UserInterface.swift
@@ -1,9 +1,12 @@
 import UIKit
 
 extension UICollectionView: UserInterface {
+  public var visibleIndexes: [Int] {
+    return indexPathsForVisibleItems.map { $0.item }
+  }
+
   public func reloadVisibleViews(with animation: Animation = .none, completion: Completion) {
-    let indexes = indexPathsForVisibleItems.map { $0.item }
-    reload(indexes, withAnimation: animation, completion: completion)
+    reload(visibleIndexes, withAnimation: animation, completion: completion)
   }
 
   public func register(with configuration: Configuration) {
@@ -156,6 +159,7 @@ extension UICollectionView: UserInterface {
   ///  - parameter section: The section you want to update
   ///  - parameter completion: A completion block for when the updates are done
   public func reload(_ indexes: [Int], withAnimation animation: Animation = .automatic, completion: (() -> Void)? = nil) {
+    Swift.print("\(#function)")
     applyAnimation(animation: animation)
     let indexPaths = indexes.map { IndexPath(item: $0, section: 0) }
 

--- a/Sources/iOS/Extensions/UITableView+UserInterface.swift
+++ b/Sources/iOS/Extensions/UITableView+UserInterface.swift
@@ -1,9 +1,12 @@
 import UIKit
 
 extension UITableView: UserInterface {
+  public var visibleIndexes: [Int] {
+    return indexPathsForVisibleRows?.map { $0.item } ?? []
+  }
+
   public func reloadVisibleViews(with animation: Animation = .none, completion: Completion) {
-    let indexes = indexPathsForVisibleRows?.map { $0.item } ?? []
-    reload(indexes, withAnimation: animation, completion: completion)
+    reload(visibleIndexes, withAnimation: animation, completion: completion)
   }
 
   public func register(with configuration: Configuration) {

--- a/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+UserInterface.swift
@@ -1,9 +1,12 @@
 import Cocoa
 
 extension NSCollectionView: UserInterface {
+  public var visibleIndexes: [Int] {
+    return indexPathsForVisibleItems().map { $0.item }
+  }
+
   public func reloadVisibleViews(with animation: Animation, completion: Completion) {
-    let indexes = indexPathsForVisibleItems().map { $0.item }
-    reload(indexes, withAnimation: animation, completion: completion)
+    reload(visibleIndexes, withAnimation: animation, completion: completion)
   }
 
   public var visibleViews: [View] {

--- a/Sources/macOS/Extensions/NSTableView+UserInterface.swift
+++ b/Sources/macOS/Extensions/NSTableView+UserInterface.swift
@@ -1,13 +1,18 @@
 import Cocoa
 
 extension NSTableView: UserInterface {
-  public func reloadVisibleViews(with animation: Animation, completion: Completion) {
+  public var visibleIndexes: [Int] {
     let rows = self.rows(in: visibleRect)
     var indexes = [Int]()
     for row in rows.location..<rows.length-rows.location {
       indexes.append(row)
     }
-    reload(indexes, withAnimation: animation, completion: completion)
+
+    return indexes
+  }
+
+  public func reloadVisibleViews(with animation: Animation, completion: Completion) {
+    reload(visibleIndexes, withAnimation: animation, completion: completion)
   }
 
   public var visibleViews: [View] {

--- a/SpotsTests/Shared/UserInterfaceTests.swift
+++ b/SpotsTests/Shared/UserInterfaceTests.swift
@@ -62,4 +62,44 @@ class UserInterfaceTests: XCTestCase {
     // Expect two views to be visible on screen because the x offset is half of a view.
     XCTAssertEqual(component.userInterface?.visibleViews.count, 2)
   }
+
+  func testVisibleIndexesForGridComponent() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let layout = Layout(span: 1)
+    let model = ComponentModel(kind: .carousel, layout: layout, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 1)
+
+    component.view.contentOffset.x = 50
+    // If we don't call layoutIfNeeded, then `visibleCells` won't update correctly.
+    component.collectionView?.layoutIfNeeded()
+
+    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+  }
+
+  func testVisibleIndexesForListComponent() {
+    let items = [
+      Item(title: "foo"),
+      Item(title: "bar"),
+      Item(title: "baz")
+    ]
+    let layout = Layout(span: 1)
+    let model = ComponentModel(kind: .list, layout: layout, items: items)
+    let component = Component(model: model)
+    component.setup(with: CGSize(width: 100, height: 100))
+
+    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+
+    component.view.contentOffset.y = 50
+    // If we don't call layoutIfNeeded, then `visibleCells` won't update correctly.
+    component.tableView?.layoutIfNeeded()
+
+    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+  }
 }

--- a/SpotsTests/Shared/UserInterfaceTests.swift
+++ b/SpotsTests/Shared/UserInterfaceTests.swift
@@ -80,7 +80,11 @@ class UserInterfaceTests: XCTestCase {
     // If we don't call layoutIfNeeded, then `visibleCells` won't update correctly.
     component.collectionView?.layoutIfNeeded()
 
-    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+    #if os(macOS)
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+    #else
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+    #endif
   }
 
   func testVisibleIndexesForListComponent() {
@@ -94,12 +98,26 @@ class UserInterfaceTests: XCTestCase {
     let component = Component(model: model)
     component.setup(with: CGSize(width: 100, height: 100))
 
-    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+    #if os(tvOS)
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+    #else
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+    #endif
 
     component.view.contentOffset.y = 50
     // If we don't call layoutIfNeeded, then `visibleCells` won't update correctly.
     component.tableView?.layoutIfNeeded()
 
-    XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+    #if os(macOS)
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+    #endif
+
+    #if os(tvOS)
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 3)
+    #endif
+
+    #if os(iOS)
+      XCTAssertEqual(component.userInterface?.visibleIndexes.count, 2)
+    #endif
   }
 }


### PR DESCRIPTION
Now it will only use `update` on visible views, this reduces the stress
on the user interface as all updates that are not visible on screen
will now be updated in bulk using the `reload` method.

This builds on https://github.com/hyperoslo/Spots/pull/786