### PR TITLE
Improve/header and footer with custom models

### DIFF
--- a/Sources/Shared/Extensions/Component+HeaderFooter.swift
+++ b/Sources/Shared/Extensions/Component+HeaderFooter.swift
@@ -17,7 +17,9 @@ extension Component {
     } else {
       if let model = header.model,
         let configurator = self.configuration.presenters[header.kind] {
-        self.model.header?.size.height = configurator.configure(view: headerView, model: model, containerSize: view.frame.size).height
+        let size = configurator.configure(view: headerView, model: model, containerSize: view.frame.size)
+        headerView.frame.size.height = size.height
+        self.model.header?.size.height = size.height
       }
     }
   }
@@ -38,7 +40,9 @@ extension Component {
     } else {
       if let model = footer.model,
         let configurator = self.configuration.presenters[footer.kind] {
-        self.model.footer?.size.height = configurator.configure(view: footerView, model: model, containerSize: view.frame.size).height
+        let size = configurator.configure(view: footerView, model: model, containerSize: view.frame.size)
+        footerView.frame.size.height = size.height
+        self.model.footer?.size.height = size.height
       }
     }
   }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -60,12 +60,20 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
       return 0.0
     }
 
+    if model.header?.model != nil {
+      return model.header?.size.height ?? 0
+    }
+
     return headerView.frame.size.height
   }
   /// The height of the footer view.
   var footerHeight: CGFloat {
     guard let footerView = footerView else {
       return 0.0
+    }
+
+    if model.footer?.model != nil {
+      return model.footer?.size.height ?? 0
     }
 
     return footerView.frame.size.height


### PR DESCRIPTION
This improves the usage of header and footer views when using presenters.
Now the computed height from the presenter will be used for the views frame and it will be used to resolve the size of the header and footer when accessing it using `headerHeight` and `footerHeight` on `Component`.