### PR TITLE
Improve/infinite scrolling on tvos

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ We would love you to contribute to **Spots**, check the [CONTRIBUTING](https://g
 
 ## Credits
 
+- Infinite scrolling on tvOS was greatly inspired by [willowtreeapps/ouroboros](https://github.com/willowtreeapps/ouroboros), if you haven't check it out. You should!
 - The idea behind Spot came from [John Sundell](https://github.com/johnsundell)'s tech talk "ComponentModels & View Models in the Cloud - how Spotify builds native, dynamic UIs".
 - [Ole Begemanns](https://github.com/ole/) implementation of [OLEContainerScrollView](https://github.com/ole/OLEContainerScrollView) is the basis for `SpotsScrollView`, we salute you.
 Reference: http://oleb.net/blog/2014/05/scrollviews-inside-scrollviews/

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -14,7 +14,7 @@ public class DataSource: NSObject, ComponentResolvable {
   /// about how to configure your views.
   let viewPreparer: ViewPreparer
   let configuration: Configuration
-  let indexPathManager: IndexPathManager!
+  let indexPathManager: IndexPathManager
   var buffer: Int = 2
 
   /// A computed value that holds the amount of items that the component model holds.

--- a/Sources/Shared/Classes/DataSource.swift
+++ b/Sources/Shared/Classes/DataSource.swift
@@ -14,6 +14,8 @@ public class DataSource: NSObject, ComponentResolvable {
   /// about how to configure your views.
   let viewPreparer: ViewPreparer
   let configuration: Configuration
+  let indexPathManager: IndexPathManager!
+  var buffer: Int = 2
 
   /// A computed value that holds the amount of items that the component model holds.
   var numberOfItems: Int {
@@ -30,6 +32,7 @@ public class DataSource: NSObject, ComponentResolvable {
   init(component: Component, with configuration: Configuration = .shared) {
     self.component = component
     self.configuration = configuration
+    self.indexPathManager = IndexPathManager(component: component)
     self.viewPreparer = ViewPreparer(configuration: configuration)
   }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -14,7 +14,7 @@ public class Delegate: NSObject, ComponentResolvable {
   /// about how to configure your views.
   let viewPreparer: ViewPreparer
   let configuration: Configuration
-  let indexPathManager: IndexPathManager!
+  let indexPathManager: IndexPathManager
 
   #if os(tvOS)
   /// A boolean value that indicates that the scrolling offset has reached

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -17,7 +17,7 @@ public class Delegate: NSObject, ComponentResolvable {
   let indexPathManager: IndexPathManager!
   var navigating: Bool = false
   var currentlyFocusedItem: Int = 0
-  var manualFocusCell: IndexPath = IndexPath(item: 0, section: 0)
+  var manualFocusedIndexPath: IndexPath = IndexPath(item: 0, section: 0)
 
   #if !os(macOS)
   /// The scroll view manager handles constraining horizontal components.

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -14,6 +14,10 @@ public class Delegate: NSObject, ComponentResolvable {
   /// about how to configure your views.
   let viewPreparer: ViewPreparer
   let configuration: Configuration
+  let indexPathManager: IndexPathManager!
+  var navigating: Bool = false
+  var currentlyFocusedItem: Int = 0
+  var manualFocusCell: IndexPath = IndexPath(item: 0, section: 0)
 
   #if !os(macOS)
   /// The scroll view manager handles constraining horizontal components.
@@ -29,6 +33,7 @@ public class Delegate: NSObject, ComponentResolvable {
   init(component: Component, with configuration: Configuration = .shared) {
     self.component = component
     self.configuration = configuration
+    self.indexPathManager = IndexPathManager(component: component)
     self.viewPreparer = ViewPreparer(configuration: configuration)
   }
 }

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -15,9 +15,17 @@ public class Delegate: NSObject, ComponentResolvable {
   let viewPreparer: ViewPreparer
   let configuration: Configuration
   let indexPathManager: IndexPathManager!
-  var navigating: Bool = false
+
+  #if os(tvOS)
+  /// A boolean value that indicates that the scrolling offset has reached
+  /// the added buffer when using infinite scrolling.
+  var hasReachedBuffer: Bool = false
+  /// The index of the focused item.
   var currentlyFocusedItem: Int = 0
+  /// A property used for navigating seamlessly with the focus engine on
+  /// tvOS when a component has infinite scrolling enabled.
   var manualFocusedIndexPath: IndexPath = IndexPath(item: 0, section: 0)
+  #endif
 
   #if !os(macOS)
   /// The scroll view manager handles constraining horizontal components.

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -20,8 +20,6 @@ public class Delegate: NSObject, ComponentResolvable {
   /// A boolean value that indicates that the scrolling offset has reached
   /// the added buffer when using infinite scrolling.
   var hasReachedBuffer: Bool = false
-  /// The index of the focused item.
-  var currentlyFocusedItem: Int = 0
   /// A property used for navigating seamlessly with the focus engine on
   /// tvOS when a component has infinite scrolling enabled.
   var manualFocusedIndexPath: IndexPath = IndexPath(item: 0, section: 0)

--- a/Sources/Shared/Classes/IndexPathManager.swift
+++ b/Sources/Shared/Classes/IndexPathManager.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-class IndexPathManager {
-  var component: Component
+final class IndexPathManager {
+  weak private var component: Component?
 
   init(component: Component) {
     self.component = component
   }
 
   func computeIndexPath(_ indexPath: IndexPath) -> IndexPath {
-    guard component.model.layout.infiniteScrolling else {
+    guard let component = component, component.model.layout.infiniteScrolling else {
       return indexPath
     }
 

--- a/Sources/Shared/Classes/IndexPathManager.swift
+++ b/Sources/Shared/Classes/IndexPathManager.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class IndexPathManager {
+  var component: Component
+
+  init(component: Component) {
+    self.component = component
+  }
+
+  func computeIndexPath(_ indexPath: IndexPath) -> IndexPath {
+    guard component.model.layout.infiniteScrolling else {
+      return indexPath
+    }
+
+    let buffer = component.componentDataSource?.buffer ?? 2
+    let count = component.model.items.count
+    let index = indexPath.item
+    let wrapped = (index - buffer < 0) ? (count + (index - buffer)) : (index - buffer)
+    let adjustedIndex = wrapped % count
+    return IndexPath(item: adjustedIndex, section: 0)
+  }
+}

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -190,7 +190,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       let attributes = collectionView!.layoutAttributesForItem(at: indexPath)!
       collectionView?.contentOffset.x = attributes.frame.minX
       componentDelegate?.manualFocusedIndexPath = indexPath
-      componentDelegate?.currentlyFocusedItem = indexPath.item
       if #available(iOS 9.0, *) {
         view.setNeedsFocusUpdate()
       }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -191,7 +191,9 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       collectionView?.contentOffset.x = attributes.frame.minX
       componentDelegate?.manualFocusCell = indexPath
       componentDelegate?.currentlyFocusedItem = indexPath.item
-      view.setNeedsFocusUpdate()
+      if #available(iOS 9.0, *) {
+        view.setNeedsFocusUpdate()
+      }
     }
   }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -186,13 +186,25 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     Component.configure?(self)
 
     if model.layout.infiniteScrolling {
-      let indexPath = IndexPath(item: 2, section: 0)
-      let attributes = collectionView!.layoutAttributesForItem(at: indexPath)!
-      collectionView?.contentOffset.x = attributes.frame.minX
-      componentDelegate?.manualFocusedIndexPath = indexPath
-      if #available(iOS 9.0, *) {
-        view.setNeedsFocusUpdate()
-      }
+      setupInfiniteScrolling()
+    }
+  }
+
+  private func setupInfiniteScrolling() {
+    guard let collectionView = collectionView,
+      let componentDataSource = componentDataSource else {
+        return
+    }
+
+    let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
+    guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
+      return
+    }
+
+    collectionView.contentOffset.x = attributes.frame.minX
+    componentDelegate?.manualFocusedIndexPath = indexPath
+    if #available(iOS 9.0, *) {
+      view.setNeedsFocusUpdate()
     }
   }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -186,8 +186,12 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     Component.configure?(self)
 
     if model.layout.infiniteScrolling {
-      let size = sizeForItem(at: IndexPath(item: 0, section: 0))
-      collectionView?.contentOffset.x = size.width + CGFloat(model.layout.itemSpacing)
+      let indexPath = IndexPath(item: 2, section: 0)
+      let attributes = collectionView!.layoutAttributesForItem(at: indexPath)!
+      collectionView?.contentOffset.x = attributes.frame.minX
+      componentDelegate?.manualFocusCell = indexPath
+      componentDelegate?.currentlyFocusedItem = indexPath.item
+      view.setNeedsFocusUpdate()
     }
   }
 
@@ -225,11 +229,13 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   /// It is used to invoke `handleInfiniteScrolling` when the users scrolls a horizontal
   /// `Component` with `infiniteScrolling` enabled.
   func layoutSubviews() {
+    #if os(iOS)
     guard model.kind == .carousel, model.layout.infiniteScrolling == true else {
       return
     }
 
     handleInfiniteScrolling()
+    #endif
   }
 
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.
@@ -258,7 +264,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     collectionView.layer.masksToBounds = false
 
     if #available(iOS 9.0, *) {
-      collectionView.remembersLastFocusedIndexPath = true
+      collectionView.remembersLastFocusedIndexPath = !model.layout.infiniteScrolling
     }
 
     guard model.kind == .carousel else {

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -189,7 +189,7 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       let indexPath = IndexPath(item: 2, section: 0)
       let attributes = collectionView!.layoutAttributesForItem(at: indexPath)!
       collectionView?.contentOffset.x = attributes.frame.minX
-      componentDelegate?.manualFocusCell = indexPath
+      componentDelegate?.manualFocusedIndexPath = indexPath
       componentDelegate?.currentlyFocusedItem = indexPath.item
       if #available(iOS 9.0, *) {
         view.setNeedsFocusUpdate()

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -185,27 +185,11 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     configurePageControl()
     Component.configure?(self)
 
+    #if os(tvOS)
     if model.layout.infiniteScrolling {
       setupInfiniteScrolling()
     }
-  }
-
-  private func setupInfiniteScrolling() {
-    guard let collectionView = collectionView,
-      let componentDataSource = componentDataSource else {
-        return
-    }
-
-    let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
-    guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
-      return
-    }
-
-    collectionView.contentOffset.x = attributes.frame.minX
-    componentDelegate?.manualFocusedIndexPath = indexPath
-    if #available(iOS 9.0, *) {
-      view.setNeedsFocusUpdate()
-    }
+    #endif
   }
 
   /// Configure the view frame with a given size.
@@ -250,6 +234,26 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     handleInfiniteScrolling()
     #endif
   }
+
+  #if os(tvOS)
+  private func setupInfiniteScrolling() {
+    guard let collectionView = collectionView,
+      let componentDataSource = componentDataSource else {
+        return
+    }
+
+    let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
+    guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
+      return
+    }
+
+    collectionView.contentOffset.x = attributes.frame.minX
+    componentDelegate?.manualFocusedIndexPath = indexPath
+    if #available(iOS 9.0, *) {
+      view.setNeedsFocusUpdate()
+    }
+  }
+  #endif
 
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.
   /// The `.x` offset is changed when the user reaches the beginning or the end of a `Component`.

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -92,8 +92,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
             let indexPath = IndexPath(item: index - component.model.items.count, section: 0)
             contentSize.width += component.sizeForItem(at: indexPath).width + minimumInteritemSpacing
           }
-
-          contentSize.width += CGFloat(component.model.layout.inset.right)
         }
       }
 

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -33,6 +33,10 @@ extension DataSource: UICollectionViewDataSource {
       return UICollectionViewCell()
     }
 
