### PR TITLE
Improve/layout with paginated scrolling

### DIFF
--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 
 /// `Delegate` works as the delegate for both table views and collection views.
 /// It does this by implementing all of the necessary methods on either implementation

--- a/Sources/Shared/Classes/Delegate.swift
+++ b/Sources/Shared/Classes/Delegate.swift
@@ -16,6 +16,7 @@ public class Delegate: NSObject, ComponentResolvable {
   let configuration: Configuration
   let indexPathManager: IndexPathManager
   var needsInfiniteScrollingAlignment: Bool = false
+  var beginDraggingAtContentOffset: CGPoint?
 
   #if os(tvOS)
   /// A boolean value that indicates that the scrolling offset has reached

--- a/Sources/iOS-Exclusive/Extensions/Delegate+iOS+Extensions+Exclusive.swift
+++ b/Sources/iOS-Exclusive/Extensions/Delegate+iOS+Extensions+Exclusive.swift
@@ -1,7 +1,6 @@
 import UIKit
 
-/// A scroll view extension on CarouselComponent to handle scrolling specifically for this object.
-extension Delegate: UIScrollViewDelegate {
+extension Delegate {
   #if os(iOS)
   public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     beginDraggingAtContentOffset = scrollView.contentOffset
@@ -40,9 +39,9 @@ extension Delegate: UIScrollViewDelegate {
     #endif
 
     #if os(iOS)
-    if let spotsScrollView = scrollView.superview?.superview as? SpotsScrollView {
-      spotsScrollView.panGestureRecognizer.isEnabled = true
-    }
+      if let spotsScrollView = scrollView.superview?.superview as? SpotsScrollView {
+        spotsScrollView.panGestureRecognizer.isEnabled = true
+      }
     #endif
 
     if let component = component {
@@ -148,7 +147,7 @@ extension Delegate: UIScrollViewDelegate {
       }
 
       guard let foundIndexPath = centerIndexPath else {
-          return
+        return
       }
 
       if let item = component.item(at: foundIndexPath.item) {
@@ -185,28 +184,5 @@ extension Delegate: UIScrollViewDelegate {
 
       handler(component, collectionView, collectionViewLayout)
     }
-  }
-
-  func getCenterIndexPath(in collectionView: UICollectionView, scrollView: UIScrollView, point: CGPoint, contentSize: CGSize, offset: CGFloat) -> IndexPath? {
-    guard point.x > 0.0 else {
-      return IndexPath(item: 0, section: 0)
-    }
-
-    let pointXUpperBound = round(contentSize.width - scrollView.frame.width / 2)
-    var point = point
-    point.x += scrollView.frame.width / 2
-    point.y = scrollView.contentSize.height / 2
-    var indexPath: IndexPath?
-
-    while indexPath == nil && point.x < pointXUpperBound {
-      indexPath = collectionView.indexPathForItem(at: point)
-      point.x += max(offset, 1)
-    }
-
-    guard let centerIndexPath = indexPath else {
-      return nil
-    }
-
-    return centerIndexPath
   }
 }

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -266,27 +266,29 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
 
     let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
-
+    view.layoutIfNeeded()
     UIView.performWithoutAnimation {
-      view.layoutIfNeeded()
       if let x = collectionView.layoutAttributesForItem(at: indexPath)?.frame.origin.x,
         var point = collectionView.flowLayout?.targetContentOffset(forProposedContentOffset: .init(x: x, y: collectionView.contentOffset.y),
                                                                    withScrollingVelocity: .zero) {
 
         if model.interaction.paginate == .disabled {
           point.x -= CGFloat(model.layout.itemSpacing + model.layout.inset.left / 2)
+        } else {
+          point.x -= CGFloat(model.layout.inset.left)
         }
 
         collectionView.contentOffset.x = point.x
       }
-
-      #if os(tvOS)
-        componentDelegate?.manualFocusedIndexPath = indexPath
-        if #available(tvOS 9.0, *) {
-          view.setNeedsFocusUpdate()
-        }
-      #endif
     }
+
+    #if os(tvOS)
+      componentDelegate?.manualFocusedIndexPath = indexPath
+      if #available(tvOS 9.0, *) {
+        view.setNeedsFocusUpdate()
+        view.updateFocusIfNeeded()
+      }
+    #endif
   }
 
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -270,8 +270,13 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     UIView.performWithoutAnimation {
       view.layoutIfNeeded()
       if let x = collectionView.layoutAttributesForItem(at: indexPath)?.frame.origin.x,
-        let point = collectionView.flowLayout?.targetContentOffset(forProposedContentOffset: .init(x: x, y: collectionView.contentOffset.y),
+        var point = collectionView.flowLayout?.targetContentOffset(forProposedContentOffset: .init(x: x, y: collectionView.contentOffset.y),
                                                                    withScrollingVelocity: .zero) {
+
+        if model.interaction.paginate == .disabled {
+          point.x -= CGFloat(model.layout.itemSpacing + model.layout.inset.left / 2)
+        }
+
         collectionView.contentOffset.x = point.x
       }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -257,29 +257,20 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   func setupInfiniteScrolling() {
     guard let collectionView = collectionView,
       let componentDataSource = componentDataSource,
+      let delegate = componentDelegate,
       model.items.count >= componentDataSource.buffer else {
         return
     }
 
     let indexPath = IndexPath(item: componentDataSource.buffer, section: 0)
     view.layoutIfNeeded()
-    UIView.performWithoutAnimation {
-      if let x = collectionView.layoutAttributesForItem(at: indexPath)?.frame.origin.x,
-        var point = collectionView.flowLayout?.targetContentOffset(forProposedContentOffset: .init(x: x, y: collectionView.contentOffset.y),
-                                                                   withScrollingVelocity: .zero) {
 
-        #if os(iOS)
-          if model.interaction.paginate == .disabled {
-            point.x -= CGFloat(model.layout.itemSpacing + model.layout.inset.left / 2)
-          } else {
-            point.x -= CGFloat(model.layout.inset.left)
-          }
-        #else
-          point.x += CGFloat(model.layout.inset.left)
-        #endif
-
-        collectionView.contentOffset.x = point.x
-      }
+    if let point = collectionView.layoutAttributesForItem(at: indexPath)?.frame.origin,
+      let targetContentOffset = (collectionView.flowLayout as? ComponentFlowLayout)?.targetContentOffsetForComponent(self,
+                                                                                                                     targetContentOffset: point,
+                                                                                                                     collectionView: collectionView,
+                                                                                                                     delegate: delegate) {
+      collectionView.setContentOffset(targetContentOffset, animated: false)
     }
   }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -284,26 +284,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
     }
   }
 
-  func initialXCoordinateItemAtIndexPath(_ indexPath: IndexPath) -> CGFloat? {
-    guard let attributes = collectionView?.layoutAttributesForItem(at: indexPath) else {
-      return nil
-    }
-
-    return componentCenterOffset(for: attributes)
-  }
-
-  func componentCenterOffset(for attributes: UICollectionViewLayoutAttributes) -> CGFloat {
-    let span: Double = model.layout.span > 1 ? model.layout.span : 1
-    var centerAlignment = CGFloat(model.layout.itemSpacing * span)
-    var remainingWidth = attributes.size.width + centerAlignment * 2
-    while remainingWidth < view.frame.size.width {
-      remainingWidth *= 2
-      centerAlignment -= CGFloat(model.layout.itemSpacing)
-    }
-
-    return attributes.frame.minX - centerAlignment
-  }
-
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.
   /// The `.x` offset is changed when the user reaches the beginning or the end of a `Component`.
   private func handleInfiniteScrolling() {

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -186,10 +186,6 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
   @objc private func didInject() {
     userInterface?.register(with: configuration)
     userInterface?.reloadVisibleViews(with: .none, completion: nil)
-
-    if model.layout.infiniteScrolling {
-      setupInfiniteScrolling()
-    }
   }
 
   /// Setup up the component with a given size, this is usually the parent size when used in a controller context.

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -300,10 +300,14 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
         return
     }
 
+    let max = model.interaction.paginate == .page
+      ? lastAttributes.frame.maxX - CGFloat(model.layout.itemSpacing)
+      : lastAttributes.frame.maxX + CGFloat(model.layout.inset.left)
+
     if view.contentOffset.x < CGFloat(model.layout.inset.left) {
-      view.contentOffset.x = lastAttributes.frame.origin.x
-    } else if view.contentOffset.x > lastAttributes.frame.maxX + CGFloat(model.layout.inset.left) {
-      view.contentOffset.x = firstAttributes.frame.origin.x
+      view.contentOffset.x = lastAttributes.frame.origin.x - CGFloat(model.layout.inset.left)
+    } else if view.contentOffset.x >= max {
+      view.contentOffset.x = firstAttributes.frame.origin.x - CGFloat(model.layout.inset.left)
     }
   }
 

--- a/Sources/iOS/Classes/Component.swift
+++ b/Sources/iOS/Classes/Component.swift
@@ -272,23 +272,19 @@ public class Component: NSObject, ComponentHorizontallyScrollable {
         var point = collectionView.flowLayout?.targetContentOffset(forProposedContentOffset: .init(x: x, y: collectionView.contentOffset.y),
                                                                    withScrollingVelocity: .zero) {
 
-        if model.interaction.paginate == .disabled {
-          point.x -= CGFloat(model.layout.itemSpacing + model.layout.inset.left / 2)
-        } else {
-          point.x -= CGFloat(model.layout.inset.left)
-        }
+        #if os(iOS)
+          if model.interaction.paginate == .disabled {
+            point.x -= CGFloat(model.layout.itemSpacing + model.layout.inset.left / 2)
+          } else {
+            point.x -= CGFloat(model.layout.inset.left)
+          }
+        #else
+          point.x += CGFloat(model.layout.inset.left)
+        #endif
 
         collectionView.contentOffset.x = point.x
       }
     }
-
-    #if os(tvOS)
-      componentDelegate?.manualFocusedIndexPath = indexPath
-      if #available(tvOS 9.0, *) {
-        view.setNeedsFocusUpdate()
-        view.updateFocusIfNeeded()
-      }
-    #endif
   }
 
   /// Manipulates the x content offset when `infiniteScrolling` is enabled on the `Component`.

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -455,8 +455,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
                                                       scrollView: collectionView,
                                                       point: contentOffset,
                                                       contentSize: contentSize,
