### PR TITLE
Filter out empty components when using reload methods on SpotsController

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,7 +27,7 @@ type_name:
     warning: 40
     error: 50
   excluded: iPhone
-variable_name:
+identifier_name:
   min_length:
     error: 2
   excluded:
@@ -37,7 +37,7 @@ variable_name:
     - URL
     - GlobalAPIKey
 function_body_length:
-  warning: 50
+  warning: 75
 reporter: "xcode"
 missing_docs: internal
 large_tuple:

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -427,8 +427,6 @@ public class SpotsControllerManager {
         return
       }
 
-      let models = strongSelf.filterEmptyComponentsModels(models)
-
       // Opt-out of doing component cleanup if the controller has no components.
       let performCleanup = !controller.components.isEmpty
       let previousContentOffset = controller.scrollView.contentOffset

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -68,7 +68,7 @@ public class SpotsControllerManager {
                              compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              withAnimation animation: Animation = .automatic,
                              completion: Completion = nil) {
-    let components = filterEmptyComponentsModels(components)
+    let components = removeComponentsWithoutItemsIfNeeded(components, configuration: controller.configuration)
 
     guard !components.isEmpty else {
       Dispatch.main {
@@ -379,7 +379,8 @@ public class SpotsControllerManager {
 
       let newComponents: [Component] = Parser.parseComponents(json: json,
                                                               configuration: controller.configuration)
-      let newComponentModels = strongSelf.filterEmptyComponentsModels(newComponents.map { $0.model } )
+      let newComponentModels = strongSelf.removeComponentsWithoutItemsIfNeeded(newComponents.map { $0.model },
+                                                                              configuration: controller.configuration)
       let oldComponentModels = controller.components.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
@@ -469,8 +470,8 @@ public class SpotsControllerManager {
         return
       }
 
-      let models: [ComponentModel] = strongSelf.filterEmptyComponentsModels(Parser.parseComponentModels(json: json))
-
+      let models: [ComponentModel] = strongSelf.removeComponentsWithoutItemsIfNeeded(Parser.parseComponentModels(json: json),
+                                                                                    configuration: controller.configuration)
       controller.components = models.map { Component(model: $0, configuration: controller.configuration) }
 
       if controller.scrollView.superview == nil {
@@ -776,7 +777,11 @@ public class SpotsControllerManager {
     }
   }
 
-  func filterEmptyComponentsModels(_ models: [ComponentModel]) -> [ComponentModel] {
-    return models.filter { !$0.items.isEmpty }
+  func removeComponentsWithoutItemsIfNeeded(_ models: [ComponentModel], configuration: Configuration) -> [ComponentModel] {
+    if configuration.removeEmptyComponents {
+      return models.filter { !$0.items.isEmpty }
+    } else {
+      return models
+    }
   }
 }

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -68,6 +68,8 @@ public class SpotsControllerManager {
                              compare: @escaping CompareClosure = { lhs, rhs in return lhs !== rhs },
                              withAnimation animation: Animation = .automatic,
                              completion: Completion = nil) {
+    let components = filterEmptyComponentsModels(components)
+
     guard !components.isEmpty else {
       Dispatch.main {
         controller.components.forEach {
@@ -251,7 +253,6 @@ public class SpotsControllerManager {
                       lessItems newItems: [Item],
                       animation: Animation,
                       completion: (() -> Void)? = nil) {
-
     let updateDatasource = {
       component.model.items = newItems
     }
@@ -378,7 +379,7 @@ public class SpotsControllerManager {
 
       let newComponents: [Component] = Parser.parseComponents(json: json,
                                                               configuration: controller.configuration)
-      let newComponentModels = newComponents.map { $0.model }
+      let newComponentModels = strongSelf.filterEmptyComponentsModels(newComponents.map { $0.model } )
       let oldComponentModels = controller.components.map { $0.model }
 
       guard compare(newComponentModels, oldComponentModels) else {
@@ -426,6 +427,8 @@ public class SpotsControllerManager {
         return
       }
 
+      let models = strongSelf.filterEmptyComponentsModels(models)
+
       // Opt-out of doing component cleanup if the controller has no components.
       let performCleanup = !controller.components.isEmpty
       let previousContentOffset = controller.scrollView.contentOffset
@@ -468,7 +471,9 @@ public class SpotsControllerManager {
         return
       }
 
-      controller.components = Parser.parseComponents(json: json, configuration: controller.configuration)
+      let models: [ComponentModel] = strongSelf.filterEmptyComponentsModels(Parser.parseComponentModels(json: json))
+
+      controller.components = models.map { Component(model: $0, configuration: controller.configuration) }
 
       if controller.scrollView.superview == nil {
         controller.view.addSubview(controller.scrollView)
@@ -771,5 +776,9 @@ public class SpotsControllerManager {
     for component in components {
       component.configuration.views.purge()
     }
+  }
+
+  func filterEmptyComponentsModels(_ models: [ComponentModel]) -> [ComponentModel] {
+    return models.filter { !$0.items.isEmpty }
   }
 }

--- a/Sources/Shared/Structs/Configuration.swift
+++ b/Sources/Shared/Structs/Configuration.swift
@@ -31,10 +31,10 @@ public class Configuration {
   ///  --------   --------
   /// ```
   public var stretchLastComponent: Bool = false
-
   public var defaultComponentKind: ComponentKind = .grid
   public var defaultViewSize: CGSize = .init(width: 0, height: PlatformDefaults.defaultHeight)
   public var views: Registry = .init()
+  public var removeEmptyComponents: Bool = false
   var presenters: [String: AnyPresenter] = .init()
   var coders: [String: AnyItemModelCoder] = .init()
   var modelCoder: AnyItemModelCoder?

--- a/Sources/Shared/Structs/Parser.swift
+++ b/Sources/Shared/Structs/Parser.swift
@@ -57,7 +57,6 @@ public struct Parser {
   /// - parameter key: The key that should be used for parsing JSON, defaults to `components`.
   ///
   /// - returns: A collection of `ComponentModel`s
-  @available(*, deprecated: 7.0, message: "Deprecated in favor for parseComponentModels with data")
   public static func parseComponentModels(json: [String : Any],
                                           key: String = "components") -> [ComponentModel] {
     let jsonEncoder = JSONEncoder()

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 import Cache
 

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -79,7 +79,7 @@ extension Delegate: UIScrollViewDelegate {
         return
       }
 
-      performPaginatedScrolling { component, collectionView, collectionViewLayout in
+      performPaginatedScrolling { _, collectionView, collectionViewLayout in
         let centerIndexPath = getCenterIndexPath(in: collectionView,
                                                  scrollView: scrollView,
                                                  point: scrollView.contentOffset,
@@ -160,7 +160,7 @@ extension Delegate: UIScrollViewDelegate {
       }
 
       let widthBounds = scrollView.contentSize.width - scrollView.frame.size.width
-      if component.model.layout.infiniteScrolling, (newPointeeX == 0 || newPointeeX == widthBounds)  {
+      if component.model.layout.infiniteScrolling, (newPointeeX == 0 || newPointeeX == widthBounds) {
         needsInfiniteScrollingAlignment = true
       }
 

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -626,7 +626,6 @@
 		BDFBB76C1F75094600421BCF /* ComponentTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTableView.swift; sourceTree = "<group>"; };
 		BDFC474C1E747B2B008700BF /* GridWrapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridWrapperTests.swift; sourceTree = "<group>"; };
 		BDFC474D1E747B2B008700BF /* ListWrapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListWrapperTests.swift; sourceTree = "<group>"; };
-		D55B7B041E42315A000125C8 /* Rx-Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Rx-Info-iOS.plist"; sourceTree = "<group>"; };
 		D55B7B071E4231A4000125C8 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		D55CFF641FA257F100F69973 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		D58478091C43FEB8006EBA49 /* Spots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Spots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1057,7 +1056,6 @@
 		D58478231C43FF34006EBA49 /* Spots */ = {
 			isa = PBXGroup;
 			children = (
-				D55B7B041E42315A000125C8 /* Rx-Info-iOS.plist */,
 				BD129E3A1D7B2DE2009AC164 /* Info-tvOS.plist */,
 				D584784F1C43FFA1006EBA49 /* Info-macOS.plist */,
 				D58478241C43FF34006EBA49 /* Info-iOS.plist */,

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -446,11 +446,11 @@ class SpotsControllerManagerTests: XCTestCase {
   }
 
   func testReloadIfNeededFilteringEmptyComponentModels() {
-    var configuration = Configuration()
+    let configuration = Configuration()
     configuration.removeEmptyComponents = true
     let models = [ComponentModel(), ComponentModel(), ComponentModel()]
     let components = models.map { Component(model: $0) }
-    let controller = SpotsController(components: components)
+    let controller = SpotsController(components: components, configuration: configuration)
 
     XCTAssertEqual(controller.components.count, 3)
 

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -444,4 +444,20 @@ class SpotsControllerManagerTests: XCTestCase {
     }
     waitForExpectations(timeout: 10.0, handler: nil)
   }
+
+  func testReloadIfNeededFilteringEmptyComponentModels() {
+    let models = [ComponentModel(), ComponentModel(), ComponentModel()]
+    let components = models.map { Component(model: $0) }
+    let controller = SpotsController(components: components)
+
+    XCTAssertEqual(controller.components.count, 3)
+
+    let expectation = self.expectation(description: "Wait for exception to be fulfilled.")
+    controller.reloadIfNeeded(models) {
+      XCTAssertEqual(controller.components.count, 0)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 10.0, handler: nil)
+  }
 }

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -421,7 +421,7 @@ class SpotsControllerManagerTests: XCTestCase {
 
       newComponent.items = []
       self.controller.reloadIfNeeded([newComponent]) {
-        XCTAssertTrue(self.controller.components[0].model.items.isEmpty)
+        XCTAssertTrue(self.controller.components.isEmpty)
 
         let items = [
           Item(title: "foo"),

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -421,7 +421,7 @@ class SpotsControllerManagerTests: XCTestCase {
 
       newComponent.items = []
       self.controller.reloadIfNeeded([newComponent]) {
-        XCTAssertTrue(self.controller.components.isEmpty)
+        XCTAssertTrue(self.controller.components[0].model.items.isEmpty)
 
         let items = [
           Item(title: "foo"),

--- a/SpotsTests/Shared/SpotsControllerManagerTests.swift
+++ b/SpotsTests/Shared/SpotsControllerManagerTests.swift
@@ -446,6 +446,8 @@ class SpotsControllerManagerTests: XCTestCase {
   }
 
   func testReloadIfNeededFilteringEmptyComponentModels() {
+    var configuration = Configuration()
+    configuration.removeEmptyComponents = true
     let models = [ComponentModel(), ComponentModel(), ComponentModel()]
     let components = models.map { Component(model: $0) }
     let controller = SpotsController(components: components)


### PR DESCRIPTION
This PR improves the usage of reloading `SpotsController`'s with component models. Now components are deemed useless if they don't have any content, this results in the component model being filter out before reloading happens.