+    if indexPath.item >= component.model.items.count {
+      return UICollectionViewCell()
+    }
+
     let currentIndexPath: IndexPath = indexPathManager.computeIndexPath(indexPath)
     let reuseIdentifier = component.identifier(for: currentIndexPath)
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: currentIndexPath)

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -1,52 +1,6 @@
 import UIKit
 
-private extension Delegate {
-  /// Sets the initial values to the focus delegate.
-  /// See `updateFocusDelegate(_ index: Int, _ userInterface: UserInterface)` for more details.
-  ///
-  /// - Parameter scrollView: The scrollview that is currently in focus, can either be a `UICollectionView`
-  ///                         or a `UITableView`.
-  func setInitialValuesToFocusDelegate(_ scrollView: ScrollView) {
-    if let component = component,
-      component.view == scrollView,
-      component.focusDelegate?.focusedComponent == nil {
-      let focusedIndex = component.focusDelegate?.focusedItemIndex ?? 0
-      component.focusDelegate?.focusedComponent = component
-      component.focusDelegate?.focusedView = component.userInterface?.view(at: focusedIndex)
-    }
-  }
-
-  /// Sets new properties to the focus delegate.
-  /// The properties that gets updated are `.focusedComponent`, `focusedItemIndex` and `focusedView`.
-  /// `.focusedComponent` only gets set if the current focused component is different than the current one.
-  /// This is done to only trigger the observation once.
-  ///
-  /// - Parameters:
-  ///   - index: The index of the current view that is selected.
-  ///   - userInterface: The user interface that is currently in focus, can either be a `UICollectionView`
-  ///                    or a `UITableView`.
-  func updateFocusDelegate(_ index: Int, _ userInterface: UserInterface) {
-    if let component = component, index < component.model.items.count {
-      if component.focusDelegate?.focusedComponent != component {
-        component.focusDelegate?.focusedComponent = component
-      }
-      component.focusDelegate?.focusedItemIndex = index
-      component.focusDelegate?.focusedView = userInterface.view(at: index)
-      #if os(tvOS)
-        component.focusGuide.preferredFocusedView = userInterface.view(at: index)
-      #endif
-    }
-  }
-}
-
 extension Delegate: UICollectionViewDelegate {
-
-  public func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
-    return component?.model.layout.infiniteScrolling == true
-      ? manualFocusCell
-      : nil
-  }
-
   /// Asks the delegate for the size of the specified item’s cell.
   ///
   /// - parameter collectionView: The collection view object displaying the flow layout.
