### PR TITLE
Set new width to header and footer views when rotating

### DIFF
--- a/Sources/iOS+tvOS/Classes/SpotsController.swift
+++ b/Sources/iOS+tvOS/Classes/SpotsController.swift
@@ -273,6 +273,10 @@ open class SpotsController: UIViewController, SpotsProtocol, ComponentFocusDeleg
       component.collectionView?.flowLayout?.prepare()
       component.collectionView?.flowLayout?.invalidateLayout()
       component.collectionView?.flowLayout?.finalizeAnimatedBoundsChange()
+      component.headerView?.frame.size.width = size.width
+      component.footerView?.frame.size.width = size.width
+      component.headerView?.frame.origin = .zero
+      component.footerView?.frame.origin = .zero
     }
 
     scrollView.frame.size = size


### PR DESCRIPTION
Fixes the issue with headers and footers not getting a new size when the controller rotates.