-                                                      offset: minimumInteritemSpacing,
-                                                      multiplier: 2)
+                                                      offset: minimumInteritemSpacing)
 
     guard let foundCenterIndex = centerIndexPath,
       let itemAttributes = collectionView.layoutAttributesForItem(at: foundCenterIndex) else {

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -14,6 +14,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
   private var indexPathsToAnimate = [IndexPath]()
   private var indexPathsToMove = [IndexPath]()
   private var layoutAttributes: [UICollectionViewLayoutAttributes]?
+  private var intersectingAttributes: [UICollectionViewLayoutAttributes] = []
   private(set) var cachedFrames = [CGRect]()
 
   // Subclasses must override this method and use it to return the width and height of the collection view’s content. These values represent the width and height of all the content, not just the content that is currently visible. The collection view uses this information to configure its own content size to facilitate scrolling.
@@ -130,6 +131,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     var attributes = [UICollectionViewLayoutAttributes]()
     var nextX: CGFloat = sectionInset.left
     var nextY: CGFloat = 0.0
+    intersectingAttributes.removeAll()
 
     if let newAttributes = self.layoutAttributes {
       for (index, attribute) in newAttributes.enumerated() {
@@ -168,6 +170,11 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
           } else {
             nextY = itemAttribute.frame.maxY + minimumLineSpacing
           }
+
+          if itemAttribute.frame.intersects(rect) {
+            intersectingAttributes.append(itemAttribute)
+          }
+
           attributes.append(itemAttribute)
         case .vertical:
           itemAttribute.frame.origin.y += component.headerHeight
@@ -176,6 +183,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
           // Note that this only applies to vertical components.
           if itemAttribute.frame.intersects(rect) {
             attributes.append(itemAttribute)
+            intersectingAttributes.append(itemAttribute)
           }
         }
 

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -475,8 +475,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
       targetContentOffset.x = itemAttributes.frame.origin.x + offset
     }
 