@@ -103,131 +57,6 @@ extension Delegate: UICollectionViewDelegate {
       let view = (cell as? Wrappable)?.wrappedView ?? cell
       component.delegate?.component(component, didEndDisplaying: view, item: item)
     }
-  }
-
-  /// Asks the delegate whether the item at the specified index path can be focused.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter indexPath:      The index path of an item in the collection view.
-  ///
-  /// - returns: YES if the item can receive be focused or NO if it can not.
-  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    let indexPath = indexPathManager.computeIndexPath(indexPath)
-    let canFocusItem = resolveComponent({ component in
-      return component.item(at: indexPath) != nil
-    }, fallback: false)
-    return canFocusItem
-  }
-
-  ///Asks the delegate whether a change in focus should occur.
-  ///
-  /// - parameter collectionView: The collection view object requesting this information.
-  /// - parameter context:        The context object containing metadata associated with the focus change.
-  /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
-  ///
-  /// - returns: YES if the focus change should occur or NO if it should not.
-  @available(iOS 9.0, *)
-  public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
-    guard let indexPath = context.nextFocusedIndexPath else {
-      return true
-    }
-
-    if let component = component, component.model.layout.infiniteScrolling == true {
-      let count = component.model.items.count
-      let buffer = (collectionView.dataSource as? DataSource)?.buffer ?? 0
-      let computedIndexPath = indexPathManager.computeIndexPath(indexPath)
-      updateFocusDelegate(computedIndexPath.item, collectionView)
-
-      if context.focusHeading == .left && indexPath.item < buffer {
-        navigating = true
-        jump(with: context, collectionView: collectionView, indexPath: indexPath)
-        return true
-      }
-
-      if context.focusHeading == .right && indexPath.item >= buffer + count {
-        navigating = true
-        jump(with: context, collectionView: collectionView, indexPath: indexPath)
-        return true
-      }
-    } else {
-      updateFocusDelegate(indexPath.item, collectionView)
-    }
-
-    return context.nextFocusedView?.canBecomeFocused ?? false
-  }
-
-  @available(iOS 9.0, *)
-  public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-    setInitialValuesToFocusDelegate(collectionView)
-    guard let nextFocusedIndexPath = context.nextFocusedIndexPath, navigating else {
-      return
-    }
-
-    navigating = false
-
-    if context.focusHeading == .left {
-      jump(.forward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
-    } else {
-      jump(.backward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
-    }
-
-    currentlyFocusedItem = manualFocusCell.item
-    collectionView.setNeedsFocusUpdate()
-  }
-
-  enum JumpDirection {
-    case forward
-    case backward
-  }
-
-  func jump(_ direction: JumpDirection, indexPath: IndexPath, collectionView: UICollectionView) {
-    guard let component = component else {
-      return
-    }
-
-    var newIndexPath = indexPath
-    switch direction {
-    case .forward:
-      newIndexPath.item += component.model.items.count
-    case .backward:
-      newIndexPath.item -= component.model.items.count
-    }
-
-    let currentOffset = collectionView.contentOffset.x
-    let itemSizeIndexPath = indexPathManager.computeIndexPath(newIndexPath)
-    let totalWidth = component.sizeForItem(at: itemSizeIndexPath).width + CGFloat(component.model.layout.itemSpacing)
-    var jumpOffset = CGFloat(component.model.items.count) * totalWidth
-    if case .backward = direction {
-      jumpOffset *= -1
-    }
-
-    manualFocusCell = newIndexPath
-
-    collectionView.setContentOffset(CGPoint(x: currentOffset + jumpOffset,
-                                            y: collectionView.contentOffset.y),
-                                    animated: false)
-  }
-
-  func jump(with context: UICollectionViewFocusUpdateContext, collectionView: UICollectionView, indexPath: IndexPath) {
-    guard context.focusHeading == .left || context.focusHeading == .right else {
-      return
-    }
-
-    let focusHeading = context.focusHeading
-    let count = component!.model.items.count
-    let buffer = component!.componentDataSource?.buffer ?? 0
-
-    currentlyFocusedItem = indexPath.item
-
-    if focusHeading == .left && indexPath.item < buffer {
-      currentlyFocusedItem += count
-    }
-
-    if focusHeading == .right && indexPath.item >= buffer + count {
-      currentlyFocusedItem -= count
-    }
-
-    manualFocusCell = IndexPath(item: currentlyFocusedItem, section: 0)
   }
 }
 
