### PR TITLE
Feature focused view and refactor focus delegate implementation

### DIFF
--- a/Sources/Shared/Protocols/ComponentFocusDelegate.swift
+++ b/Sources/Shared/Protocols/ComponentFocusDelegate.swift
@@ -1,4 +1,5 @@
 public protocol ComponentFocusDelegate: class {
   var focusedComponent: Component? { get set }
   var focusedItemIndex: Int? { get set }
+  var focusedView: View? { get set }
 }

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -7,8 +7,10 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
     return view
   }
 
-  public weak var focusedComponent: Component?
   public var focusedItemIndex: Int?
+  /// The instance of the current focused component.
+  /// This property is observable using Key-value observing.
+  @objc dynamic public weak var focusedComponent: Component?
   /// The view instance of the current focused view.
   /// This property is observable using Key-value observing.
   @objc dynamic public weak var focusedView: View?

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -9,6 +9,9 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
 
   public weak var focusedComponent: Component?
   public var focusedItemIndex: Int?
+  /// The view instance of the current focused view.
+  /// This property is observable using Key-value observing.
+  @objc dynamic public weak var focusedView: View?
 
   /// A closure that is called when the controller is reloaded with components
   public static var componentsDidReloadComponentModels: ((SpotsController) -> Void)?

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -373,7 +373,7 @@ extension SpotsController {
   }
 
   /// It updates the delegates for all underlaying components inside the controller.
-  fileprivate  func updateDelegates() {
+  fileprivate func updateDelegates() {
     components.forEach {
       $0.delegate = delegate
       $0.focusDelegate = self

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		BD45D9951E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
 		BD45D9961E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
 		BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
+		BD4F05AB1FFD5AE5009528BB /* ComponentFocusDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4F05A91FFD5AE5009528BB /* ComponentFocusDelegateTests.swift */; };
 		BD5500FE1F93950D0075CC4E /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */; };
 		BD5500FF1F93950D0075CC4E /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */; };
 		BD5501001F93950D0075CC4E /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */; };
@@ -477,6 +478,7 @@
 		BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetTests.swift; sourceTree = "<group>"; };
 		BD45D9981E30B0F700C2D6B2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BD45D9991E30B0F700C2D6B2 /* Spots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Spots.podspec; sourceTree = "<group>"; };
+		BD4F05A91FFD5AE5009528BB /* ComponentFocusDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentFocusDelegateTests.swift; sourceTree = "<group>"; };
 		BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensionsTests.swift; sourceTree = "<group>"; };
 		BD5CF7361E8B7C57006CC281 /* ComponentResize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentResize.swift; sourceTree = "<group>"; };
 		BD5D69D31F398C370078AC19 /* Changes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Changes.swift; sourceTree = "<group>"; };
@@ -1120,6 +1122,7 @@
 				BDCFCD401DCA7EFF0047E84C /* SpotsControllerTests.swift */,
 				BD677E881DC61EFC006D1654 /* StateCacheTests.swift */,
 				BDCA3CF21E8295EB00A98A76 /* UserInterfaceTests.swift */,
+				BD4F05A91FFD5AE5009528BB /* ComponentFocusDelegateTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1607,6 +1610,7 @@
 				BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */,
 				BD30491F1F041C7E00D9EECB /* MoveAlgorithmTests.swift in Sources */,
 				BD31BB9F1EA6209E00D1FC8A /* DelegateConfigurationClosureTests.swift in Sources */,