-    Swift.print("🎭targetContentOffset: \(targetContentOffset)")
-
     return targetContentOffset
   }
 }

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -404,7 +404,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     return itemsPerRow == 1 || index % itemsPerRow == itemsPerRow - 1
   }
 
-  @discardableResult open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
+  open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
     guard let collectionView = collectionView,
       let delegate = collectionView.delegate as? Delegate,
       let component = delegate.component,

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -416,11 +416,13 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
     defer {
       if component.model.interaction.paginate == .page {
-        UIView.animate(withDuration: 0.25, delay: 0, options: .beginFromCurrentState, animations: {
-          collectionView.contentOffset.x = targetContentOffset.x
+        let point = CGPoint(x: targetContentOffset.x, y: collectionView.contentOffset.y)
+        let options: UIViewAnimationOptions = [.beginFromCurrentState, .allowAnimatedContent, .allowUserInteraction]
+        UIView.animate(withDuration: 0.25, delay: 0, options: options, animations: {
+          collectionView.contentOffset = point
           // This is called in order to invoke the delegate methods attached
           // to the scroll view.
-          collectionView.setContentOffset(targetContentOffset, animated: true)
+          collectionView.setContentOffset(point, animated: true)
         }, completion: nil)
       }
     }

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -14,7 +14,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
   private var indexPathsToAnimate = [IndexPath]()
   private var indexPathsToMove = [IndexPath]()
   private var layoutAttributes: [UICollectionViewLayoutAttributes]?
-  private var intersectingAttributes: [UICollectionViewLayoutAttributes] = []
   private(set) var cachedFrames = [CGRect]()
 
   // Subclasses must override this method and use it to return the width and height of the collection view’s content. These values represent the width and height of all the content, not just the content that is currently visible. The collection view uses this information to configure its own content size to facilitate scrolling.
@@ -131,7 +130,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     var attributes = [UICollectionViewLayoutAttributes]()
     var nextX: CGFloat = sectionInset.left
     var nextY: CGFloat = 0.0
-    intersectingAttributes.removeAll()
 
     if let newAttributes = self.layoutAttributes {
       for (index, attribute) in newAttributes.enumerated() {
@@ -171,10 +169,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
             nextY = itemAttribute.frame.maxY + minimumLineSpacing
           }
 
-          if itemAttribute.frame.intersects(rect) {
-            intersectingAttributes.append(itemAttribute)
-          }
-
           attributes.append(itemAttribute)
         case .vertical:
           itemAttribute.frame.origin.y += component.headerHeight
@@ -183,7 +177,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
           // Note that this only applies to vertical components.
           if itemAttribute.frame.intersects(rect) {
             attributes.append(itemAttribute)
-            intersectingAttributes.append(itemAttribute)
           }
         }
 

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -407,30 +407,27 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
   @discardableResult open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
     guard let collectionView = collectionView,
       let delegate = collectionView.delegate as? Delegate,
-      let dataSource = collectionView.dataSource as? DataSource,
-      let component = delegate.component else {
+      let component = delegate.component,
+      component.model.interaction.paginate != .disabled else {
         return proposedContentOffset
     }
 
-    var targetContentOffset = proposedContentOffset
+    let targetContentOffset = targetContentOffsetForComponent(component,
+                                                              targetContentOffset: proposedContentOffset,
+                                                              collectionView: collectionView,
+                                                              delegate: delegate)
 
-    defer {
-      if component.model.interaction.paginate == .page {
-        let point = CGPoint(x: targetContentOffset.x, y: collectionView.contentOffset.y)
-        let options: UIViewAnimationOptions = [.beginFromCurrentState, .allowAnimatedContent, .allowUserInteraction]
-        UIView.animate(withDuration: 0.25, delay: 0, options: options, animations: {
-          collectionView.contentOffset = point
-          // This is called in order to invoke the delegate methods attached
-          // to the scroll view.
-          collectionView.setContentOffset(point, animated: true)
-        }, completion: nil)
-      }
+    if component.model.interaction.paginate == .page {
+      let point = CGPoint(x: targetContentOffset.x, y: collectionView.contentOffset.y)
+      let options: UIViewAnimationOptions = [.beginFromCurrentState, .allowAnimatedContent, .allowUserInteraction]
+      UIView.animate(withDuration: 0.25, delay: 0, options: options, animations: {
+        collectionView.contentOffset = point
+        // This is called in order to invoke the delegate methods attached
+        // to the scroll view.
+        collectionView.setContentOffset(point, animated: true)
+
+      }, completion: nil)
     }
-
-    targetContentOffset = targetContentOffsetForComponent(component,
-                                                          targetContentOffset: targetContentOffset,
-                                                          collectionView: collectionView,
-                                                          delegate: delegate)
 
     return targetContentOffset
   }

--- a/Sources/iOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS/Classes/ComponentFlowLayout.swift
@@ -411,7 +411,6 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     return itemsPerRow == 1 || index % itemsPerRow == itemsPerRow - 1
   }
 
-  #if os(iOS)
   @discardableResult open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint, withScrollingVelocity velocity: CGPoint) -> CGPoint {
     var targetContentOffset = proposedContentOffset
 
@@ -475,5 +474,4 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
     return targetContentOffset
   }
-  #endif
 }