@@ -297,22 +126,6 @@ extension Delegate: UITableViewDelegate {
 
   public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
     return component?.footerView ?? nil
-  }
-
-  @available(iOS 9.0, *)
-  public func tableView(_ tableView: UITableView, shouldUpdateFocusIn context: UITableViewFocusUpdateContext) -> Bool {
-    guard let indexPath = context.nextFocusedIndexPath else {
-      return true
-    }
-
-    updateFocusDelegate(indexPath.item, tableView)
-
-    return true
-  }
-
-  @available(iOS 9.0, *)
-  public func tableView(_ tableView: UITableView, didUpdateFocusIn context: UITableViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-    setInitialValuesToFocusDelegate(tableView)
   }
 
   /// Asks the delegate for the height to use for a row in a specified location.

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -1,19 +1,6 @@
 import UIKit
 
 private extension Delegate {
-
-  private func computeIndexPath(_ indexPath: IndexPath) -> IndexPath {
-    var indexPath = indexPath
-
-    if let component = component, component.model.layout.infiniteScrolling {
-      if indexPath.item >= component.model.items.count {
-        indexPath.item = indexPath.item - component.model.items.count
-      }
-    }
-
-    return indexPath
-  }
-
   /// Sets the initial values to the focus delegate.
   /// See `updateFocusDelegate(_ index: Int, _ userInterface: UserInterface)` for more details.
   ///
@@ -55,14 +42,9 @@ private extension Delegate {
 extension Delegate: UICollectionViewDelegate {
 
   public func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
-    guard let component = component, component.model.layout.infiniteScrolling else {
-      return nil
-    }
-
-    let offset = collectionView.numberOfItems(inSection: 0) - component.model.items.count
-    let indexPath = IndexPath(item: offset, section: 0)
-
-    return indexPath
+    return component?.model.layout.infiniteScrolling == true
+      ? manualFocusCell
+      : nil
   }
 
   /// Asks the delegate for the size of the specified item’s cell.
@@ -73,7 +55,7 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: The width and height of the specified item. Both values must be greater than 0.
   public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    let indexPath = computeIndexPath(indexPath)
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
     let sizeForItem = resolveComponent({ component in
       component.sizeForItem(at: indexPath)
     }, fallback: .zero)
@@ -86,7 +68,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter collectionView: The collection view object that is notifying you of the selection change.
   /// - parameter indexPath: The index path of the cell that was selected.
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    let indexPath = computeIndexPath(indexPath)
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
     resolveComponentItem(at: indexPath) { component, item in
       component.delegate?.component(component, itemSelected: item)
     }
@@ -98,7 +80,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter cell: The cell object being added.
   /// - parameter indexPath: The index path of the data item that the cell represents.
   public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-    let indexPath = computeIndexPath(indexPath)
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
     resolveComponentItem(at: indexPath) { component, item in
       let view = (cell as? Wrappable)?.wrappedView ?? cell
 
@@ -116,7 +98,7 @@ extension Delegate: UICollectionViewDelegate {
   /// - parameter cell: The cell object that was removed.
   /// - parameter indexPath: The index path of the data item that the cell represented.
   public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-    let indexPath = computeIndexPath(indexPath)
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
     resolveComponentItem(at: indexPath) { (component, item) in
       let view = (cell as? Wrappable)?.wrappedView ?? cell
       component.delegate?.component(component, didEndDisplaying: view, item: item)
@@ -130,7 +112,7 @@ extension Delegate: UICollectionViewDelegate {
   ///
   /// - returns: YES if the item can receive be focused or NO if it can not.
   public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
-    let indexPath = computeIndexPath(indexPath)
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
     let canFocusItem = resolveComponent({ component in
       return component.item(at: indexPath) != nil
     }, fallback: false)
@@ -150,9 +132,25 @@ extension Delegate: UICollectionViewDelegate {
       return true
     }
 
-    let computedIndexPath = computeIndexPath(indexPath)
+    if let component = component, component.model.layout.infiniteScrolling == true {
+      let count = component.model.items.count
+      let buffer = (collectionView.dataSource as? DataSource)?.buffer ?? 0
+      updateFocusDelegate(manualFocusCell.item, collectionView)
 
-    updateFocusDelegate(computedIndexPath.item, collectionView)
+      if context.focusHeading == .left && indexPath.item < buffer {
+        navigating = true
+        jump(with: context, collectionView: collectionView, indexPath: indexPath)
+        return true
+      }
+
+      if context.focusHeading == .right && indexPath.item >= buffer + count {
+        navigating = true
+        jump(with: context, collectionView: collectionView, indexPath: indexPath)
+        return true
+      }
+    } else {
+      updateFocusDelegate(indexPath.item, collectionView)
+    }
 
     return context.nextFocusedView?.canBecomeFocused ?? false
   }
@@ -160,6 +158,75 @@ extension Delegate: UICollectionViewDelegate {
   @available(iOS 9.0, *)
   public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
     setInitialValuesToFocusDelegate(collectionView)
+    guard let nextFocusedIndexPath = context.nextFocusedIndexPath, navigating else {
+      return
+    }
+
+    navigating = false
+
+    if context.focusHeading == .left {
+      jump(.forward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
+    } else {
+      jump(.backward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
+    }
+
+    currentlyFocusedItem = manualFocusCell.item
+    collectionView.setNeedsFocusUpdate()
+  }
+
+  enum JumpDirection {
+    case forward
+    case backward
+  }
+
+  func jump(_ direction: JumpDirection, indexPath: IndexPath, collectionView: UICollectionView) {
+    guard let component = component else {
+      return
+    }
+
+    var newIndexPath = indexPath
+    switch direction {
+    case .forward:
+      newIndexPath.item += component.model.items.count
+    case .backward:
+      newIndexPath.item -= component.model.items.count
+    }
+
+    let currentOffset = collectionView.contentOffset.x
+    let itemSizeIndexPath = indexPathManager.computeIndexPath(newIndexPath)
+    let totalWidth = component.sizeForItem(at: itemSizeIndexPath).width + CGFloat(component.model.layout.itemSpacing)
+    var jumpOffset = CGFloat(component.model.items.count) * totalWidth
+    if case .backward = direction {
+      jumpOffset *= -1
+    }
+
+    manualFocusCell = newIndexPath
+
+    collectionView.setContentOffset(CGPoint(x: currentOffset + jumpOffset,
+                                            y: collectionView.contentOffset.y),
+                                    animated: false)
+  }
+
+  func jump(with context: UICollectionViewFocusUpdateContext, collectionView: UICollectionView, indexPath: IndexPath) {
+    guard context.focusHeading == .left || context.focusHeading == .right else {
+      return
+    }
+
+    let focusHeading = context.focusHeading
+    let count = component!.model.items.count
+    let buffer = component!.componentDataSource?.buffer ?? 0
+
+    currentlyFocusedItem = indexPath.item
+
+    if focusHeading == .left && indexPath.item < buffer {
+      currentlyFocusedItem += count
+    }
+
+    if focusHeading == .right && indexPath.item >= buffer + count {
+      currentlyFocusedItem -= count
+    }
+
+    manualFocusCell = IndexPath(item: currentlyFocusedItem, section: 0)
   }
 }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+Extensions.swift
@@ -135,7 +135,8 @@ extension Delegate: UICollectionViewDelegate {
     if let component = component, component.model.layout.infiniteScrolling == true {
       let count = component.model.items.count
       let buffer = (collectionView.dataSource as? DataSource)?.buffer ?? 0
-      updateFocusDelegate(manualFocusCell.item, collectionView)
+      let computedIndexPath = indexPathManager.computeIndexPath(indexPath)
+      updateFocusDelegate(computedIndexPath.item, collectionView)
 
       if context.focusHeading == .left && indexPath.item < buffer {
         navigating = true

--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -38,7 +38,7 @@ class FocusEngineManager {
           if component.model.kind == .grid {
             result -= CGFloat(component.model.layout.inset.top + component.model.layout.lineSpacing)
           } else if component.model.kind == .carousel {
-            result += cell.frame.height / 2
+            result -= component.headerHeight
           }
         }
       }

--- a/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
+++ b/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
@@ -36,10 +36,11 @@ extension Delegate {
       return true
     }
 
+    let computedIndexPath = indexPathManager.computeIndexPath(indexPath)
+
     if let component = component, component.model.layout.infiniteScrolling == true {
       let count = component.model.items.count
       let buffer = (collectionView.dataSource as? DataSource)?.buffer ?? 0
-      let computedIndexPath = indexPathManager.computeIndexPath(indexPath)
       updateFocusDelegate(computedIndexPath.item, collectionView)
 
       if context.focusHeading == .left && indexPath.item < buffer {
@@ -54,7 +55,7 @@ extension Delegate {
         return true
       }
     } else {
-      updateFocusDelegate(indexPath.item, collectionView)
+      updateFocusDelegate(computedIndexPath.item, collectionView)
     }
 
     return context.nextFocusedView?.canBecomeFocused ?? false
@@ -69,7 +70,6 @@ extension Delegate {
 
     hasReachedBuffer = false
     modifyContentOffsetFor(context.focusHeading, indexPath: nextFocusedIndexPath, collectionView: collectionView)
-    currentlyFocusedItem = manualFocusedIndexPath.item
     collectionView.setNeedsFocusUpdate()
   }
 
@@ -167,16 +167,16 @@ extension Delegate {
     let count = component.model.items.count
     let buffer = component.componentDataSource?.buffer ?? 0
 
-    currentlyFocusedItem = indexPath.item
+    var newFocusedIndex = indexPath.item
 
     if focusHeading == .left && indexPath.item < buffer {
-      currentlyFocusedItem += count
+      newFocusedIndex += count
     }
 
     if focusHeading == .right && indexPath.item >= buffer + count {
-      currentlyFocusedItem -= count
+      newFocusedIndex -= count
     }
 
-    manualFocusedIndexPath = IndexPath(item: currentlyFocusedItem, section: 0)
+    manualFocusedIndexPath = IndexPath(item: newFocusedIndex, section: 0)
   }
 }

--- a/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
+++ b/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
@@ -43,13 +43,13 @@ extension Delegate {
       updateFocusDelegate(computedIndexPath.item, collectionView)
 
       if context.focusHeading == .left && indexPath.item < buffer {
-        navigating = true
+        hasReachedBuffer = true
         jump(with: context, collectionView: collectionView, indexPath: indexPath)
         return true
       }
 
       if context.focusHeading == .right && indexPath.item >= buffer + count {
-        navigating = true
+        hasReachedBuffer = true
         jump(with: context, collectionView: collectionView, indexPath: indexPath)
         return true
       }
@@ -63,11 +63,11 @@ extension Delegate {
   @available(iOS 9.0, *)
   public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
     setInitialValuesToFocusDelegate(collectionView)
-    guard let nextFocusedIndexPath = context.nextFocusedIndexPath, navigating else {
+    guard let nextFocusedIndexPath = context.nextFocusedIndexPath, hasReachedBuffer else {
       return
     }
 
-    navigating = false
+    hasReachedBuffer = false
 
     if context.focusHeading == .left {
       jump(.forward, indexPath: nextFocusedIndexPath, collectionView: collectionView)

--- a/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
+++ b/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
@@ -1,0 +1,195 @@
+import UIKit
+
+extension Delegate {
+  // MARK: - UICollectionView
+
+  public func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
+    return component?.model.layout.infiniteScrolling == true
+      ? manualFocusCell
+      : nil
+  }
+
+  /// Asks the delegate whether the item at the specified index path can be focused.
+  ///
+  /// - parameter collectionView: The collection view object requesting this information.
+  /// - parameter indexPath:      The index path of an item in the collection view.
+  ///
+  /// - returns: YES if the item can receive be focused or NO if it can not.
+  public func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
+    let indexPath = indexPathManager.computeIndexPath(indexPath)
+    let canFocusItem = resolveComponent({ component in
+      return component.item(at: indexPath) != nil
+    }, fallback: false)
+    return canFocusItem
+  }
+
+  ///Asks the delegate whether a change in focus should occur.
+  ///
+  /// - parameter collectionView: The collection view object requesting this information.
+  /// - parameter context:        The context object containing metadata associated with the focus change.
+  /// This object contains the index path of the previously focused item and the item targeted to receive focus next. Use this information to determine if the focus change should occur.
+  ///
+  /// - returns: YES if the focus change should occur or NO if it should not.
+  @available(iOS 9.0, *)
+  public func collectionView(_ collectionView: UICollectionView, shouldUpdateFocusIn context: UICollectionViewFocusUpdateContext) -> Bool {
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return true
+    }
+
+    if let component = component, component.model.layout.infiniteScrolling == true {
+      let count = component.model.items.count
+      let buffer = (collectionView.dataSource as? DataSource)?.buffer ?? 0
+      let computedIndexPath = indexPathManager.computeIndexPath(indexPath)
+      updateFocusDelegate(computedIndexPath.item, collectionView)
+
+      if context.focusHeading == .left && indexPath.item < buffer {
+        navigating = true
+        jump(with: context, collectionView: collectionView, indexPath: indexPath)
+        return true
+      }
+
+      if context.focusHeading == .right && indexPath.item >= buffer + count {
+        navigating = true
+        jump(with: context, collectionView: collectionView, indexPath: indexPath)
+        return true
+      }
+    } else {
+      updateFocusDelegate(indexPath.item, collectionView)
+    }
+
+    return context.nextFocusedView?.canBecomeFocused ?? false
+  }
+
+  @available(iOS 9.0, *)
+  public func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    setInitialValuesToFocusDelegate(collectionView)
+    guard let nextFocusedIndexPath = context.nextFocusedIndexPath, navigating else {
+      return
+    }
+
+    navigating = false
+
+    if context.focusHeading == .left {
+      jump(.forward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
+    } else {
+      jump(.backward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
+    }
+
+    currentlyFocusedItem = manualFocusCell.item
+    collectionView.setNeedsFocusUpdate()
+  }
+
+  // MARK: - UITableView
+
+  @available(iOS 9.0, *)
+  public func tableView(_ tableView: UITableView, didUpdateFocusIn context: UITableViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    setInitialValuesToFocusDelegate(tableView)
+  }
+
+  @available(iOS 9.0, *)
+  public func tableView(_ tableView: UITableView, shouldUpdateFocusIn context: UITableViewFocusUpdateContext) -> Bool {
+    guard let indexPath = context.nextFocusedIndexPath else {
+      return true
+    }
+
+    #if os(tvOS)
+      updateFocusDelegate(indexPath.item, tableView)
+    #endif
+
+    return true
+  }
+
+  // MARK: - Private methods
+
+  /// Sets the initial values to the focus delegate.
+  /// See `updateFocusDelegate(_ index: Int, _ userInterface: UserInterface)` for more details.
+  ///
+  /// - Parameter scrollView: The scrollview that is currently in focus, can either be a `UICollectionView`
+  ///                         or a `UITableView`.
+  private func setInitialValuesToFocusDelegate(_ scrollView: ScrollView) {
+    if let component = component,
+      component.view == scrollView,
+      component.focusDelegate?.focusedComponent == nil {
+      let focusedIndex = component.focusDelegate?.focusedItemIndex ?? 0
+      component.focusDelegate?.focusedComponent = component
+      component.focusDelegate?.focusedView = component.userInterface?.view(at: focusedIndex)
+    }
+  }
+
+  /// Sets new properties to the focus delegate.
+  /// The properties that gets updated are `.focusedComponent`, `focusedItemIndex` and `focusedView`.
+  /// `.focusedComponent` only gets set if the current focused component is different than the current one.
+  /// This is done to only trigger the observation once.
+  ///
+  /// - Parameters:
+  ///   - index: The index of the current view that is selected.
+  ///   - userInterface: The user interface that is currently in focus, can either be a `UICollectionView`
+  ///                    or a `UITableView`.
+  private func updateFocusDelegate(_ index: Int, _ userInterface: UserInterface) {
+    if let component = component, index < component.model.items.count {
+      if component.focusDelegate?.focusedComponent != component {
+        component.focusDelegate?.focusedComponent = component
+      }
+      component.focusDelegate?.focusedItemIndex = index
+      component.focusDelegate?.focusedView = userInterface.view(at: index)
+      #if os(tvOS)
+        component.focusGuide.preferredFocusedView = userInterface.view(at: index)
+      #endif
+    }
+  }
+
+  private enum JumpDirection {
+    case forward
+    case backward
+  }
+
+  private func jump(_ direction: JumpDirection, indexPath: IndexPath, collectionView: UICollectionView) {
+    guard let component = component else {
+      return
+    }
+
+    var newIndexPath = indexPath
+    switch direction {
+    case .forward:
+      newIndexPath.item += component.model.items.count
+    case .backward:
+      newIndexPath.item -= component.model.items.count
+    }
+
+    let currentOffset = collectionView.contentOffset.x
+    let itemSizeIndexPath = indexPathManager.computeIndexPath(newIndexPath)
+    let totalWidth = component.sizeForItem(at: itemSizeIndexPath).width + CGFloat(component.model.layout.itemSpacing)
+    var jumpOffset = CGFloat(component.model.items.count) * totalWidth
+    if case .backward = direction {
+      jumpOffset *= -1
+    }
+
+    manualFocusCell = newIndexPath
+
+    collectionView.setContentOffset(CGPoint(x: currentOffset + jumpOffset,
+                                            y: collectionView.contentOffset.y),
+                                    animated: false)
+  }
+
+  private func jump(with context: UICollectionViewFocusUpdateContext, collectionView: UICollectionView, indexPath: IndexPath) {
+    guard context.focusHeading == .left || context.focusHeading == .right else {
+      return
+    }
+
+    let focusHeading = context.focusHeading
+    let count = component!.model.items.count
+    let buffer = component!.componentDataSource?.buffer ?? 0
+
+    currentlyFocusedItem = indexPath.item
+
+    if focusHeading == .left && indexPath.item < buffer {
+      currentlyFocusedItem += count
+    }
+
+    if focusHeading == .right && indexPath.item >= buffer + count {
+      currentlyFocusedItem -= count
+    }
+
+    manualFocusCell = IndexPath(item: currentlyFocusedItem, section: 0)
+  }
+}

--- a/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
+++ b/Sources/tvOS/Extensions/Delegate+tvOS+Extensions.swift
@@ -5,7 +5,7 @@ extension Delegate {
 
   public func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
     return component?.model.layout.infiniteScrolling == true
-      ? manualFocusCell
+      ? manualFocusedIndexPath
       : nil
   }
 
@@ -75,7 +75,7 @@ extension Delegate {
       jump(.backward, indexPath: nextFocusedIndexPath, collectionView: collectionView)
     }
 
-    currentlyFocusedItem = manualFocusCell.item
+    currentlyFocusedItem = manualFocusedIndexPath.item
     collectionView.setNeedsFocusUpdate()
   }
 
@@ -164,7 +164,7 @@ extension Delegate {
       jumpOffset *= -1
     }
 
-    manualFocusCell = newIndexPath
+    manualFocusedIndexPath = newIndexPath
 
     collectionView.setContentOffset(CGPoint(x: currentOffset + jumpOffset,
                                             y: collectionView.contentOffset.y),
@@ -190,6 +190,6 @@ extension Delegate {
       currentlyFocusedItem -= count
     }
 
-    manualFocusCell = IndexPath(item: currentlyFocusedItem, section: 0)
+    manualFocusedIndexPath = IndexPath(item: currentlyFocusedItem, section: 0)
   }
 }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BD2872AC1FA20ED200799CEB /* SpotsScrollView+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2872AB1FA20ED200799CEB /* SpotsScrollView+tvOS.swift */; };
 		BD2872AE1FA20F9300799CEB /* SpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2872AD1FA20F9300799CEB /* SpotsScrollView.swift */; };
 		BD2872AF1FA20F9300799CEB /* SpotsScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2872AD1FA20F9300799CEB /* SpotsScrollView.swift */; };
+		BD2BF912200CACD7002FF092 /* Delegate+tvOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2BF911200CACD7002FF092 /* Delegate+tvOS+Extensions.swift */; };
 		BD30491D1F041C7E00D9EECB /* MoveAlgorithmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */; };
 		BD30491E1F041C7E00D9EECB /* MoveAlgorithmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */; };
 		BD30491F1F041C7E00D9EECB /* MoveAlgorithmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */; };
@@ -465,6 +466,7 @@
 		BD2403101E4B9A02005BAA19 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		BD2872AB1FA20ED200799CEB /* SpotsScrollView+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpotsScrollView+tvOS.swift"; sourceTree = "<group>"; };
 		BD2872AD1FA20F9300799CEB /* SpotsScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotsScrollView.swift; sourceTree = "<group>"; };
+		BD2BF911200CACD7002FF092 /* Delegate+tvOS+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Delegate+tvOS+Extensions.swift"; sourceTree = "<group>"; };
 		BD30491C1F041C7E00D9EECB /* MoveAlgorithmTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveAlgorithmTests.swift; sourceTree = "<group>"; };
 		BD31BB991EA6208600D1FC8A /* DelegateConfigurationClosureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateConfigurationClosureTests.swift; sourceTree = "<group>"; };
 		BD34B4011F93D5C800840F2F /* ItemChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemChange.swift; sourceTree = "<group>"; };
@@ -988,6 +990,7 @@
 				BDAD85F51E3E703A008289AE /* Component+tvOS.swift */,
 				BD6857A31F7CCCFC008EA9B5 /* SpotsController+tvOS.swift */,
 				BD2872AB1FA20ED200799CEB /* SpotsScrollView+tvOS.swift */,
+				BD2BF911200CACD7002FF092 /* Delegate+tvOS+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1513,6 +1516,7 @@
 				BD34B4041F93D5C800840F2F /* ItemChange.swift in Sources */,
 				BDC5F37B1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */,
 				BD1F9A8B1F908866003E6D8D /* ItemModel.swift in Sources */,
+				BD2BF912200CACD7002FF092 /* Delegate+tvOS+Extensions.swift in Sources */,
 				BDAD85F21E3E7032008289AE /* TypeAlias.swift in Sources */,
 				BDAD85C51E3E7032008289AE /* ComponentFocusDelegate.swift in Sources */,
 				D5D282711E5474E0004BF251 /* Cell.swift in Sources */,

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		BD45D9951E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
 		BD45D9961E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
 		BD45D9971E30A8A000C2D6B2 /* InsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */; };