+				BD4F05AB1FFD5AE5009528BB /* ComponentFocusDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SpotsTests/Shared/ComponentFocusDelegateTests.swift
+++ b/SpotsTests/Shared/ComponentFocusDelegateTests.swift
@@ -1,0 +1,64 @@
+@testable import Spots
+import XCTest
+
+class ComponentFocusDelegateTests: XCTestCase {
+  class CollectionViewFocusUpdateContextMock: UICollectionViewFocusUpdateContext {
+    override var nextFocusedIndexPath: IndexPath? {
+      return IndexPath(item: 0, section: 0)
+    }
+  }
+
+  class TableViewFocusUpdateContextMock: UITableViewFocusUpdateContext {
+    override var nextFocusedIndexPath: IndexPath? {
+      return IndexPath(row: 0, section: 0)
+    }
+  }
+
+  func testFocusedDelegatePropertiesOnCollectionView() {
+    let collectionViewContextMock = CollectionViewFocusUpdateContextMock()
+    let (component, controller) = createComponentWithController(ofKind: .grid)
+
+    guard let collectionView = component.collectionView else {
+      XCTFail("Could not resolve .collectionView")
+      return
+    }
+
+    // Trigger a focus update using the mocked context.
+    let _ = collectionView.delegate?.collectionView!(collectionView,
+                                                     shouldUpdateFocusIn: collectionViewContextMock)
+
+    let firstView = component.userInterface?.view(at: 0)
+    XCTAssertNotNil(firstView)
+    XCTAssertEqual(controller.focusedComponent, component)
+    XCTAssertEqual(controller.focusedView, firstView)
+    XCTAssertEqual(controller.focusedItemIndex, 0)
+  }
+
+  func testFocusedDelegatePropertiesOnTableView() {
+    let tableViewContextMock = TableViewFocusUpdateContextMock()
+    let (component, controller) = createComponentWithController(ofKind: .list)
+
+    guard let tableView = component.tableView else {
+      XCTFail("Could not resolve .tableView")
+      return
+    }
+
+    // Trigger a focus update using the mocked context.
+    let _ = tableView.delegate?.tableView!(tableView, shouldUpdateFocusIn: tableViewContextMock)
+
+    let firstView = component.userInterface?.view(at: 0)
+    XCTAssertNotNil(firstView)
+    XCTAssertEqual(controller.focusedComponent, component)
+    XCTAssertEqual(controller.focusedView, firstView)
+    XCTAssertEqual(controller.focusedItemIndex, 0)
+  }
+
+  private func createComponentWithController(ofKind kind: ComponentKind) -> (Component, SpotsController) {
+    let items = [Item(), Item()]
+    let model = ComponentModel(kind: kind, items: items)
+    let component = Component(model: model)
+    let controller = SpotsController(components: [component])
+    controller.prepareController()
+    return (component, controller)
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,15 @@ coverage:
   comment: "header diff changes sunburst"
   behavior: new
   ignore:
-  - Applications/Xcode.app/.*
-  - build/.*
-  - bin/.*
-  - Carthage/.*
-  - Examples/.*
-  - Images/.*
-  - Playgrounds/.*
-  - Spots/.*
-  - SpotsTests/.*
+  - "Applications/Xcode.app/.*"
+  - "build"
+  - "bin"
+  - "Carthage"
+  - "Examples"
+  - "Images"
+  - "Playgrounds"
+  - "Spots"
+  - "SpotsTests"
   status:
     patch:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,15 @@ coverage:
   comment: "header diff changes sunburst"
   behavior: new
   ignore:
-  - "Applications/Xcode.app/.*"
-  - "build"
-  - "bin"
-  - "Carthage"
-  - "Examples"
-  - "Images"
-  - "Playgrounds"
-  - "Spots"
-  - "SpotsTests"
+    - "Applications/Xcode.app/.*"
+    - "build"
+    - "bin"
+    - "Carthage"
+    - "Examples"
+    - "Images"
+    - "Playgrounds"
+    - "Spots"
+    - "SpotsTests"
   status:
     patch:
       default:


### PR DESCRIPTION
This PR is all about the focus delegate.

The focus delegate now has a new property `.focusedView`. 
This is the view that is currently in focus, it is optional because there might not be any views selected.
`SpotsController` has also been slightly changed, the `ComponentFocusDelegate` properties `.focusedComponent` and `.focusedView` are now `dynamic` so that you can easily observe them using key value observing.

### Example

```swift
observer = spotsController.observe(\.focusedView, options: [.new]) { (controller, value) in
    guard let view = value.newValue else {
        return
    }

    // Do something with the view.
}
```

The delegate methods related to focus updates on `Component` has also been improved and should be more reliable.