--- a/Sources/iOS/Extensions/Component+iOS+List.swift
+++ b/Sources/iOS/Extensions/Component+iOS+List.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 extension Component {
-
   func setupTableView(_ tableView: TableView, with size: CGSize) {
     tableView.dataSource = componentDataSource
     tableView.delegate = componentDelegate

--- a/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+UIScrollView.swift
@@ -4,6 +4,8 @@ import UIKit
 extension Delegate: UIScrollViewDelegate {
   #if os(iOS)
   public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    beginDraggingAtContentOffset = scrollView.contentOffset
+
     if let spotsScrollView = scrollView.superview?.superview as? SpotsScrollView {
       let spotsScrollGesture = spotsScrollView.panGestureRecognizer
       let componentGesture = scrollView.panGestureRecognizer
@@ -126,6 +128,7 @@ extension Delegate: UIScrollViewDelegate {
   /// - parameter velocity:            The velocity of the scroll view (in points) at the moment the touch was released.
   /// - parameter targetContentOffset: The expected offset when the scrolling action decelerates to a stop.
   public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    beginDraggingAtContentOffset = nil
     performPaginatedScrolling { component, collectionView, collectionViewLayout in
       var centerIndexPath: IndexPath?
 

--- a/Sources/iOS/Extensions/Delegate+iOS+tvOS+UIScrollView.swift
+++ b/Sources/iOS/Extensions/Delegate+iOS+tvOS+UIScrollView.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+/// A scroll view extension on CarouselComponent to handle scrolling specifically for this object.
+extension Delegate: UIScrollViewDelegate {
+  func getCenterIndexPath(in collectionView: UICollectionView, scrollView: UIScrollView, point: CGPoint, contentSize: CGSize, offset: CGFloat) -> IndexPath? {
+    guard point.x > 0.0 else {
+      return IndexPath(item: 0, section: 0)
+    }
+
+    let pointXUpperBound = round(contentSize.width - scrollView.frame.width / 2)
+    var point = point
+    point.x += scrollView.frame.width / 2
+    point.y = scrollView.contentSize.height / 2
+    var indexPath: IndexPath?
+
+    while indexPath == nil && point.x < pointXUpperBound {
+      indexPath = collectionView.indexPathForItem(at: point)
+      point.x += max(offset, 1)
+    }
+
+    guard let centerIndexPath = indexPath else {
+      return nil
+    }
+
+    return centerIndexPath
+  }
+}

--- a/Sources/tvOS/Classes/FocusEngineManager.swift
+++ b/Sources/tvOS/Classes/FocusEngineManager.swift
@@ -39,6 +39,8 @@ class FocusEngineManager {
             result -= CGFloat(component.model.layout.inset.top + component.model.layout.lineSpacing)
           } else if component.model.kind == .carousel {
             result -= component.headerHeight
+            result -= CGFloat(component.model.layout.inset.top)
+            result -= CGFloat(component.model.layout.inset.bottom)
           }
         }
       }

--- a/Spots.xcodeproj/project.pbxproj
+++ b/Spots.xcodeproj/project.pbxproj
@@ -140,6 +140,9 @@
 		BD798EF81EA2A1320069EFB7 /* SpotsControllerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* SpotsControllerManagerTests.swift */; };
 		BD798EF91EA2A1320069EFB7 /* SpotsControllerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* SpotsControllerManagerTests.swift */; };
 		BD798EFA1EA2A1320069EFB7 /* SpotsControllerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD798EF71EA2A1320069EFB7 /* SpotsControllerManagerTests.swift */; };
+		BD83138E201F5D31005C1F51 /* Delegate+iOS+Extensions+Exclusive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83138D201F5D31005C1F51 /* Delegate+iOS+Extensions+Exclusive.swift */; };
+		BD83138F201F5D58005C1F51 /* Delegate+iOS+tvOS+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift */; };
+		BD831390201F5E08005C1F51 /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */; };
 		BD83A6671F938B0F00BCCFE3 /* SpotsRefreshControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83A6661F938B0F00BCCFE3 /* SpotsRefreshControlTests.swift */; };
 		BD91A94E1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */; };
 		BD91A94F1F2FAB68005B6A38 /* ComponentResolvable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */; };
