### PR TITLE
Improves the scroll view algorithm

### DIFF
--- a/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
+++ b/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
@@ -45,12 +45,15 @@ extension SpotsScrollView {
 
       switch multipleComponents {
       case true:
-        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height
         if configuration.componentResizeBehavior == .contentSize {
           newHeight = fmin(componentsView.frame.height, scrollView.contentSize.height)
         }
+
+        let shouldModifyContentOffset = contentOffset.y <= scrollView.contentSize.height &&
+          self.contentOffset.y != frame.minY
+
         if shouldModifyContentOffset {
-          scrollView.contentOffset = CGPoint(x: Int(contentOffset.x), y: Int(contentOffset.y))
+          scrollView.contentOffset.y = contentOffset.y
         } else {
           frame.origin.y = yOffsetOfCurrentSubview
         }

--- a/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
+++ b/Sources/iOS-Exclusive/Classes/SpotsScrollView+iOS.swift
@@ -59,7 +59,10 @@ extension SpotsScrollView {
       }
 
       frame.size.height = newHeight
-      scrollView.frame = frame
+
+      if scrollView.frame != frame {
+        scrollView.frame = frame
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a condition not to set the same frame twice. It also solves an observer recursion.
The recursion could be triggered when scrolling in a horizontal component that was only partially on screen.