### PR TITLE
Set focused item index to zero if index is nil when updating the delegates

### DIFF
--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -374,8 +374,9 @@ extension SpotsController {
       $0.focusDelegate = self
     }
 
-    if focusedComponent == nil {
+    if focusedComponent == nil && focusedItemIndex == nil {
       focusedComponent = components.first
+      focusedItemIndex = 0
     }
   }
 

--- a/Spots.podspec
+++ b/Spots.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Spots"
   s.summary          = "A cross-platform view controller framework for building component-based UIs"
-  s.version          = "7.4.1"
+  s.version          = "7.4.2"
   s.homepage         = "https://github.com/hyperoslo/Spots"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }


### PR DESCRIPTION
This fixes an issue that a user cannot resolve the current item at the index path when the view initially loads because it has yet to receive its initial index. The first component will be returned but if the index is zero you end up without a view.

To fix this, we simply set the index to zero but only if neither the component of item has been set.
This should comply nicely with the focus engine because it searches from the top left corner for the first view to focus.

**Note**
I bumped the version because I intend to do a minor release as soon as this has been merge into `master`.