@@ -203,7 +206,6 @@
 		BDAD84CF1E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84971E3E701C008289AE /* SpotsController+UIScrollViewDelegate.swift */; };
 		BDAD84D01E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */; };
 		BDAD84D11E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */; };
-		BDAD84D21E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */; };
 		BDAD84D31E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */; };
 		BDAD84D61E3E701C008289AE /* Inset+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD849B1E3E701C008289AE /* Inset+iOS.swift */; };
 		BDAD84D71E3E701C008289AE /* Inset+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAD849B1E3E701C008289AE /* Inset+iOS.swift */; };
@@ -342,7 +344,7 @@
 		BDB8D5931E4DFADC00220BC3 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* ItemTests.swift */; };
 		BDB8D5941E4DFADC00220BC3 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* ItemTests.swift */; };
 		BDB8D5951E4DFADC00220BC3 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5921E4DFADC00220BC3 /* ItemTests.swift */; };
-		BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */; };
+		BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift */; };
 		BDC5F3791F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
 		BDC5F37A1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
 		BDC5F37B1F041A6500EA6A2C /* MoveAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */; };
@@ -510,6 +512,7 @@
 		BD789F771F91E97300B002FD /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		BD798EF31EA28F200069EFB7 /* SpotsControllerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManager.swift; sourceTree = "<group>"; };
 		BD798EF71EA2A1320069EFB7 /* SpotsControllerManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotsControllerManagerTests.swift; sourceTree = "<group>"; };
+		BD83138D201F5D31005C1F51 /* Delegate+iOS+Extensions+Exclusive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+Extensions+Exclusive.swift"; sourceTree = "<group>"; };
 		BD83A6661F938B0F00BCCFE3 /* SpotsRefreshControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotsRefreshControlTests.swift; sourceTree = "<group>"; };
 		BD91A94D1F2FAB68005B6A38 /* ComponentResolvable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentResolvable.swift; sourceTree = "<group>"; };
 		BD91A9511F2FAB87005B6A38 /* ComponentResolvable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ComponentResolvable+Extensions.swift"; sourceTree = "<group>"; };
@@ -601,7 +604,7 @@
 		BDB1FCBB1ED060FF0042ED61 /* ComponentCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentCollectionView.swift; sourceTree = "<group>"; };
 		BDB648551D75EF150041449A /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
 		BDB8D5921E4DFADC00220BC3 /* ItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemTests.swift; sourceTree = "<group>"; };
-		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+UIScrollView.swift"; sourceTree = "<group>"; };
+		BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Delegate+iOS+tvOS+UIScrollView.swift"; sourceTree = "<group>"; };
 		BDC5F3781F041A6500EA6A2C /* MoveAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveAlgorithm.swift; sourceTree = "<group>"; };
 		BDCA3CF21E8295EB00A98A76 /* UserInterfaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInterfaceTests.swift; sourceTree = "<group>"; };
 		BDCBE3841EEEFF1E00BB2514 /* ScrollViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewManager.swift; sourceTree = "<group>"; };
@@ -699,6 +702,7 @@
 		BD13C1EA1FA10D3E00386D57 /* iOS-Exclusive */ = {
 			isa = PBXGroup;
 			children = (
+				BD83138C201F5D24005C1F51 /* Extensions */,
 				BD13C1EB1FA10D3E00386D57 /* Classes */,
 			);
 			path = "iOS-Exclusive";
@@ -749,6 +753,14 @@
 			path = tvOS;
 			sourceTree = "<group>";
 		};
