### PR TITLE
Feature auto alignment when using item pagination

### DIFF
--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -15,6 +15,7 @@ public class Delegate: NSObject, ComponentResolvable {
   let viewPreparer: ViewPreparer
   let configuration: Configuration
   let indexPathManager: IndexPathManager
+  var needsInfiniteScrollingAlignment: Bool = false
 
   #if os(tvOS)
   /// A boolean value that indicates that the scrolling offset has reached

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -255,7 +255,15 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     #if os(iOS)
-      let offset = CGFloat(model.layout.itemSpacing) + CGFloat(model.layout.inset.left / 2)
+      var offset = CGFloat(model.layout.itemSpacing) + CGFloat(model.layout.inset.left / 2)
+
+      // Calculate desired start offset of the component when multiple views fit on the screen.
+      var remainingWidth = attributes.size.width + offset * 2
+      while remainingWidth < view.frame.size.width {
+        remainingWidth *= 2
+        offset -= CGFloat(model.layout.itemSpacing)
+      }
+
       collectionView.contentOffset.x = attributes.frame.minX + offset
     #endif
 


### PR DESCRIPTION
If you combine infinite scrolling with item pagination, the component scroll view delegate will now correct the final content offset so that your view is centered inside your component.