### PR TITLE
Fixes delegates getting lost when replacing components

### DIFF
--- a/Sources/Shared/Classes/SpotsControllerManager.swift
+++ b/Sources/Shared/Classes/SpotsControllerManager.swift
@@ -167,6 +167,7 @@ public class SpotsControllerManager {
 
       defer {
         controller.setupComponent(at: index, component: component)
+        component.afterUpdate()
       }
     }
 

--- a/Sources/iOS/Classes/SpotsController.swift
+++ b/Sources/iOS/Classes/SpotsController.swift
@@ -342,6 +342,7 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
       width: superview.frame.width,
       height: ceil(component.view.frame.height))
     component.focusDelegate = self
+    component.delegate = delegate
   }
 
   #if os(iOS)


### PR DESCRIPTION
When a controller replaces components, the component delegate is not set which means that the header wont get configured correctly. This PR fixes that issue by setting the delegate to the component during setupComponent and invoking afterUpdate after the component has been replaced which causes the component to reload headers and footers