+		BD83138C201F5D24005C1F51 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				BD83138D201F5D31005C1F51 /* Delegate+iOS+Extensions+Exclusive.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		BDAD847E1E3E701B008289AE /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -791,7 +803,7 @@
 				BDB1F8B21E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift */,
 				BDAD84981E3E701C008289AE /* DataSource+iOS+Extensions.swift */,
 				BDAD84991E3E701C008289AE /* Delegate+iOS+Extensions.swift */,
-				BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift */,
+				BDB8D5991E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift */,
 				BDAD849B1E3E701C008289AE /* Inset+iOS.swift */,
 				BDAD849D1E3E701C008289AE /* Layout+iOS.swift */,
 				BD1F9E0E1EA39DFD009C018B /* SpotsController+iOS+Extensions.swift */,
@@ -1562,6 +1574,7 @@
 				BDE44B111EA0E5E80021EAC8 /* ComponentManager.swift in Sources */,
 				BDAD85D11E3E7032008289AE /* Wrappable.swift in Sources */,
 				BD5D69DE1F39B71A0078AC19 /* ItemDiff.swift in Sources */,
+				BD83138F201F5D58005C1F51 /* Delegate+iOS+tvOS+UIScrollView.swift in Sources */,
 				BD9ECEBF1E6EC8A5003E4388 /* Component+iOS+Carousel.swift in Sources */,
 				BDAD85A41E3E7032008289AE /* Wrappable+Extensions.swift in Sources */,
 				BDAD84DF1E3E701C008289AE /* UICollectionView+UserInterface.swift in Sources */,