+		BD48C97E200BE62E00A3561F /* IndexPathManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48C97D200BE62E00A3561F /* IndexPathManager.swift */; };
+		BD48C97F200BE62E00A3561F /* IndexPathManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48C97D200BE62E00A3561F /* IndexPathManager.swift */; };
+		BD48C980200BE62E00A3561F /* IndexPathManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48C97D200BE62E00A3561F /* IndexPathManager.swift */; };
 		BD4F05AB1FFD5AE5009528BB /* ComponentFocusDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4F05A91FFD5AE5009528BB /* ComponentFocusDelegateTests.swift */; };
 		BD5500FE1F93950D0075CC4E /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */; };
 		BD5500FF1F93950D0075CC4E /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */; };
@@ -478,6 +481,7 @@
 		BD45D9941E30A8A000C2D6B2 /* InsetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsetTests.swift; sourceTree = "<group>"; };
 		BD45D9981E30B0F700C2D6B2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BD45D9991E30B0F700C2D6B2 /* Spots.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Spots.podspec; sourceTree = "<group>"; };
+		BD48C97D200BE62E00A3561F /* IndexPathManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexPathManager.swift; sourceTree = "<group>"; };
 		BD4F05A91FFD5AE5009528BB /* ComponentFocusDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentFocusDelegateTests.swift; sourceTree = "<group>"; };
 		BD5500FD1F93950D0075CC4E /* ArrayExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensionsTests.swift; sourceTree = "<group>"; };
 		BD5CF7361E8B7C57006CC281 /* ComponentResize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentResize.swift; sourceTree = "<group>"; };
@@ -870,6 +874,7 @@
 		BDAD852A1E3E7032008289AE /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				BD48C97D200BE62E00A3561F /* IndexPathManager.swift */,
 				BDE44B0E1EA0E5E80021EAC8 /* ComponentManager.swift */,
 				BDAD852C1E3E7032008289AE /* DataSource.swift */,
 				BDAD852D1E3E7032008289AE /* Delegate.swift */,
