### PR TITLE
Add safe guard in infinite scrolling implementation

### DIFF
--- a/Sources/Shared/Classes/IndexPathManager.swift
+++ b/Sources/Shared/Classes/IndexPathManager.swift
@@ -8,15 +8,18 @@ final class IndexPathManager {
   }
 
   func computeIndexPath(_ indexPath: IndexPath) -> IndexPath {
-    guard let component = component, component.model.layout.infiniteScrolling else {
-      return indexPath
+    guard let component = component,
+      let dataSource = component.componentDataSource,
+      component.model.layout.infiniteScrolling,
+      component.model.items.count >= dataSource.buffer else {
+        return indexPath
     }
 
-    let buffer = component.componentDataSource?.buffer ?? 2
-    let count = component.model.items.count
     let index = indexPath.item
-    let wrapped = (index - buffer < 0) ? (count + (index - buffer)) : (index - buffer)
-    let adjustedIndex = wrapped % count
+    let wrapped = (index - dataSource.buffer < 0)
+      ? (component.model.items.count + (index - dataSource.buffer))
+      : (index - dataSource.buffer)
+    let adjustedIndex = wrapped % component.model.items.count
     return IndexPath(item: adjustedIndex, section: 0)
   }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -238,7 +238,8 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   #if os(tvOS)
   private func setupInfiniteScrolling() {
     guard let collectionView = collectionView,
-      let componentDataSource = componentDataSource else {
+      let componentDataSource = componentDataSource,
+      model.items.count >= componentDataSource.buffer else {
         return
     }
 

--- a/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
+++ b/Sources/iOS/Extensions/DataSource+iOS+Extensions.swift
@@ -9,17 +9,16 @@ extension DataSource: UICollectionViewDataSource {
   /// - returns: The number of rows in section.
   @available(iOS 6.0, *)
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let component = component else {
-      return 0
+    guard component?.model.layout.infiniteScrolling == true && numberOfItems >= buffer else {
+      return numberOfItems
     }
 
-    let numberOfItemsInSection = component.model.items.count
-
-    guard component.model.layout.infiniteScrolling else {
-      return numberOfItemsInSection
+    if numberOfItems == buffer {
+      buffer = 1
+      return numberOfItems + 2 * buffer
     }
 
-    return numberOfItemsInSection + 2 * buffer
+    return numberOfItems + 2 * buffer
   }
 
   /// Asks the data source for the number of items in the specified section. (required)


### PR DESCRIPTION
The count of items needs to be larger than the buffer in order to enable infinite scrolling.