### PR TITLE
Fix constraints warnings when rotating the device on iOS

### DIFF
--- a/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
+++ b/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
@@ -48,7 +48,10 @@ extension SpotsScrollView {
           frame.size.height = 0
         }
 
-        scrollView.frame = frame
+        if !isRotating {
+          scrollView.frame = frame
+        }
+
         scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
         yOffsetOfCurrentSubview += scrollView.contentSize.height
       } else {

--- a/Sources/iOS/Classes/SpotsScrollView.swift
+++ b/Sources/iOS/Classes/SpotsScrollView.swift
@@ -4,6 +4,7 @@ import QuartzCore
 /// The core foundation scroll view inside of Spots that manages the linear layout of all components.
 open class SpotsScrollView: UIScrollView, UIGestureRecognizerDelegate {
   var sizeCache = [Int: CGFloat]()
+  var isRotating = false
 
   private struct Observer: Equatable {
     let view: UIView


### PR DESCRIPTION
This PR fixes constraints warnings that could occur when rotating the device when you have multiple components that need to invalidate their size.