@@ -1523,6 +1528,7 @@
 				BD6857A41F7CCCFC008EA9B5 /* SpotsController+tvOS.swift in Sources */,
 				BDAD85D41E3E7032008289AE /* ComponentModel.swift in Sources */,
 				BDAD85F61E3E703A008289AE /* Component+tvOS.swift in Sources */,
+				BD48C980200BE62E00A3561F /* IndexPathManager.swift in Sources */,
 				BDAD85E31E3E7032008289AE /* Interaction.swift in Sources */,
 				BD24030D1E4B981A005BAA19 /* Component.swift in Sources */,
 				BD2872AF1FA20F9300799CEB /* SpotsScrollView.swift in Sources */,
@@ -1675,6 +1681,7 @@
 				BDAD85631E3E7032008289AE /* DataSource.swift in Sources */,
 				BDAD84B61E3E701C008289AE /* GridWrapper.swift in Sources */,
 				BDA3D96C1EC6F1A400141227 /* ItemManager.swift in Sources */,
+				BD48C97E200BE62E00A3561F /* IndexPathManager.swift in Sources */,
 				BD91A9521F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift in Sources */,
 				BDC5F3791F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */,
 				BDDCF6E01E4DF927004B38C4 /* ItemConfigurable.swift in Sources */,
