### PR TITLE
Fix typo bug that caused errors when reloading headers and footers

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -324,7 +324,7 @@ public class SpotsControllerManager {
           controller.components[index].reloadHeader()
           fallthrough
         case .footer:
-          controller.components[index].model.header = newComponentModels[index].footer
+          controller.components[index].model.footer = newComponentModels[index].footer
           controller.components[index].reloadFooter()
           fallthrough
         case .items:

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -324,6 +324,7 @@ public class SpotsControllerManager {
           controller.components[index].reloadHeader()
           controller.components[index].model.footer = newComponentModels[index].footer
           controller.components[index].reloadFooter()
+          fallthrough
         case .items:
           if index == lastItemChange {
             completion = { [weak self] in

--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -319,14 +319,11 @@ public class SpotsControllerManager {
           strongSelf.newComponent(atIndex: index, controller: controller, newComponentModels: newComponentModels)
         case .removed:
           strongSelf.removeComponent(atIndex: index, controller: controller)
-        case .header:
+        case .header, .footer:
           controller.components[index].model.header = newComponentModels[index].header
           controller.components[index].reloadHeader()
-          fallthrough
-        case .footer:
           controller.components[index].model.footer = newComponentModels[index].footer
           controller.components[index].reloadFooter()
-          fallthrough
         case .items:
           if index == lastItemChange {
             completion = { [weak self] in


### PR DESCRIPTION
Because of a minor typo in the code, reloading headers did not work properly as it got replaced by the footer, which can be nil.