### PR TITLE
Compatibility with Swift 4.1

### DIFF
--- a/Sources/Universal/Protocols/UserInterface.swift
+++ b/Sources/Universal/Protocols/UserInterface.swift
@@ -78,7 +78,7 @@ public protocol UserInterface: class {
   func processChanges(_ changes: Changes,
                       withAnimation animation: Animation,
                       updateDataSource: () -> Void,
-                      completion: ((()) -> Void)?)
+                      completion: (() -> Void)?)
 
   /// A convenience method for performing inserts on a UserInterface.
   ///


### PR DESCRIPTION
It seems that Swift 4.1 treats tuple more strictly, so the current version does not compiles on Swift 4.1. This pull request makes it compile with swift 4.1