@@ -1826,6 +1833,7 @@
 				BDA25E901EB5070F002B21C0 /* Wrappable+macOS.swift in Sources */,
 				BDDCF6F01E4DF93D004B38C4 /* DictionaryConvertible.swift in Sources */,
 				BD77D1F51E8537E80075A3FC /* ComponentModelDiff.swift in Sources */,
+				BD48C97F200BE62E00A3561F /* IndexPathManager.swift in Sources */,
 				BDAD851D1E3E7025008289AE /* DataSource+macOS+Extensions.swift in Sources */,
 				BD0AF3531E83CC53008795C3 /* UserInterface+Extensions.swift in Sources */,
 				BDC5F37A1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */,

--- a/SpotsTests/iOS/ComponentDelegateiOSTests.swift
+++ b/SpotsTests/iOS/ComponentDelegateiOSTests.swift
@@ -36,6 +36,7 @@ class ComponentDelegateiOSTests: XCTestCase {
     XCTAssertEqual(delegate.countsInvoked, 1)
   }
 
+  #if os(tvOS)
   func testCollectionViewCanFocus() {
     let component = Component(model: ComponentModel(kind: .grid, layout: Layout(span: 1), items: [Item(title: "title 1")]))
 
@@ -47,6 +48,7 @@ class ComponentDelegateiOSTests: XCTestCase {
     XCTAssertEqual(component.componentDelegate?.collectionView(collectionView, canFocusItemAt: IndexPath(item: 0, section: 0)), true)
     XCTAssertEqual(component.componentDelegate?.collectionView(collectionView, canFocusItemAt: IndexPath(item: 1, section: 0)), false)
   }
+  #endif
 
   // MARK: - UITableView
 

--- a/SpotsTests/iOS/ComponentTests.swift
+++ b/SpotsTests/iOS/ComponentTests.swift
@@ -62,27 +62,4 @@ class ComponentTests: XCTestCase {
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
-
-  #if os(iOS)
-  func testComponentInfiniteScrolling() {
-    let items = (0...20).map { Item(title: "\($0)") }
-    let model = ComponentModel(kind: .carousel, layout: Layout(infiniteScrolling: true), items: items)
-    let component = Component(model: model)
-    component.setup(with: .init(width: 100, height: 100))
-    component.view.contentOffset.x = 2000
-    /// Manually invoke layout subviews to invoke handling of `infiniteScrolling`.
-    component.layoutSubviews()
-    XCTAssertEqual(component.view.contentOffset.x, 2000)
-
-    /// Expect the content offset to go back to zero because it went all the way to the right.
-    component.view.contentOffset.x = 2100
-    component.layoutSubviews()
-    XCTAssertEqual(component.view.contentOffset.x, 0)
-
-    /// Expect the content offset to go to the last item as the offset went all the way to the left.
-    component.view.contentOffset.x = -1.0
-    component.layoutSubviews()
-    XCTAssertEqual(component.view.contentOffset.x, 2000)
-  }
-  #endif
 }

--- a/SpotsTests/iOS/ComponentTests.swift
+++ b/SpotsTests/iOS/ComponentTests.swift
@@ -63,6 +63,7 @@ class ComponentTests: XCTestCase {
     waitForExpectations(timeout: 10.0, handler: nil)
   }
 
+  #if os(iOS)
   func testComponentInfiniteScrolling() {
     let items = (0...20).map { Item(title: "\($0)") }
     let model = ComponentModel(kind: .carousel, layout: Layout(infiniteScrolling: true), items: items)
@@ -83,4 +84,5 @@ class ComponentTests: XCTestCase {
     component.layoutSubviews()
     XCTAssertEqual(component.view.contentOffset.x, 2000)
   }
+  #endif
 }

--- a/SpotsTests/iOS/DataSourceiOSTests.swift
+++ b/SpotsTests/iOS/DataSourceiOSTests.swift
@@ -113,6 +113,6 @@ class DataSourceiOSTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(dataSource.collectionView(collectionView, numberOfItemsInSection: 0), 22)
+    XCTAssertEqual(dataSource.collectionView(collectionView, numberOfItemsInSection: 0), 25)
   }
 }


### PR DESCRIPTION
This PR refactors the way that infinite scrolling works with a focus on tvOS.
Now the buffering of additional cells has been refactored to add more additional items and the "invisible" scrolling is done whenever the index path's item has reached either the beginning or end of the buffer.

Resolving index paths for getting the correct index path without the added buffer is handled by the new `IndexPathManger`. If `infiniteScrolling` is disabled, the method will simply return the index path as is.

One other great change is that all focus delegate related methods have been moved into its own file and scoped to tvOS to make it more clear what is in use for the platform and what is not applicable.

We will have to re-implement infinite scrolling for iOS at some point to follow the same logic, this will be done in a separate PR for an upcoming version.

This PR was made possible the contributors of (willowtreeapps/ouroboros)[https://github.com/willowtreeapps/ouroboros]. The credit in the README has been update to give credit where credit is due!

Cheers @eriklamanna @Grigs-b @chrsmys @chaseacton 🍻 