### PR TITLE
Fix scrolling horizontal components

### DIFF
--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -178,6 +178,8 @@ extension Delegate: UIScrollViewDelegate {
           return
       }
 
+      collectionView.contentOffset.y = 0
+
       handler(component, collectionView, collectionViewLayout)
     }
   }


### PR DESCRIPTION
This fixes the issue that a component can be scrolled vertically when only partially on screen.