### PR TITLE
Improve/paginated scrolling on ios

### DIFF
--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -250,35 +250,42 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
-    guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
-      return
-    }
-
     #if os(iOS)
-      let span: Double = model.layout.span > 1 ? model.layout.span : 1
-      var offset = CGFloat(model.layout.itemSpacing * span)
-
-      // Calculate desired start offset of the component when multiple views fit on the screen.
-      var remainingWidth = attributes.size.width + offset * 2
-      while remainingWidth < view.frame.size.width {
-        remainingWidth *= 2
-        offset -= CGFloat(model.layout.itemSpacing)
+      if let x = initialXCoordinateItemAtIndexPath(indexPath) {
+        collectionView.contentOffset.x = x
       }
-
-      if offset == 0 {
-        offset -= CGFloat(model.layout.inset.left / 2 + model.layout.itemSpacing)
-      }
-
-      collectionView.contentOffset.x = attributes.frame.minX - offset
     #endif
 
     #if os(tvOS)
+      guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
+        return
+      }
       collectionView.contentOffset.x = attributes.frame.minX
       componentDelegate?.manualFocusedIndexPath = indexPath
       if #available(tvOS 9.0, *) {
         view.setNeedsFocusUpdate()
       }
     #endif
+  }
+
+  func initialXCoordinateItemAtIndexPath(_ indexPath: IndexPath) -> CGFloat? {
+    guard let attributes = collectionView?.layoutAttributesForItem(at: indexPath) else {
+      return nil
+    }
+
+    let span: Double = model.layout.span > 1 ? model.layout.span : 1
+    var offset = CGFloat(model.layout.itemSpacing * span)
+    var remainingWidth = attributes.size.width + offset * 2
+    while remainingWidth < view.frame.size.width {
+      remainingWidth *= 2
+      offset -= CGFloat(model.layout.itemSpacing)
+    }
+
+    if offset == 0 {
+      offset -= CGFloat(model.layout.inset.left / 2 + model.layout.itemSpacing)
+    }
+
+    return attributes.frame.minX - offset
   }
 
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -403,6 +403,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     return itemsPerRow == 1 || index % itemsPerRow == itemsPerRow - 1
   }
 
+  #if os(iOS)
   open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
     var targetContentOffset = proposedContentOffset
 
@@ -439,4 +440,5 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
     return targetContentOffset
   }
+  #endif
 }

--- a/Sources/iOS/Extensions/Component+iOS+Carousel.swift
+++ b/Sources/iOS/Extensions/Component+iOS+Carousel.swift
@@ -9,9 +9,6 @@ extension Component {
 
     collectionView.isScrollEnabled = true
     collectionViewLayout.scrollDirection = .horizontal
-    #if os(iOS)
-      collectionView.isPagingEnabled = model.interaction.paginate == .page
-    #endif
     configurePageControl()
 
     if collectionView.contentSize.height > 0 {

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -44,6 +44,8 @@ extension Delegate: UIScrollViewDelegate {
     #endif
 
     if let component = component {
+      component.backgroundView.frame.origin.x = scrollView.contentOffset.x
+
       if let footerView = component.footerView {
         scrollViewManager.positionFooterView(footerView, in: scrollView)
       }

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -152,21 +152,22 @@ extension Delegate: UIScrollViewDelegate {
         component.carouselScrollDelegate?.componentCarouselDidEndScrolling(component, item: item, animated: false)
       }
 
-      let itemFrame = collectionViewLayout.cachedFrames[foundIndexPath.item]
-      let newPointeeX = itemFrame.midX - scrollView.frame.size.width / 2
+      var newPointeeX: CGFloat = targetContentOffset.pointee.x
+      if component.model.interaction.paginate == .item {
+        let itemFrame = collectionViewLayout.cachedFrames[foundIndexPath.item]
+        newPointeeX = itemFrame.midX - scrollView.frame.size.width / 2
+        // Only snap to item if new value exceeds zero or that the index path
+        // at center is larger than zero.
+        guard (newPointeeX > 0 && foundIndexPath.item > 0) || component.model.layout.infiniteScrolling else {
+          return
+        }
 
-      // Only snap to item if new value exceeds zero or that the index path
-      // at center is larger than zero.
-      guard (newPointeeX > 0 && foundIndexPath.item > 0) || component.model.layout.infiniteScrolling else {
-        return
+        let widthBounds = scrollView.contentSize.width - scrollView.frame.size.width
+        if component.model.layout.infiniteScrolling, (newPointeeX == 0 || newPointeeX == widthBounds) {
+          needsInfiniteScrollingAlignment = true
+        }
+        targetContentOffset.pointee.x = newPointeeX
       }
-
-      let widthBounds = scrollView.contentSize.width - scrollView.frame.size.width
-      if component.model.layout.infiniteScrolling, (newPointeeX == 0 || newPointeeX == widthBounds) {
-        needsInfiniteScrollingAlignment = true
-      }
-
-      targetContentOffset.pointee.x = newPointeeX
     }
   }
 

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -182,7 +182,7 @@ extension Delegate: UIScrollViewDelegate {
     }
   }
 
-  fileprivate func getCenterIndexPath(in collectionView: UICollectionView, scrollView: UIScrollView, point: CGPoint, contentSize: CGSize, offset: CGFloat) -> IndexPath? {
+  func getCenterIndexPath(in collectionView: UICollectionView, scrollView: UIScrollView, point: CGPoint, contentSize: CGSize, offset: CGFloat) -> IndexPath? {
     guard point.x > 0.0 else {
       return IndexPath(item: 0, section: 0)
     }


### PR DESCRIPTION
This improves paginated scrolling on iOS by manually implementing how the component should scroll instead of relying on `isPagingEnabled` which does not take content insets, section insets, and item spacing into account.