@@ -1626,6 +1639,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD831390201F5E08005C1F51 /* Delegate+iOS+Extensions.swift in Sources */,
+				BD83138E201F5D31005C1F51 /* Delegate+iOS+Extensions+Exclusive.swift in Sources */,
 				BDAD84D01E3E701C008289AE /* DataSource+iOS+Extensions.swift in Sources */,
 				BDAD84BA1E3E701C008289AE /* ListHeaderFooterWrapper.swift in Sources */,
 				BDAD858D1E3E7032008289AE /* Component+Mutation.swift in Sources */,
@@ -1636,7 +1651,6 @@
 				BDB1F8B31E5D921F0064F64B /* CoreComponent+Extensions+iOS.swift in Sources */,
 				BDAD84DA1E3E701C008289AE /* Layout+iOS.swift in Sources */,
 				BD9ECEC71E6EC8C4003E4388 /* Component+iOS+HeaderFooter.swift in Sources */,
-				BDAD84D21E3E701C008289AE /* Delegate+iOS+Extensions.swift in Sources */,
 				BDDCF6D61E4DF911004B38C4 /* Item.swift in Sources */,
 				BDAD85C01E3E7032008289AE /* ComponentDelegate.swift in Sources */,
 				BDAD85751E3E7032008289AE /* RegistryType.swift in Sources */,
@@ -1644,7 +1658,7 @@
 				BDAD84BE1E3E701C008289AE /* DefaultItemView.swift in Sources */,
 				BDAD85ED1E3E7032008289AE /* StateCache.swift in Sources */,
 				BD5D69D41F398C370078AC19 /* Changes.swift in Sources */,
-				BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+UIScrollView.swift in Sources */,
+				BDB8D59A1E51C4FE00220BC3 /* Delegate+iOS+tvOS+UIScrollView.swift in Sources */,
 				BD1D17251EA89A36000DBCF8 /* SpotsRefreshControl.swift in Sources */,
 				BDAD85B71E3E7032008289AE /* ScrollDelegate.swift in Sources */,
 				BD24030C1E4B981A005BAA19 /* Component.swift in Sources */,


### PR DESCRIPTION
This PR aims to improve the user experience when scrolling paginated components on iOS. It also simplifies the implementation be removing the methods on `Component` that was related to scrolling and instead have that live on the `ComponentFlowLayout.` The `Component` now calls that method when it needs the initial offset for a `Component`.

The improvements to the scrolling are that the offset that the user has to scroll is much less than it was before this PR. It creates an offset by checking the initial content offset with the proposed new offset, that way it knows which way the user wanted to scroll plus how much they scrolled. Based on that outcome we can determine what the user wants with greater precision.