### PR TITLE
Floor width to only rely on whole numbers

### DIFF
--- a/Sources/Shared/Classes/ItemManager.swift
+++ b/Sources/Shared/Classes/ItemManager.swift
@@ -260,6 +260,7 @@ public class ItemManager {
     #endif
 
     size.height = fmax(size.height, 0)
+    size.width = floor(size.width)
 
     return size
   }


### PR DESCRIPTION
This improves the rendering of views, now it will `floor` the width value before giving it to the collection view. That way it won't try to render widths that have decimals. I went with `floor` to make sure that all views would fit on screen. If we do `round` or `ceil` we could risk that the collection view layout would throw exceptions because the views don't fit on screen.