### PR TITLE
Refactor ComponentFlowLayout to increase performance

### DIFF
--- a/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
@@ -52,8 +52,10 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     var previousItem: UICollectionViewLayoutAttributes? = nil
 
     for index in 0..<(collectionView?.numberOfItems(inSection: 0) ?? 0) {
-      if let itemAttribute = self.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
-        defer { previousItem = itemAttribute }
+      if let itemAttribute = super.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
+        defer {
+          previousItem = itemAttribute
+        }
 
         if component.model.layout.infiniteScrolling, index >= component.model.items.count {
           itemAttribute.size = component.sizeForItem(at: IndexPath(item: index - component.model.items.count, section: 0))
@@ -86,6 +88,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
     self.layoutAttributes = layoutAttributes
     computeContentSize(with: component)
+    collectionView?.setNeedsLayout()
   }
 
   func computeContentSize(with component: Component) {
@@ -153,6 +156,22 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     case .vertical:
       return layoutAttributes?.filter({ $0.frame.intersects(rect) })
     }
+  }
+
+  open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+    guard layoutAttributes?.isEmpty == false,
+      let component = (collectionView?.dataSource as? DataSource)?.component else {
+      return nil
+    }
+
+    let newIndex: Int
+    if component.model.layout.infiniteScrolling, indexPath.item >= component.model.items.count {
+      newIndex = indexPath.item - component.model.items.count
+    } else {
+      newIndex = indexPath.item
+    }
+
+    return layoutAttributes?[newIndex]
   }
 
   open override func initialLayoutAttributesForAppearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {

--- a/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
@@ -52,7 +52,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
     var previousItem: UICollectionViewLayoutAttributes? = nil
 
     for index in 0..<(collectionView?.numberOfItems(inSection: 0) ?? 0) {
-      if let itemAttribute = super.layoutAttributesForItem(at: IndexPath(item: index, section: 0)) {
+      if let itemAttribute = super.layoutAttributesForItem(at: IndexPath(item: index, section: 0))?.copy() as? UICollectionViewLayoutAttributes {
         defer {
           previousItem = itemAttribute
         }

--- a/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
+++ b/Sources/iOS+tvOS/Classes/ComponentFlowLayout.swift
@@ -366,7 +366,7 @@ open class ComponentFlowLayout: UICollectionViewFlowLayout {
 
     switch scrollDirection {
     case .horizontal:
-      return newBounds.size.height >= contentSize.height
+      return newBounds.size.height > contentSize.height || newBounds.size.height < contentSize.height
     case .vertical:
       #if os(tvOS)
         return true

--- a/Sources/iOS/Extensions/Component+iOS.swift
+++ b/Sources/iOS/Extensions/Component+iOS.swift
@@ -2,6 +2,8 @@ import UIKit
 
 extension Component {
   func setupInfiniteScrolling() {
+    collectionView?.collectionViewLayout.prepare()
+
     guard let collectionView = collectionView,
       let componentDataSource = componentDataSource,
       model.items.count >= componentDataSource.buffer,


### PR DESCRIPTION
The previous algorithm was a bit flawed when it came to performance. When calculating the previous item, it had to do a reverse lookup, this didn't scale while scrolling horizontal collections with a lot of items. With this refactoring, scrolling performance should be better as it safes a reference to the previous layout attribute instead of trying to look it up each time.